### PR TITLE
Resolve standalone INDEX dependencies via constraint-based inference

### DIFF
--- a/excel_grapher/grapher/__init__.py
+++ b/excel_grapher/grapher/__init__.py
@@ -9,6 +9,7 @@ from .dynamic_refs import (
     DynamicRefConfig,
     DynamicRefError,
     DynamicRefLimits,
+    infer_dynamic_index_targets,
     infer_dynamic_indirect_targets,
     infer_dynamic_offset_targets,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "DynamicRefConfig",
     "DynamicRefError",
     "DynamicRefLimits",
+    "infer_dynamic_index_targets",
     "infer_dynamic_indirect_targets",
     "infer_dynamic_offset_targets",
     "NodeHook",

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -14,6 +14,7 @@ from .dynamic_refs import (
     DynamicRefError,
     GlobalWorkbookBounds,
     expand_leaf_env_to_argument_env,
+    infer_dynamic_index_targets,
     infer_dynamic_indirect_targets,
     infer_dynamic_offset_targets,
 )
@@ -211,12 +212,33 @@ def create_dependency_graph(
                         arg_sheet = ref.sheet if ref.sheet is not None else current_sheet
                         deps.append((arg_sheet, f"{ref.column}{ref.row}"))
             else:
-                calls = _find_function_calls_with_spans(f, {"OFFSET", "INDIRECT"})
+                calls = _find_function_calls_with_spans(f, {"OFFSET", "INDIRECT", "INDEX"})
                 if dynamic_refs is None:
+                    # Filter out INDEX calls that only have literal args (no dynamic resolution needed).
+                    dynamic_calls = []
+                    for fn_name_check, inner_check, span_check in calls:
+                        if fn_name_check == "INDEX":
+                            # INDEX only needs dynamic resolution when row/col args are non-literal
+                            idx_args = _split_function_args(inner_check)
+                            if idx_args is not None and len(idx_args) >= 2:
+                                has_non_literal = False
+                                for j, idx_arg in enumerate(idx_args):
+                                    if j == 0:
+                                        continue  # skip array arg
+                                    try:
+                                        float(idx_arg.strip())
+                                    except ValueError:
+                                        has_non_literal = True
+                                        break
+                                if not has_non_literal:
+                                    continue
+                        dynamic_calls.append((fn_name_check, inner_check, span_check))
+                    calls = dynamic_calls
                     if calls:
                         cell_key = format_key(current_sheet, current_a1)
+                        fn_names = sorted({fn for fn, _, _ in calls})
                         raise DynamicRefError(
-                            f"Formula at {cell_key} contains OFFSET or INDIRECT that require resolution. "
+                            f"Formula at {cell_key} contains {'/'.join(fn_names)} that require resolution. "
                             "Pass dynamic_refs=DynamicRefConfig.from_constraints(...) or set "
                             "use_cached_dynamic_refs=True."
                         )
@@ -236,13 +258,14 @@ def create_dependency_graph(
                                     named_ranges=named_ranges,
                                     named_range_ranges=named_range_ranges,
                                 )
-                                # Variable args (OFFSET rows/cols/height/width, INDIRECT): always traverse to leaves.
+                                # Variable args: always traverse to leaves for domain expansion.
                                 # OFFSET base (i==0): only traverse when base is an expression (e.g. INDEX(...))
-                                # so refs inside it (e.g. ROW()-ROW(B106)+1) get expanded; simple refs (Sheet1!A1) do not.
+                                # INDEX: array arg (i==0) is not variable; row/col args (i>=1) are.
                                 is_variable = (
                                     (fn_name == "OFFSET" and i >= 1)
                                     or (fn_name == "OFFSET" and i == 0 and "(" in normalized)
                                     or fn_name == "INDIRECT"
+                                    or (fn_name == "INDEX" and i >= 1)
                                 )
                                 for ref in parse_cell_refs(normalized):
                                     sh = ref.sheet if ref.sheet is not None else current_sheet
@@ -254,7 +277,7 @@ def create_dependency_graph(
                     def _refs_in_formula_without_dynamic(formula_str: str, sheet_of_cell: str) -> set[str]:
                         dyn = _find_function_calls_with_spans(
                             formula_str if formula_str.startswith("=") else "=" + formula_str,
-                            {"OFFSET", "INDIRECT"},
+                            {"OFFSET", "INDIRECT", "INDEX"},
                         )
                         spans = [span for _fn, _inner, span in dyn]
                         masked = mask_spans(
@@ -311,7 +334,7 @@ def create_dependency_graph(
                         cell_key = format_key(current_sheet, current_a1)
                         formatted_missing = _format_missing_leaves(missing_leaves)
                         raise DynamicRefError(
-                            f"Formula at {cell_key} contains OFFSET or INDIRECT; the following leaf "
+                            f"Formula at {cell_key} contains OFFSET, INDIRECT, or INDEX; the following leaf "
                             f"cells that feed them have no constraint: {formatted_missing}. "
                             "Add constraints only for leaf (non-formula) cells."
                         )
@@ -368,13 +391,24 @@ def create_dependency_graph(
                             named_ranges=named_ranges,
                             named_range_ranges=named_range_ranges,
                         )
+                        index_targets = infer_dynamic_index_targets(
+                            formula_for_infer,
+                            current_sheet=current_sheet,
+                            cell_type_env=expanded_env,
+                            limits=dynamic_refs.limits,
+                            bounds=bounds,
+                            named_ranges=named_ranges,
+                            named_range_ranges=named_range_ranges,
+                            current_row=_current_row,
+                            current_col=_current_col,
+                        )
                     except DynamicRefError as exc:
                         cell_key = format_key(current_sheet, current_a1)
                         raise DynamicRefError(
-                            f"{exc} (while analyzing dynamic OFFSET/INDIRECT for {cell_key}; "
+                            f"{exc} (while analyzing dynamic OFFSET/INDIRECT/INDEX for {cell_key}; "
                             f"normalized formula {formula_for_infer!r})"
                         ) from exc
-                    for addr in offset_targets | indirect_targets:
+                    for addr in offset_targets | indirect_targets | index_targets:
                         sh, a1 = _parse_address_to_sheet_a1(addr)
                         deps.append((sh, a1))
             masked = mask_spans(masked, dyn_spans)

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -397,6 +397,172 @@ def infer_dynamic_offset_targets(
     return out
 
 
+def infer_dynamic_index_targets(
+    formula: str,
+    *,
+    current_sheet: str,
+    cell_type_env: CellTypeEnv,
+    limits: DynamicRefLimits | None = None,
+    bounds: WorkbookBoundsProtocol | None = None,
+    named_ranges: Mapping[str, tuple[str, str]] | None = None,
+    named_range_ranges: Mapping[str, tuple[str, str, str]] | None = None,
+    current_row: int | None = None,
+    current_col: int | None = None,
+) -> set[str]:
+    """Infer the union of all possible standalone INDEX targets for a formula.
+
+    INDEX calls that appear as the first argument of OFFSET are skipped — those
+    are already handled by :func:`infer_dynamic_offset_targets`.
+    """
+
+    if not isinstance(formula, str) or not formula.startswith("="):
+        return set()
+
+    lim = limits or DynamicRefLimits()
+    out: set[str] = set()
+
+    # Find all INDEX and OFFSET calls so we can exclude INDEX-inside-OFFSET.
+    index_calls = _find_function_calls_with_spans(formula, {"INDEX"})
+    offset_calls = _find_function_calls_with_spans(formula, {"OFFSET"})
+
+    # Build set of INDEX spans that are nested as OFFSET base (arg 0).
+    nested_index_spans: set[tuple[int, int]] = set()
+    for _fn, inner, _span in offset_calls:
+        args = _split_top_level_args(inner)
+        if args and args[0].strip().upper().startswith("INDEX("):
+            # Find the INDEX call within this OFFSET's base argument.
+            base_index_calls = _find_function_calls_with_spans("=" + args[0], {"INDEX"})
+            for _ifn, _iinner, (is_start, is_end) in base_index_calls:
+                # Adjust span: the "=" prefix adds 1 to the start position relative to args[0],
+                # but we need the span relative to the original formula.
+                # The OFFSET inner starts after "OFFSET(" in the formula, and args[0] is
+                # the first chunk. We need to find the actual INDEX spans in the original formula.
+                pass
+            # Simpler approach: check each INDEX call's span to see if it falls inside an OFFSET span.
+    # Better approach: for each INDEX call, check if its span is contained within any OFFSET span.
+    offset_spans = [span for _fn, _inner, span in offset_calls]
+    for fn, inner, idx_span in index_calls:
+        if fn != "INDEX":
+            continue
+        # Check if this INDEX is inside an OFFSET call
+        is_nested = False
+        for o_start, o_end in offset_spans:
+            if idx_span[0] > o_start and idx_span[1] <= o_end:
+                is_nested = True
+                break
+        if is_nested:
+            nested_index_spans.add(idx_span)
+
+    for fn, inner, span in index_calls:
+        if fn != "INDEX":
+            continue
+        if span in nested_index_spans:
+            continue
+        targets = _infer_single_index_call(
+            inner,
+            current_sheet=current_sheet,
+            cell_type_env=cell_type_env,
+            limits=lim,
+            named_ranges=named_ranges,
+            named_range_ranges=named_range_ranges,
+            current_row=current_row,
+            current_col=current_col,
+        )
+        out |= targets
+        if len(out) > lim.max_cells:
+            raise DynamicRefError(
+                f"Dynamic ref cells exceed limit ({len(out)} > {lim.max_cells})"
+            )
+
+    return out
+
+
+def _infer_single_index_call(
+    inner_args: str,
+    *,
+    current_sheet: str,
+    cell_type_env: CellTypeEnv,
+    limits: DynamicRefLimits,
+    named_ranges: Mapping[str, tuple[str, str]] | None = None,
+    named_range_ranges: Mapping[str, tuple[str, str, str]] | None = None,
+    current_row: int | None = None,
+    current_col: int | None = None,
+) -> set[str]:
+    """Infer targets for a single INDEX(...) call body."""
+    args = _split_top_level_args(inner_args)
+    if args is None or len(args) < 2 or len(args) > 3:
+        raise DynamicRefError("INDEX expects 2 or 3 arguments (array, row_num, [column_num])")
+
+    named_ranges = named_ranges or {}
+    named_range_ranges = named_range_ranges or {}
+
+    array_expr = _qualify_fragment(args[0], named_ranges, named_range_ranges)
+    row_expr = _qualify_fragment(args[1], named_ranges, named_range_ranges)
+    col_expr = (
+        _qualify_fragment(args[2], named_ranges, named_range_ranges)
+        if len(args) >= 3
+        else ""
+    )
+
+    try:
+        array_ast = parse_ast("=" + array_expr)
+        array_range = _base_to_range(array_ast, current_sheet=current_sheet)
+    except (DynamicRefError, FormulaParseError) as exc:
+        raise DynamicRefError(
+            f"INDEX array argument must be a static range: {exc}"
+        ) from exc
+
+    row_ast = parse_ast("=" + row_expr)
+    col_ast = parse_ast("=" + col_expr) if col_expr else None
+
+    leaf_addrs = _collect_addresses_needing_domain(row_ast)
+    if col_ast is not None:
+        leaf_addrs |= _collect_addresses_needing_domain(col_ast)
+
+    domains = _build_domains(leaf_addrs, cell_type_env, limits)
+
+    eval_context = (
+        {"row": current_row, "column": current_col}
+        if current_row is not None and current_col is not None
+        else None
+    )
+
+    targets: set[str] = set()
+    for assignment in _enumerate_assignments(domains.values(), limits):
+        addr_to_value = dict(zip(domains.keys(), assignment, strict=False))
+
+        def get_cell_value(addr: str, m=addr_to_value) -> float:
+            try:
+                return m[addr]
+            except KeyError as exc:
+                raise DynamicRefError(
+                    f"INDEX argument formula references cell without domain: {addr!r}"
+                ) from exc
+
+        row_val = _eval_arg(row_ast, get_cell_value, limits, context=eval_context)
+        col_val = (
+            _eval_arg(col_ast, get_cell_value, limits, context=eval_context)
+            if col_ast is not None
+            else 1.0
+        )
+        if isinstance(row_val, XlError) or isinstance(col_val, XlError):
+            continue
+        r1, c1 = int(row_val), int(col_val)
+        if r1 < 1 or c1 < 1:
+            continue
+        cell_row = array_range.start_row + r1 - 1
+        cell_col = array_range.start_col + c1 - 1
+        if cell_row > array_range.end_row or cell_col > array_range.end_col:
+            continue
+
+        from openpyxl.utils.cell import get_column_letter
+
+        col_letter = get_column_letter(cell_col)
+        targets.add(f"{array_range.sheet}!{col_letter}{cell_row}")
+
+    return targets
+
+
 def _qualify_fragment(
     expr: str,
     named_ranges: Mapping[str, tuple[str, str]],

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -21,6 +21,7 @@ from excel_grapher.grapher.dynamic_refs import (
     DynamicRefError,
     DynamicRefLimits,
     FromWorkbook,
+    infer_dynamic_index_targets,
     infer_dynamic_indirect_targets,
     infer_dynamic_offset_targets,
 )
@@ -629,4 +630,163 @@ def test_from_constraints_and_workbook_uses_workbook_values_for_constants(tmp_pa
 
     assert env["Sheet1!B2"].kind is CellKind.STRING
     assert env["Sheet1!B2"].enum == EnumDomain(values=frozenset({"Afghanistan"}))
+
+
+# ── Standalone INDEX inference ──────────────────────────────────────────
+
+
+def test_dynamic_index_literal_row_col() -> None:
+    """INDEX with literal row and col resolves to a single cell."""
+    formula = "=INDEX(Sheet1!A1:Sheet1!C3,2,3)"
+    env = _make_env({})
+    targets = infer_dynamic_index_targets(formula, current_sheet="Sheet1", cell_type_env=env)
+    assert targets == {"Sheet1!C2"}
+
+
+def test_dynamic_index_enum_row() -> None:
+    """INDEX with constrained row enum resolves to union of cells."""
+    formula = "=INDEX(Sheet1!A1:Sheet1!A3,Sheet1!B1,1)"
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({1, 2, 3})),
+            )
+        }
+    )
+    targets = infer_dynamic_index_targets(formula, current_sheet="Sheet1", cell_type_env=env)
+    assert targets == {"Sheet1!A1", "Sheet1!A2", "Sheet1!A3"}
+
+
+def test_dynamic_index_interval_row() -> None:
+    """INDEX with interval domain on row resolves to union of cells."""
+    formula = "=INDEX(Sheet1!A1:Sheet1!A5,Sheet1!B1,1)"
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                interval=IntIntervalDomain(min=1, max=3),
+            )
+        }
+    )
+    targets = infer_dynamic_index_targets(formula, current_sheet="Sheet1", cell_type_env=env)
+    assert targets == {"Sheet1!A1", "Sheet1!A2", "Sheet1!A3"}
+
+
+def test_dynamic_index_row_expr_with_row_function() -> None:
+    """INDEX with ROW()-based expression; ref_only arg does not require domain."""
+    formula = "=INDEX(Sheet1!A1:Sheet1!A5,ROW()-ROW(Sheet1!B106)+1,1)"
+    env = _make_env({})
+    targets = infer_dynamic_index_targets(
+        formula,
+        current_sheet="Sheet1",
+        cell_type_env=env,
+        current_row=106,
+        current_col=1,
+    )
+    assert targets == {"Sheet1!A1"}
+
+
+def test_dynamic_index_requires_domain_for_leaf() -> None:
+    """INDEX with non-literal row that has no domain raises DynamicRefError."""
+    formula = "=INDEX(Sheet1!A1:Sheet1!A3,Sheet1!B1,1)"
+    env = _make_env({})
+    with pytest.raises(DynamicRefError) as exc_info:
+        infer_dynamic_index_targets(formula, current_sheet="Sheet1", cell_type_env=env)
+    assert "Missing CellType" in str(exc_info.value) or "B1" in str(exc_info.value)
+
+
+def test_dynamic_index_two_args() -> None:
+    """INDEX with only 2 args (array, row_num) defaults col to 1."""
+    formula = "=INDEX(Sheet1!A1:Sheet1!A3,Sheet1!B1)"
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({1, 2})),
+            )
+        }
+    )
+    targets = infer_dynamic_index_targets(formula, current_sheet="Sheet1", cell_type_env=env)
+    assert targets == {"Sheet1!A1", "Sheet1!A2"}
+
+
+def test_dynamic_index_does_not_duplicate_with_offset_index() -> None:
+    """Standalone INDEX inference ignores INDEX that is nested inside OFFSET."""
+    formula = "=OFFSET(INDEX(Sheet1!A1:Sheet1!A3,Sheet1!B1,1),0,0)"
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({1, 2, 3})),
+            )
+        }
+    )
+    # Should return empty — INDEX inside OFFSET is not standalone
+    targets = infer_dynamic_index_targets(formula, current_sheet="Sheet1", cell_type_env=env)
+    assert targets == set()
+
+
+def _build_standalone_index_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number(0, 0, 100)  # A1
+    ws.write_number(1, 0, 200)  # A2
+    ws.write_number(2, 0, 300)  # A3
+    ws.write_number(0, 1, 1)  # B1 (leaf: row selector)
+    ws.write_formula(0, 2, "=INDEX(Sheet1!A1:Sheet1!A3,Sheet1!B1,1)", None, 100)  # C1
+    wb.close()
+
+
+def test_create_dependency_graph_with_standalone_index(tmp_path: Path) -> None:
+    """Graph built with DynamicRefConfig resolves standalone INDEX and yields expected edges."""
+    excel_path = tmp_path / "standalone_index.xlsx"
+    _build_standalone_index_workbook(excel_path)
+
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({1, 2, 3})),
+            )
+        }
+    )
+    config = DynamicRefConfig(cell_type_env=env, limits=DynamicRefLimits())
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!C1"],
+        load_values=False,
+        dynamic_refs=config,
+    )
+    deps = graph.dependencies("Sheet1!C1")
+    # C1 depends on B1 (row selector) and the resolved INDEX targets A1, A2, A3
+    assert deps == {"Sheet1!B1", "Sheet1!A1", "Sheet1!A2", "Sheet1!A3"}
+
+
+def test_create_dependency_graph_raises_on_standalone_index_by_default(tmp_path: Path) -> None:
+    """Standalone INDEX with non-literal args raises DynamicRefError by default."""
+    excel_path = tmp_path / "standalone_index_raise.xlsx"
+    _build_standalone_index_workbook(excel_path)
+
+    with pytest.raises(DynamicRefError):
+        create_dependency_graph(excel_path, ["Sheet1!C1"], load_values=False)
+
+
+def test_create_dependency_graph_standalone_index_missing_leaf(tmp_path: Path) -> None:
+    """Standalone INDEX with missing leaf constraint raises DynamicRefError listing the leaf."""
+    excel_path = tmp_path / "standalone_index_missing.xlsx"
+    _build_standalone_index_workbook(excel_path)
+
+    config = DynamicRefConfig(cell_type_env=_make_env({}), limits=DynamicRefLimits())
+
+    with pytest.raises(DynamicRefError) as exc_info:
+        create_dependency_graph(
+            excel_path,
+            ["Sheet1!C1"],
+            load_values=False,
+            dynamic_refs=config,
+        )
+    assert "Sheet1!B1" in str(exc_info.value)
+    assert "leaf" in str(exc_info.value).lower()
 


### PR DESCRIPTION
## Summary
- Add `infer_dynamic_index_targets()` to `dynamic_refs.py` that infers the union of possible target cells for standalone `INDEX(array, row, [col])` formulas by enumerating leaf cell domains (same approach as OFFSET/INDIRECT)
- Wire INDEX detection into `builder.py` so standalone INDEX with non-literal row/col args requires `DynamicRefConfig` leaf constraints (or raises `DynamicRefError`)
- INDEX calls nested inside OFFSET are excluded to avoid duplicate work with the existing `_resolve_offset_base` path
- Update `__init__.py` to export the new function

## Test plan
- [x] Literal row/col resolves to single cell
- [x] Enum domain on row resolves to union of cells
- [x] Interval domain on row resolves correctly
- [x] ROW()-based expression excludes ref_only args from domain requirements
- [x] Missing leaf constraint raises DynamicRefError
- [x] 2-arg INDEX defaults col to 1
- [x] INDEX inside OFFSET is skipped (not standalone)
- [x] Full graph integration: standalone INDEX resolves targets as dependencies
- [x] Default behavior raises DynamicRefError for non-literal INDEX args
- [x] Missing leaf constraint in graph builder lists the leaf in error message

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)