### PR TITLE
CellTypeEnv key normalization API; unary % abstract analysis

### DIFF
--- a/excel_grapher/core/cell_types.py
+++ b/excel_grapher/core/cell_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, TypeAlias, get_args, get_origin, get_type_hints
@@ -84,6 +84,9 @@ def constraints_to_cell_type_env(
     constraints is a validated instance (e.g. from TypeAdapter). The current
     implementation only inspects type metadata; it assumes the instance has
     already been validated elsewhere.
+
+    Dict keys are :func:`normalize_cell_type_env_key` of each hint key so they
+    align with ``format_key`` addresses from the grapher after normalization.
     """
 
     # Import here to avoid forcing Annotated / Literal into __all__ of core.
@@ -116,7 +119,7 @@ def constraints_to_cell_type_env(
         else:
             kind = _infer_kind_from_python_type(base_type)
 
-        env[_normalize_cell_address(key)] = CellType(
+        env[normalize_cell_type_env_key(key)] = CellType(
             kind=kind,
             interval=_interval_from_domain(domain),
             enum=_enum_from_domain(domain),
@@ -141,9 +144,9 @@ def _relations_from_metadata(metadata: list[object]) -> tuple[CellRelation, ...]
     relations: list[CellRelation] = []
     for meta in metadata:
         if isinstance(meta, GreaterThanCell):
-            relations.append(GreaterThanCell(_normalize_cell_address(meta.other)))
+            relations.append(GreaterThanCell(normalize_cell_type_env_key(meta.other)))
         elif isinstance(meta, NotEqualCell):
-            relations.append(NotEqualCell(_normalize_cell_address(meta.other)))
+            relations.append(NotEqualCell(normalize_cell_type_env_key(meta.other)))
     return tuple(relations)
 
 
@@ -188,12 +191,35 @@ def _enum_from_domain(domain: IntervalDomain | EnumDomain | None) -> EnumDomain 
     return None
 
 
-def _normalize_cell_address(addr: str) -> str:
-    sheet_part, coord = addr.split("!", 1)
+def normalize_cell_type_env_key(address: str) -> str:
+    """Return the canonical key for :class:`CellTypeEnv` / dynamic-ref constraint maps.
+
+    Graph code uses :func:`excel_grapher.grapher.parser.format_key`, which wraps
+    sheet names in single quotes when Excel requires it. TypedDict and
+    :func:`constraints_to_cell_type_env` may use the same spelling. This
+    function strips those delimiters and normalizes the cell coordinate (column
+    letters uppercased) so env lookups match regardless of quoting or case.
+
+    Not to be confused with :func:`excel_grapher.evaluator.name_utils.normalize_address`,
+    which follows evaluator node-key quoting rules and can differ for sheets
+    that contain spaces.
+    """
+    sheet_part, coord = address.split("!", 1)
     sheet = sheet_part.strip()
     if sheet.startswith("'") and sheet.endswith("'"):
         sheet = sheet[1:-1].replace("''", "'")
 
     col, row = coordinate_from_string(coord.strip().replace("$", ""))
-    return f"{sheet}!{col}{row}"
+    return f"{sheet}!{col.upper()}{row}"
+
+
+def leaves_missing_cell_type_constraints(
+    leaves: Iterable[str], cell_type_env: Mapping[str, CellType]
+) -> set[str]:
+    """Leaves whose normalized address has no entry in ``cell_type_env``."""
+    env_keys = frozenset(cell_type_env.keys())
+    return {addr for addr in leaves if normalize_cell_type_env_key(addr) not in env_keys}
+
+
+_normalize_cell_address = normalize_cell_type_env_key
 

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -9,7 +9,7 @@ import fastpyxl
 import fastpyxl.utils.cell
 from fastpyxl.worksheet.formula import ArrayFormula
 
-from excel_grapher.core.cell_types import _normalize_cell_address
+from excel_grapher.core.cell_types import leaves_missing_cell_type_constraints
 
 from .dependency_provenance import EdgeProvenance
 from .dynamic_refs import (
@@ -383,10 +383,9 @@ def create_dependency_graph(
                         cell_val = wb_formulas[sh][a1].value
                         if not (isinstance(cell_val, str) and cell_val.startswith("=")):
                             leaves.add(addr)
-                    leaf_env_keys = set(dynamic_refs.cell_type_env.keys())
-                    missing_leaves = {
-                        addr for addr in leaves if _normalize_cell_address(addr) not in leaf_env_keys
-                    }
+                    missing_leaves = leaves_missing_cell_type_constraints(
+                        leaves, dynamic_refs.cell_type_env
+                    )
                     if missing_leaves:
                         cell_key = format_key(current_sheet, current_a1)
                         formatted_missing = _format_missing_leaves(missing_leaves)

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -23,8 +23,8 @@ from excel_grapher.core.cell_types import (
     GreaterThanCell,
     IntervalDomain,
     NotEqualCell,
-    _normalize_cell_address,
     constraints_to_cell_type_env,
+    normalize_cell_type_env_key,
 )
 from excel_grapher.core.excel_function_meta import is_ref_only_arg
 from excel_grapher.core.expr_eval import Unsupported, evaluate_expr
@@ -285,7 +285,8 @@ def expand_leaf_env_to_argument_env(
     The cell env targets leaves: only leaf (non-formula) addresses need to be in
     leaf_env. Intermediate (formula) cells are inferred by evaluating their formulas
     over their dependencies' domains; they do not need to be constrained. If an
-    intermediate is in leaf_env, that type is used and we do not traverse that branch.
+    intermediate matches a leaf_env entry under :func:`~excel_grapher.core.cell_types.normalize_cell_type_env_key`,
+    that type is used and we do not traverse that branch.
     When an intermediate cannot be inferred (e.g. its formula is OFFSET/INDIRECT and
     refs are empty after masking), it is assigned CellType(ANY); enumeration may then
     require a constraint for that cell.
@@ -1147,15 +1148,15 @@ def _domain_without_zero(domain: _FiniteInts | _IntBounds | None) -> _FiniteInts
 
 
 def _lookup_cell_type(env: CellTypeEnv, address: str) -> CellType | None:
-    """Resolve env entry; keys match :func:`_normalize_cell_address` (no Excel quote delimiters)."""
-    return env.get(_normalize_cell_address(address))
+    """Resolve env entry; keys match :func:`~excel_grapher.core.cell_types.normalize_cell_type_env_key`."""
+    return env.get(normalize_cell_type_env_key(address))
 
 
 def _cell_has_relation(env: CellTypeEnv, addr: str, relation: type[GreaterThanCell | NotEqualCell], other: str) -> bool:
     ct = _lookup_cell_type(env, addr)
     if ct is None:
         return False
-    other_norm = _normalize_cell_address(other)
+    other_norm = normalize_cell_type_env_key(other)
     return any(isinstance(rel, relation) and rel.other == other_norm for rel in ct.relations)
 
 
@@ -1455,7 +1456,7 @@ def _describe_unsupported_numeric_construct(node: AstNode | None) -> str | None:
     if isinstance(node, (StringNode, BoolNode, ErrorNode, RangeNode)):
         return type(node).__name__
     if isinstance(node, UnaryOpNode):
-        if node.op == "-":
+        if node.op in {"-", "%"}:
             return _describe_unsupported_numeric_construct(node.operand)
         return f"unary operator {node.op!r}"
     if isinstance(node, BinaryOpNode):
@@ -1479,8 +1480,8 @@ def _describe_unsupported_numeric_construct(node: AstNode | None) -> str | None:
 def _range_node_cell_addresses(node: RangeNode) -> list[str] | None:
     """Expand a single-sheet A1 range to sheet-qualified cell keys in row-major order."""
     try:
-        norm_start = _normalize_cell_address(node.start)
-        norm_end = _normalize_cell_address(node.end)
+        norm_start = normalize_cell_type_env_key(node.start)
+        norm_end = normalize_cell_type_env_key(node.end)
         sheet, coord_start = norm_start.split("!", 1)
         sheet2, coord_end = norm_end.split("!", 1)
     except ValueError:
@@ -1732,6 +1733,19 @@ def _infer_numeric_domain_result(
             if inner.diagnostic is not None:
                 return inner
             return _domain_result(_neg_numeric_domain(inner.domain))
+        if node.op == "%":
+            inner = _infer_numeric_domain_result(
+                node.operand, env, limits, context=ctx, current_sheet=current_sheet, depth=depth + 1
+            )
+            if inner.diagnostic is not None:
+                return inner
+            return _domain_result(
+                _div_numeric_domains(
+                    inner.domain,
+                    _FiniteInts(frozenset({100})),
+                    limits,
+                )
+            )
         return _domain_result(None)
 
     if isinstance(node, BinaryOpNode):

--- a/excel_grapher/grapher/provenance_collect.py
+++ b/excel_grapher/grapher/provenance_collect.py
@@ -7,6 +7,8 @@ from typing import Literal
 import fastpyxl
 import fastpyxl.utils.cell
 
+from excel_grapher.core.cell_types import leaves_missing_cell_type_constraints
+
 from .dependency_provenance import DependencyCause, EdgeProvenance, merge_provenance_maps
 from .dynamic_refs import (
     DynamicRefConfig,
@@ -228,8 +230,9 @@ def _flat_provenance_one_string(
                 cell_val = wb_formulas[sh][a1].value
                 if not (isinstance(cell_val, str) and cell_val.startswith("=")):
                     leaves.add(addr)
-            leaf_env_keys = set(dynamic_refs.cell_type_env.keys())
-            missing_leaves = leaves - leaf_env_keys
+            missing_leaves = leaves_missing_cell_type_constraints(
+                leaves, dynamic_refs.cell_type_env
+            )
             if missing_leaves:
                 raise DynamicRefError(
                     f"Provenance: leaf cells feeding OFFSET/INDIRECT have no constraint: {sorted(missing_leaves)}"

--- a/tests/core/test_cell_type_env.py
+++ b/tests/core/test_cell_type_env.py
@@ -6,6 +6,8 @@ from excel_grapher.core.cell_types import (
     CellTypeEnv,
     EnumDomain,
     IntervalDomain,
+    leaves_missing_cell_type_constraints,
+    normalize_cell_type_env_key,
 )
 
 
@@ -56,4 +58,20 @@ def test_cell_type_env_can_mix_kinds_and_domains() -> None:
     assert a3.interval is not None
     assert a3.interval.min == -5
     assert a3.interval.max is None
+
+
+def test_normalize_cell_type_env_key_strips_excel_sheet_quotes() -> None:
+    sheet = "Chart Data"
+    assert normalize_cell_type_env_key(f"'{sheet}'!B2") == f"{sheet}!B2"
+    assert normalize_cell_type_env_key(f"'{sheet}'!b2") == f"{sheet}!B2"
+    assert normalize_cell_type_env_key(f"{sheet}!B2") == f"{sheet}!B2"
+
+
+def test_leaves_missing_cell_type_constraints_ignores_format_key_quoting() -> None:
+    env: CellTypeEnv = {
+        "Chart Data!I21": CellType(kind=CellKind.NUMBER, interval=IntervalDomain(min=1, max=1)),
+    }
+    leaves = {"'Chart Data'!I21", "Sheet1!Z9"}
+    missing = leaves_missing_cell_type_constraints(leaves, env)
+    assert missing == {"Sheet1!Z9"}
 

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -1526,6 +1526,41 @@ def test_expand_leaf_env_division_relational_constraint_avoids_zero_risk_error()
     assert out.interval == IntIntervalDomain(min=-(2 * 10**16), max=2 * 10**16)
 
 
+def test_expand_leaf_env_percent_expression_stays_in_abstract_path() -> None:
+    leaf_env = _make_env(
+        {
+            "Sheet1!A1": CellType(
+                kind=CellKind.NUMBER,
+                interval=IntIntervalDomain(min=0, max=2000),
+            ),
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                interval=IntIntervalDomain(min=0, max=1),
+            ),
+        }
+    )
+
+    def _get_cell_formula(addr: str) -> str | None:
+        return "=Sheet1!B1+(Sheet1!A1/100)%" if addr == "Sheet1!C1" else None
+
+    def _get_refs_from_formula(formula: str, sheet: str) -> set[str]:
+        assert sheet == "Sheet1"
+        return {"Sheet1!A1", "Sheet1!B1"}
+
+    env = dynamic_refs_mod.expand_leaf_env_to_argument_env(
+        {"Sheet1!C1"},
+        _get_cell_formula,
+        _get_refs_from_formula,
+        leaf_env,
+        DynamicRefLimits(max_branches=8),
+    )
+
+    out = env["Sheet1!C1"]
+    assert out.kind is CellKind.NUMBER
+    assert out.enum is not None
+    assert out.enum.values == frozenset({0, 1})
+
+
 def test_infer_numeric_domain_parity_never_raises() -> None:
     limits = DynamicRefLimits(max_branches=64, max_depth=12)
     env: CellTypeEnv = {


### PR DESCRIPTION
## Summary

Consolidates how sheet-qualified addresses are normalized for `CellTypeEnv` / dynamic-ref flows (follow-up to #44 / #46 / #48), and adds abstract numeric analysis for Excel’s unary percent operator.

## CellTypeEnv normalization

- **`normalize_cell_type_env_key`** — public canonical key (strip Excel sheet quotes, `$`, uppercase column). Documented as distinct from evaluator `name_utils.normalize_address`.
- **`leaves_missing_cell_type_constraints`** — shared rule for “leaf has no constraint” vs normalized env keys.
- **`_normalize_cell_address`** — alias of `normalize_cell_type_env_key` for compatibility.
- **builder** and **provenance_collect** use the helper instead of ad hoc set differences / `_normalize_cell_address` imports.
- **dynamic_refs** imports the public name; **expand_leaf_env_to_argument_env** resolves leaves with `_lookup_cell_type`.

## Unary `%` (abstract analysis)

- **`_infer_numeric_domain_result`**: unary `%` divides the operand domain by 100 (same spirit as Excel percent-of).
- **`_describe_unsupported_numeric_construct`**: treat `%` like unary `-` for operand traversal.
- **Test**: `test_expand_leaf_env_percent_expression_stays_in_abstract_path`.

## Tests

- `test_normalize_cell_type_env_key_strips_excel_sheet_quotes`
- `test_leaves_missing_cell_type_constraints_ignores_format_key_quoting`
- Plus expand_leaf percent integration test above.

`uv run pytest -q` → 529 passed (7 deselected).

Made with [Cursor](https://cursor.com)