### PR TITLE
Match format_key addresses to normalized cell_type_env (PR #46 follow-up)

### DIFF
--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -9,6 +9,8 @@ import fastpyxl
 import fastpyxl.utils.cell
 from fastpyxl.worksheet.formula import ArrayFormula
 
+from excel_grapher.core.cell_types import _normalize_cell_address
+
 from .dependency_provenance import EdgeProvenance
 from .dynamic_refs import (
     DynamicRefConfig,
@@ -382,7 +384,9 @@ def create_dependency_graph(
                         if not (isinstance(cell_val, str) and cell_val.startswith("=")):
                             leaves.add(addr)
                     leaf_env_keys = set(dynamic_refs.cell_type_env.keys())
-                    missing_leaves = leaves - leaf_env_keys
+                    missing_leaves = {
+                        addr for addr in leaves if _normalize_cell_address(addr) not in leaf_env_keys
+                    }
                     if missing_leaves:
                         cell_key = format_key(current_sheet, current_a1)
                         formatted_missing = _format_missing_leaves(missing_leaves)

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -328,8 +328,9 @@ def expand_leaf_env_to_argument_env(
             raise DynamicRefError(
                 f"Cycle detected while inferring argument-cell types for {addr!r}"
             )
-        if addr in leaf_env:
-            cache[addr] = leaf_env[addr]
+        ct_resolved = _lookup_cell_type(leaf_env, addr)
+        if ct_resolved is not None:
+            cache[addr] = ct_resolved
             return cache[addr]
         in_progress.add(addr)
         formula = get_cell_formula(addr)

--- a/tests/core/test_constraints_mapping.py
+++ b/tests/core/test_constraints_mapping.py
@@ -5,6 +5,7 @@ from typing import Annotated, Literal, TypedDict, cast
 from excel_grapher.core.cell_types import (
     Between,
     CellKind,
+    CellType,
     CellTypeEnv,
     EnumDomain,
     GreaterThanCell,
@@ -12,6 +13,7 @@ from excel_grapher.core.cell_types import (
     NotEqualCell,
     constraints_to_cell_type_env,
 )
+from excel_grapher.grapher.dynamic_refs import DynamicRefLimits, expand_leaf_env_to_argument_env
 
 
 # Address-style keys (Sheet1!B1) are the convention for DynamicRefConfig; TypedDict
@@ -157,4 +159,22 @@ def test_constraints_mapping_normalizes_quoted_sheet_keys_in_env() -> None:
     b1 = env[_QS_NORMAL_B1]
     assert b1.kind is CellKind.NUMBER
     assert b1.relations == (GreaterThanCell(_QS_NORMAL_A1),)
+
+
+def test_expand_leaf_env_resolves_format_key_addr_against_normalized_env() -> None:
+    """Graph builder passes format_key addresses; env keys are normalized (PR #46)."""
+    norm = "Chart Data!I21"
+    quoted = "'Chart Data'!I21"
+    leaf_env: CellTypeEnv = {
+        norm: CellType(kind=CellKind.NUMBER, interval=IntervalDomain(min=1, max=1)),
+    }
+    out = expand_leaf_env_to_argument_env(
+        {quoted},
+        lambda _addr: None,
+        lambda _f, _sh: set(),
+        leaf_env,
+        DynamicRefLimits(),
+    )
+    assert quoted in out
+    assert out[quoted].interval == IntervalDomain(min=1, max=1)
 


### PR DESCRIPTION
## Problem

PR #46 stores `cell_type_env` keys in normalized form (`Chart Data!I21`), but the dependency graph builder still collects leaf addresses with `format_key` (`'Chart Data'!I21` when the sheet name needs quoting). The set difference `leaves - leaf_env_keys` wrongly treats constrained cells as missing.

`expand_leaf_env_to_argument_env` had the same issue: `addr in leaf_env` failed for quoted `addr` strings.

## Change

- **builder.py**: treat a leaf as constrained when `_normalize_cell_address(addr)` is in `cell_type_env`.
- **dynamic_refs.py**: resolve leaves with `_lookup_cell_type(leaf_env, addr)` instead of `addr in leaf_env`.

## Test

`test_expand_leaf_env_resolves_format_key_addr_against_normalized_env` covers the expand path.
