### PR TITLE
Add RealBetween / real-interval domains for dynamic refs (#40)

### DIFF
--- a/example/map_lic_dsf_indicators.py
+++ b/example/map_lic_dsf_indicators.py
@@ -9,7 +9,7 @@ Dynamic refs (OFFSET/INDIRECT) are resolved via a constraint-based config.
 Iterative workflow: run the script; if DynamicRefError is raised, the message
 includes the formula cell that needs a constraint. Inspect that cell and the
 row/column headers in the workbook to decide plausible input domains, add the
-address to LicDsfConstraints (with Annotated[int, Between(lo, hi)] or
+address to LicDsfConstraints (with Annotated[int, Between(lo, hi)], Annotated[float, RealBetween(...)], or
 Literal[...]), then re-run until the graph
 builds.
 """
@@ -42,7 +42,7 @@ from excel_grapher import (
     to_graphviz,
     validate_graph,
 )
-from excel_grapher.core.cell_types import Between  # noqa: F401 - used when adding constraints
+from excel_grapher.core.cell_types import Between, RealBetween  # noqa: F401 - used when adding constraints
 
 # Row labels for the multi-row stress-test blocks (same row layout in each block).
 # Blank string means that row is skipped when splitting by row.
@@ -134,7 +134,7 @@ USE_CACHED_DYNAMIC_REFS = False
 # ---------------------------------------------------------------------------
 
 """
-Dynamic refs (OFFSET/INDIRECT/INDEX) are resolved via a constraint-based config. Iterative workflow: run the script; if DynamicRefError is raised, the message includes the formula cell whose inputs need constraints. Inspect that cell and the row/column headers in the workbook to decide plausible input domains, use `constrain` to set a constraint (e.g., `constrain(LicDsfConstraints, "'Sheet Name'!A965", Literal["value"])` for a constant or something like `Annotated[float, Between(min=0)]` in lieu of `Literal` for a numeric constraint).
+Dynamic refs (OFFSET/INDIRECT/INDEX) are resolved via a constraint-based config. Iterative workflow: run the script; if DynamicRefError is raised, the message includes the formula cell whose inputs need constraints. Inspect that cell and the row/column headers in the workbook to decide plausible input domains, use `constrain` to set a constraint (e.g., `constrain(LicDsfConstraints, "'Sheet Name'!A965", Literal["value"])` for a constant or something like `Annotated[float, RealBetween(min=0)]` in lieu of `Literal` for a numeric constraint).
 
 Then re-run until the graph builds. Note that if row/column labels or intentionally blank cells show up in error output, they have been referenced by a dynamic ref and must be constrained for the graph to resolve. Blank cells can be set to `Literal[None]`.
 
@@ -166,7 +166,7 @@ constrain(LicDsfConstraints, "PV_Base!A917", Literal[64])
 constrain(LicDsfConstraints, "PV_Base!A941", Literal[90])
 constrain(LicDsfConstraints, "PV_Base!A965", Literal[115])
 
-constrain(LicDsfConstraints, "PV_Base!A965", Annotated[float, Between(min=0)])
+constrain(LicDsfConstraints, "PV_Base!A965", Annotated[float, RealBetween(min=0)])
 
 # A918:A938, A942:A962, A966:A986 each has a single cached letter D, E, …, X.
 for _start, _end in [(918, 939), (942, 963), (966, 987)]:
@@ -191,17 +191,17 @@ constrain(LicDsfConstraints, "lookup!BB4:BC7", _LANG_LOOKUP)
 
 # Tailored stress test parameters (from Input 6 - Tailored Tests)
 constrain(LicDsfConstraints, "C4_Market_financing!AB20", Literal[0, 1])  # New commercial debt projected
-constrain(LicDsfConstraints, "C4_Market_financing!AB22", Annotated[float, Between(min=0, max=100)])  # FX depreciation shock (%)
-constrain(LicDsfConstraints, "C4_Market_financing!AB23", Annotated[float, Between(min=0, max=1)])  # ER pass-through to inflation
+constrain(LicDsfConstraints, "C4_Market_financing!AB22", Annotated[float, RealBetween(min=0, max=100)])  # FX depreciation shock (%)
+constrain(LicDsfConstraints, "C4_Market_financing!AB23", Annotated[float, RealBetween(min=0, max=1)])  # ER pass-through to inflation
 constrain(LicDsfConstraints, "C4_Market_financing!AB25", Annotated[int, Between(min=0, max=2000)])  # Increase in cost, bps
 constrain(LicDsfConstraints, "C4_Market_financing!AB28", Annotated[int, Between(min=1, max=50)])  # New maturity if original > 5y
-constrain(LicDsfConstraints, "C4_Market_financing!AB29", Annotated[float, Between(min=0, max=1)])  # Maturity shortening factor if < 5y
-constrain(LicDsfConstraints, "C4_Market_financing!AB30", Annotated[float, Between(min=0, max=1)])  # Grace period shortening factor
+constrain(LicDsfConstraints, "C4_Market_financing!AB29", Annotated[float, RealBetween(min=0, max=1)])  # Maturity shortening factor if < 5y
+constrain(LicDsfConstraints, "C4_Market_financing!AB30", Annotated[float, RealBetween(min=0, max=1)])  # Grace period shortening factor
 
 # New lending terms for the stress test (C4_Market_financing rows 35-39)
 constrain(LicDsfConstraints, "C4_Market_financing!C35:C39", Annotated[int, Between(min=0, max=50)])  # Grace period
 constrain(LicDsfConstraints, "C4_Market_financing!D35:D39", Annotated[int, Between(min=1, max=100)])  # Loan Maturity
-constrain(LicDsfConstraints, "C4_Market_financing!I35:I39", Annotated[float, Between(min=0, max=1)])  # Interest rate
+constrain(LicDsfConstraints, "C4_Market_financing!I35:I39", Annotated[float, RealBetween(min=0, max=1)])  # Interest rate
 
 # Structural dependencies for INDEX/MATCH resolution
 # 1. Set the default (None) for the bulk ranges
@@ -303,7 +303,7 @@ def _constrain_pv_stress_com(constraints: type[Any]) -> None:
     # W36:W140, X36:X140, Y36:Y140, Z36:Z140
 
     # Non-negative financial flows / values
-    financial_type = Annotated[float | None, Between(0, 10**15)]
+    financial_type = Annotated[float | None, RealBetween(0, 10**15)]
 
     # D9:D140 has some specific constants
     for r in range(9, 141):
@@ -338,7 +338,7 @@ _constrain_pv_stress_com(LicDsfConstraints)
 
 def _constrain_pv_baseline_com(constraints: type[Any]) -> None:
     # Non-negative financial flows / values (or None for empty cells)
-    financial_type = Annotated[float | None, Between(0, 10**15)]
+    financial_type = Annotated[float | None, RealBetween(0, 10**15)]
 
     # D column: mixed constants and financial values
     # D7: total commercial (financial)
@@ -378,8 +378,8 @@ def _constrain_pv_stress_and_pv_base_index_cells(constraints: type[Any]) -> None
     PV_Base AF: cumulative outputs; BD: total debt service; D: Interest rates, Base=100 scalars,
     IDA line, or maturity/Base blocks.
     """
-    financial_type = Annotated[float | None, Between(0, 10**15)]
-    unit_rate = Annotated[float | None, Between(0, 1)]
+    financial_type = Annotated[float | None, RealBetween(0, 10**15)]
+    unit_rate = Annotated[float | None, RealBetween(0, 1)]
 
     constrain(constraints, "'PV Stress'!D147", unit_rate)
     constrain(constraints, "'PV Stress'!D161", financial_type)
@@ -428,13 +428,13 @@ _constrain_pv_stress_and_pv_base_index_cells(LicDsfConstraints)
 # ---------------------------------------------------------------------------
 
 def _constrain_pv_lc_nr(constraints: type[Any], sheet: str) -> None:
-    financial_type = Annotated[float | None, Between(0, 10**15)]
+    financial_type = Annotated[float | None, RealBetween(0, 10**15)]
 
     # C28: text label "Stock of debt (in LC)"
     constrain(constraints, f"{sheet}!C28", Literal["Stock of debt (in LC)"])
 
     # BD7: interest rate (local currency) — unit rate
-    constrain(constraints, f"{sheet}!BD7", Annotated[float | None, Between(0, 1)])
+    constrain(constraints, f"{sheet}!BD7", Annotated[float | None, RealBetween(0, 1)])
 
     # Y6:AE6: tail end of gross financing row (beyond projection horizon)
     for _col in ("Y", "Z", "AA", "AB", "AC", "AD", "AE"):
@@ -468,7 +468,7 @@ _constrain_pv_lc_nr(LicDsfConstraints, "PV_LC_NR3")
 # enrichment_audit.json: first projection year; discount rate (template 0.05); ext/dom
 # definition (data validation lookup!X4:X5).
 constrain(LicDsfConstraints, "'Input 1 - Basics'!C18", Annotated[int, Between(1990, 2100)])
-constrain(LicDsfConstraints, "'Input 1 - Basics'!C25", Annotated[float, Between(0, 1)])
+constrain(LicDsfConstraints, "'Input 1 - Basics'!C25", Annotated[float, RealBetween(0, 1)])
 constrain(
     LicDsfConstraints,
     "'Input 1 - Basics'!C33",
@@ -687,7 +687,7 @@ _INPUT3_DMX_A1_RANGES: tuple[str, ...] = (
 
 def _constrain_input3_dmx(constraints: type[Any]) -> None:
     """Input 3 DMX macro series feeding INDEX (enrichment_audit: flows/GDP; may be negative)."""
-    dmx_macro = Annotated[float | None, Between(-10**15, 10**15)]
+    dmx_macro = Annotated[float | None, RealBetween(-10**15, 10**15)]
     q = "'Input 3 - Macro-Debt data(DMX)'"
     for a1 in _INPUT3_DMX_A1_RANGES:
         constrain(constraints, f"{q}!{a1}", dmx_macro)
@@ -702,8 +702,8 @@ _constrain_input3_dmx(LicDsfConstraints)
 
 def _constrain_input4_external_financing(constraints: type[Any]) -> None:
     """External financing (enrichment_audit: AG–AM and L–N flows; F interest; G grace; H maturity)."""
-    financial_type = Annotated[float | None, Between(0, 10**15)]
-    unit_rate = Annotated[float | None, Between(0, 1)]
+    financial_type = Annotated[float | None, RealBetween(0, 10**15)]
+    unit_rate = Annotated[float | None, RealBetween(0, 1)]
     grace = Annotated[int | None, Between(0, 50)]
     maturity = Annotated[int | None, Between(1, 100)]
 
@@ -757,9 +757,9 @@ def _constrain_input5_local_debt(constraints: type[Any]) -> None:
         return [get_column_letter(i) for i in range(min_c, max_c + 1)]
 
     q = "'Input 5 - Local-debt Financing'"
-    financial = Annotated[float | None, Between(0, 10**15)]
-    financial_signed = Annotated[float | None, Between(-10**15, 10**15)]
-    unit_rate = Annotated[float | None, Between(0, 1)]
+    financial = Annotated[float | None, RealBetween(0, 10**15)]
+    financial_signed = Annotated[float | None, RealBetween(-10**15, 10**15)]
+    unit_rate = Annotated[float | None, RealBetween(0, 1)]
     grace = Annotated[int | None, Between(0, 50)]
     maturity = Annotated[int | None, Between(1, 100)]
     small_int = Annotated[int | None, Between(0, 10)]
@@ -843,9 +843,9 @@ _constrain_input5_local_debt(LicDsfConstraints)
 def _constrain_input6_input8(constraints: type[Any]) -> None:
     """Tailored and standardized stress options; SDR sheet (enrichment_audit + template dropdowns)."""
     _threshold = Literal["Historical average only", "Baseline projection only", "Whichever is lower"]
-    financial = Annotated[float | None, Between(0, 10**15)]
-    financial_signed = Annotated[float | None, Between(-10**15, 10**15)]
-    unit_rate = Annotated[float | None, Between(0, 1)]
+    financial = Annotated[float | None, RealBetween(0, 10**15)]
+    financial_signed = Annotated[float | None, RealBetween(-10**15, 10**15)]
+    unit_rate = Annotated[float | None, RealBetween(0, 1)]
 
     q6t = "'Input 6 - Tailored Tests'"
     q6o = "'Input 6(optional)-Standard Test'"
@@ -857,7 +857,7 @@ def _constrain_input6_input8(constraints: type[Any]) -> None:
     constrain(constraints, f"{q6o}!C5", _threshold)
     constrain(constraints, f"{q6o}!C7", _threshold)
     constrain(constraints, f"{q6o}!C8", Literal["On", "Off"])
-    constrain(constraints, f"{q6o}!C17", Annotated[float, Between(0, 10)])
+    constrain(constraints, f"{q6o}!C17", Annotated[float, RealBetween(0, 10)])
     constrain(constraints, f"{q6o}!D8", Literal[None])
     constrain(constraints, f"{q6o}!D9", Literal[None])
     constrain(constraints, f"{q6o}!D18", _threshold)
@@ -886,10 +886,10 @@ _constrain_input6_input8(LicDsfConstraints)
 
 # AA403:AG403 — "Exchange rate (pa)" projection columns (years); may also map to
 # creditor-row financial data depending on workbook layout.
-constrain(LicDsfConstraints, "Ext_Debt_Data!AA403:AG403", Annotated[float | None, Between(0, 10**15)])
+constrain(LicDsfConstraints, "Ext_Debt_Data!AA403:AG403", Annotated[float | None, RealBetween(0, 10**15)])
 
 # F383:F384 — short-term debt principal / interest (or exchange rate in some layouts)
-constrain(LicDsfConstraints, "Ext_Debt_Data!F383:F384", Annotated[float | None, Between(0, 10**15)])
+constrain(LicDsfConstraints, "Ext_Debt_Data!F383:F384", Annotated[float | None, RealBetween(0, 10**15)])
 
 # ---------------------------------------------------------------------------
 # Translation table constraints
@@ -1050,7 +1050,7 @@ def main() -> None:
         print(f"\n   DynamicRefError: {e}")
         print(
             "   Add the reported cell's argument cells to LicDsfConstraints (address-style keys)"
-            " using Annotated[..., Between(...)] / Annotated[..., FromWorkbook()] as needed,"
+            " using Annotated[..., Between(...)] or Annotated[..., RealBetween(...)] / Annotated[..., FromWorkbook()] as needed,"
             " then re-run. Or set USE_CACHED_DYNAMIC_REFS=True to resolve from cached values."
         )
         raise

--- a/excel_grapher/__init__.py
+++ b/excel_grapher/__init__.py
@@ -23,6 +23,8 @@ from .grapher import (
     DynamicRefLimits,
     FromWorkbook,
     GreaterThanCell,
+    RealBetween,
+    RealIntervalDomain,
     GuardCellRef,
     GuardExpr,
     Literal,
@@ -50,6 +52,8 @@ from .grapher import (
 __all__ = [
     "GreaterThanCell",
     "NotEqualCell",
+    "RealBetween",
+    "RealIntervalDomain",
     "And",
     "GuardCellRef",
     "Compare",

--- a/excel_grapher/core/cell_types.py
+++ b/excel_grapher/core/cell_types.py
@@ -19,14 +19,22 @@ class CellKind(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class IntervalDomain:
-    """Closed numeric interval domain for a cell."""
+    """Closed integer interval domain for a cell (discrete steps, enumerable for dynamic refs)."""
 
-    min: int | float | None = None
-    max: int | float | None = None
+    min: int | None = None
+    max: int | None = None
 
 
 # Backwards-compatible alias
 IntIntervalDomain = IntervalDomain
+
+
+@dataclass(frozen=True, slots=True)
+class RealIntervalDomain:
+    """Closed real-valued interval metadata; not enumerable for dynamic-ref branching."""
+
+    min: float | None = None
+    max: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,6 +67,7 @@ class CellType:
 
     kind: CellKind
     interval: IntervalDomain | None = None
+    real_interval: RealIntervalDomain | None = None
     enum: EnumDomain | None = None
     relations: tuple[CellRelation, ...] = ()
 
@@ -68,10 +77,18 @@ CellTypeEnv: TypeAlias = Mapping[str, CellType]
 
 @dataclass(frozen=True, slots=True)
 class Between:
-    """Metadata marker for numeric interval constraints in Annotated types."""
+    """Integer interval constraint for Annotated numeric types (discrete / enumerable)."""
 
-    min: int | float | None = None
-    max: int | float | None = None
+    min: int | None = None
+    max: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RealBetween:
+    """Real-valued interval constraint for Annotated float types (not enumerable for dynamic refs)."""
+
+    min: float | int | None = None
+    max: float | int | None = None
 
 
 def constraints_to_cell_type_env(
@@ -107,22 +124,24 @@ def constraints_to_cell_type_env(
                 base_type = args[0]
                 metadata = list(args[1:])
 
-        domain = _domain_from_metadata(metadata)
+        int_domain, real_domain = _interval_domains_from_metadata(metadata)
         relations = _relations_from_metadata(metadata)
 
         origin = get_origin(base_type)
+        enum_domain: EnumDomain | None = None
         if origin is Literal:
             literal_values = get_args(base_type)
             kind = _infer_kind_from_literal_values(literal_values)
-            if domain is None:
-                domain = EnumDomain(values=frozenset(literal_values))
+            if int_domain is None and real_domain is None:
+                enum_domain = EnumDomain(values=frozenset(literal_values))
         else:
             kind = _infer_kind_from_python_type(base_type)
 
         env[normalize_cell_type_env_key(key)] = CellType(
             kind=kind,
-            interval=_interval_from_domain(domain),
-            enum=_enum_from_domain(domain),
+            interval=int_domain,
+            real_interval=real_domain,
+            enum=enum_domain,
             relations=relations,
         )
 
@@ -133,11 +152,26 @@ def constraints_to_cell_type_env(
     return env
 
 
-def _domain_from_metadata(metadata: list[object]) -> IntervalDomain | EnumDomain | None:
+def _as_real_bound(x: float | int | None) -> float | None:
+    if x is None:
+        return None
+    return float(x)
+
+
+def _interval_domains_from_metadata(
+    metadata: list[object],
+) -> tuple[IntervalDomain | None, RealIntervalDomain | None]:
+    int_domain: IntervalDomain | None = None
+    real_domain: RealIntervalDomain | None = None
     for meta in metadata:
         if isinstance(meta, Between):
-            return IntervalDomain(min=meta.min, max=meta.max)
-    return None
+            int_domain = IntervalDomain(min=meta.min, max=meta.max)
+        elif isinstance(meta, RealBetween):
+            real_domain = RealIntervalDomain(
+                min=_as_real_bound(meta.min),
+                max=_as_real_bound(meta.max),
+            )
+    return int_domain, real_domain
 
 
 def _relations_from_metadata(metadata: list[object]) -> tuple[CellRelation, ...]:
@@ -177,18 +211,6 @@ def _infer_kind_from_python_type(tp: Any) -> CellKind:
         return CellKind.STRING
     # A richer implementation could handle dates, errors, etc.
     return CellKind.ANY
-
-
-def _interval_from_domain(domain: IntervalDomain | EnumDomain | None) -> IntervalDomain | None:
-    if isinstance(domain, IntervalDomain):
-        return domain
-    return None
-
-
-def _enum_from_domain(domain: IntervalDomain | EnumDomain | None) -> EnumDomain | None:
-    if isinstance(domain, EnumDomain):
-        return domain
-    return None
 
 
 def normalize_cell_type_env_key(address: str) -> str:

--- a/excel_grapher/grapher/__init__.py
+++ b/excel_grapher/grapher/__init__.py
@@ -4,7 +4,7 @@ excel_grapher: Build and analyze dependency graphs from Excel workbooks.
 This package intentionally keeps the public API small and stable.
 """
 
-from excel_grapher.core.cell_types import GreaterThanCell, NotEqualCell
+from excel_grapher.core.cell_types import GreaterThanCell, NotEqualCell, RealBetween, RealIntervalDomain
 
 from .builder import create_dependency_graph
 from .dependency_provenance import DependencyCause, EdgeProvenance
@@ -37,6 +37,8 @@ __all__ = [
     "FromWorkbook",
     "GreaterThanCell",
     "NotEqualCell",
+    "RealBetween",
+    "RealIntervalDomain",
     "constrain",
     "infer_dynamic_index_targets",
     "infer_dynamic_indirect_targets",

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -433,6 +433,9 @@ def expand_leaf_env_to_argument_env(
                             f"constrain {r!r} more tightly, simplify the formula, or extend analysis "
                             f"for the unsupported construct)"
                         ) from exc
+                elif ct.real_interval is not None:
+                    cache[addr] = CellType(kind=CellKind.ANY)
+                    return cache[addr]
                 else:
                     cache[addr] = CellType(kind=CellKind.ANY)
                     return cache[addr]
@@ -1848,7 +1851,9 @@ def _infer_numeric_domain_result(
                     return _domain_result(None)
                 if ct.kind is CellKind.NUMBER:
                     return _domain_result(_FiniteInts(frozenset({1})))
-                if ct.kind is CellKind.ANY and (ct.enum is not None or ct.interval is not None):
+                if ct.kind is CellKind.ANY and (
+                    ct.enum is not None or ct.interval is not None or ct.real_interval is not None
+                ):
                     return _domain_result(_FiniteInts(frozenset({0, 1})))
                 return _domain_result(_FiniteInts(frozenset({0})))
             arg_result = _infer_numeric_domain_result(
@@ -2303,6 +2308,11 @@ def _build_domains(
             vals = [int(v) for v in ct.enum.values]
         elif ct.interval is not None:
             vals = _interval_to_values(ct.interval, limits)
+        elif ct.real_interval is not None:
+            raise DynamicRefError(
+                f"CellType for {addr!r} uses a real interval (RealBetween); "
+                "integer enum or Between bounds are required to enumerate OFFSET/INDEX arguments."
+            )
         else:
             raise DynamicRefError(
                 f"CellType for {addr!r} has no enum or interval domain (e.g. formula uses "
@@ -2325,11 +2335,6 @@ def _build_domains(
 def _interval_to_values(interval: IntervalDomain, limits: DynamicRefLimits) -> list[int]:
     if interval.min is None or interval.max is None:
         raise DynamicRefError("Unbounded intervals are not supported for dynamic refs")
-    if isinstance(interval.min, float) or isinstance(interval.max, float):
-        raise DynamicRefError(
-            "Float interval domains cannot be enumerated for dynamic refs; "
-            "use an enum domain or integer bounds instead"
-        )
     lo, hi = int(interval.min), int(interval.max)
     if hi < lo:
         raise DynamicRefError(f"Invalid interval domain [{lo}, {hi}]")
@@ -2501,6 +2506,11 @@ def _build_value_domains(
             values = list(ct.enum.values)
         elif ct.interval is not None:
             values = _interval_to_values(ct.interval, limits)
+        elif ct.real_interval is not None:
+            raise DynamicRefError(
+                f"CellType for {addr!r} uses a real interval (RealBetween); "
+                "use Literal / integer Between or an explicit enum for INDIRECT text arguments."
+            )
         else:
             raise DynamicRefError(
                 f"CellType for {addr!r} must have an interval or enum domain for INDIRECT analysis"

--- a/tests/core/test_constraints_mapping.py
+++ b/tests/core/test_constraints_mapping.py
@@ -11,6 +11,8 @@ from excel_grapher.core.cell_types import (
     GreaterThanCell,
     IntervalDomain,
     NotEqualCell,
+    RealBetween,
+    RealIntervalDomain,
     constraints_to_cell_type_env,
 )
 from excel_grapher.grapher.dynamic_refs import DynamicRefLimits, expand_leaf_env_to_argument_env
@@ -59,8 +61,8 @@ class _FloatConstraintsDict(TypedDict, total=False):
     pass
 
 
-_FloatConstraintsDict.__annotations__["Sheet1!E1"] = Annotated[float, Between(0.0, 1.0)]
-_FloatConstraintsDict.__annotations__["Sheet1!F1"] = Annotated[float, Between(-0.5, 0.5)]
+_FloatConstraintsDict.__annotations__["Sheet1!E1"] = Annotated[float, RealBetween(0.0, 1.0)]
+_FloatConstraintsDict.__annotations__["Sheet1!F1"] = Annotated[float, RealBetween(-0.5, 0.5)]
 
 
 def test_constraints_mapping_supports_float_between() -> None:
@@ -76,13 +78,38 @@ def test_constraints_mapping_supports_float_between() -> None:
 
     e1 = env["Sheet1!E1"]
     assert e1.kind is CellKind.NUMBER
-    assert e1.interval == IntervalDomain(min=0.0, max=1.0)
+    assert e1.interval is None
+    assert e1.real_interval == RealIntervalDomain(min=0.0, max=1.0)
     assert e1.enum is None
 
     f1 = env["Sheet1!F1"]
     assert f1.kind is CellKind.NUMBER
-    assert f1.interval == IntervalDomain(min=-0.5, max=0.5)
+    assert f1.interval is None
+    assert f1.real_interval == RealIntervalDomain(min=-0.5, max=0.5)
     assert f1.enum is None
+
+
+class _RealIntervalLeafEnvDict(TypedDict, total=False):
+    pass
+
+
+_RealIntervalLeafEnvDict.__annotations__["Sheet1!B1"] = Annotated[float, RealBetween(0.0, 1.0)]
+
+
+def test_expand_leaf_env_widens_formula_when_dependency_has_real_interval_only() -> None:
+    """Real intervals are not enumerable; type expansion falls back to ANY (issue #40)."""
+    constraints = cast(_RealIntervalLeafEnvDict, {"Sheet1!B1": 0.5})
+    leaf_env = constraints_to_cell_type_env(_RealIntervalLeafEnvDict, constraints)
+    out = expand_leaf_env_to_argument_env(
+        {"Sheet1!A1"},
+        lambda addr: "=Sheet1!B1+1" if addr == "Sheet1!A1" else None,
+        lambda _f, _sh: {"Sheet1!B1"},
+        leaf_env,
+        DynamicRefLimits(),
+    )
+    assert out["Sheet1!A1"].kind is CellKind.ANY
+    assert out["Sheet1!A1"].interval is None
+    assert out["Sheet1!A1"].enum is None
 
 
 class _RelationalConstraintsDict(TypedDict, total=False):

--- a/tests/grapher/test_smoke_api.py
+++ b/tests/grapher/test_smoke_api.py
@@ -18,4 +18,6 @@ def test_public_api_imports() -> None:
     assert eg.FromWorkbook is not None
     assert eg.GreaterThanCell is not None
     assert eg.NotEqualCell is not None
+    assert eg.RealBetween is not None
+    assert eg.RealIntervalDomain is not None
 


### PR DESCRIPTION
Closes #40.

## Summary
- **Between** / **IntervalDomain** are integer-only and remain the enumerable domains for OFFSET/INDEX/INDIRECT branching and `expand_leaf_env_to_argument_env` fallback enumeration.
- **RealBetween** / **RealIntervalDomain** hold real-valued bounds for float-typed inputs; they are not enumerated. When numeric abstract analysis falls back to enumeration and a dependency only has a real interval, the expanded type widens to `CellKind.ANY` instead of raising.
- OFFSET/INDEX and INDIRECT now raise explicit errors if a cell is only constrained with a real interval where integer enumeration is required.
- **example/map_lic_dsf_indicators.py** uses `RealBetween` for float annotations.
- **RealBetween** and **RealIntervalDomain** are re-exported from `excel_grapher` and `excel_grapher.grapher` (same pattern as `GreaterThanCell`).

## Tests
- Constraints mapping and new widen test; smoke API asserts new exports.
- Full suite: `uv run pytest`.

Made with [Cursor](https://cursor.com)