### PR TITLE
Normalize keys in constraints_to_cell_type_env (follow-up to #44)

### DIFF
--- a/excel_grapher/core/cell_types.py
+++ b/excel_grapher/core/cell_types.py
@@ -116,7 +116,7 @@ def constraints_to_cell_type_env(
         else:
             kind = _infer_kind_from_python_type(base_type)
 
-        env[key] = CellType(
+        env[_normalize_cell_address(key)] = CellType(
             kind=kind,
             interval=_interval_from_domain(domain),
             enum=_enum_from_domain(domain),


### PR DESCRIPTION
## Problem

PR #44 introduced `_lookup_cell_type` so env lookups use `_normalize_cell_address(address)`. TypedDict / `constrain()` keys for sheets that need Excel quoting still look like `'Input 4 - External Financing'!H10`, while normalized lookup uses `Input 4 - External Financing!H10`. Those strings never match, so `CellType` (including `GreaterThanCell` metadata) is never found for quoted sheets.

Upstream regression tests build env dicts with **already-unquoted** keys (`f"{sheet}!B9"`), which masked this gap for real `constraints_to_cell_type_env` output.

## Change

Store each cell type under `_normalize_cell_address(key)` when building the env from type hints.

## Notes

- Unquoted keys like `Sheet1!A1` are unchanged by normalization.
- Relational metadata already normalizes `other`; keys and lookups are now consistent.
