### PR TITLE
Handle cycles in expand_leaf_env_to_argument_env (issue #54)

### DIFF
--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -326,9 +326,7 @@ def expand_leaf_env_to_argument_env(
         if addr in cache:
             return cache[addr]
         if addr in in_progress:
-            raise DynamicRefError(
-                f"Cycle detected while inferring argument-cell types for {addr!r}"
-            )
+            return CellType(kind=CellKind.ANY)
         ct_resolved = _lookup_cell_type(leaf_env, addr)
         if ct_resolved is not None:
             cache[addr] = ct_resolved

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -27,6 +27,7 @@ from excel_grapher.grapher.dynamic_refs import (
     DynamicRefLimits,
     FromWorkbook,
     constrain,
+    expand_leaf_env_to_argument_env,
     infer_dynamic_index_targets,
     infer_dynamic_indirect_targets,
     infer_dynamic_offset_targets,
@@ -512,6 +513,39 @@ def test_create_dependency_graph_raises_when_leaf_missing_constraint(tmp_path: P
     assert "leaf" in str(exc_info.value).lower()
 
 
+def test_expand_leaf_env_mutual_formula_refs_in_argument_subgraph_issue_54() -> None:
+    """Issue #54: mutual formula refs in the argument chain must not abort type expansion.
+
+    Mirrors LIC-style patterns (e.g. aggregate cell referenced by scaled rows that also
+    feed formulas pointing back). The cycle edge is approximated as ``ANY`` so graph build
+    can continue.
+    """
+    leaf_env = _make_env({})
+    f_a1 = "=Sheet1!B1+1"
+    f_b1 = "=Sheet1!A1+1"
+
+    def _get_cell_formula(addr: str) -> str | None:
+        if addr == "Sheet1!A1":
+            return f_a1
+        if addr == "Sheet1!B1":
+            return f_b1
+        return None
+
+    def _get_refs_from_formula(formula: str, sheet: str) -> set[str]:
+        assert sheet == "Sheet1"
+        return {f_a1: {"Sheet1!B1"}, f_b1: {"Sheet1!A1"}}[formula]
+
+    env = expand_leaf_env_to_argument_env(
+        {"Sheet1!A1"},
+        _get_cell_formula,
+        _get_refs_from_formula,
+        leaf_env,
+        DynamicRefLimits(),
+    )
+    assert env["Sheet1!A1"].kind is CellKind.ANY
+    assert env["Sheet1!B1"].kind is CellKind.ANY
+
+
 def test_expand_leaf_env_assigns_any_when_intermediate_unsupported() -> None:
     """Intermediates that cannot be inferred (e.g. unsupported function) get CellKind.ANY.
 
@@ -519,12 +553,6 @@ def test_expand_leaf_env_assigns_any_when_intermediate_unsupported() -> None:
     intermediate's formula cannot be evaluated (e.g. uses VLOOKUP), we assign ANY
     so expansion succeeds; enumeration may later require a constraint for that cell.
     """
-    from excel_grapher.core.cell_types import CellKind
-    from excel_grapher.grapher.dynamic_refs import (
-        DynamicRefLimits,
-        expand_leaf_env_to_argument_env,
-    )
-
     leaf_env = _make_env(
         {
             "Sheet1!A1": CellType(
@@ -1141,7 +1169,9 @@ def test_expand_leaf_env_comparison_infers_zero_one_domain() -> None:
     assert out.enum.values == frozenset({0, 1})
 
 
-def test_expand_leaf_env_cycle_detection_is_stable() -> None:
+def test_expand_leaf_env_mutual_refs_terminates_with_any() -> None:
+    """Mutual formula-only refs: cycle edge is ANY; expansion finishes (issue #54)."""
+
     def _get_cell_formula(addr: str) -> str | None:
         if addr == "Sheet1!B1":
             return "=Sheet1!C1"
@@ -1157,16 +1187,15 @@ def test_expand_leaf_env_cycle_detection_is_stable() -> None:
             return {"Sheet1!B1"}
         return set()
 
-    with pytest.raises(DynamicRefError) as exc_info:
-        dynamic_refs_mod.expand_leaf_env_to_argument_env(
-            {"Sheet1!B1"},
-            _get_cell_formula,
-            _get_refs_from_formula,
-            _make_env({}),
-            DynamicRefLimits(max_depth=4),
-        )
-
-    assert "cycle" in str(exc_info.value).lower()
+    env = dynamic_refs_mod.expand_leaf_env_to_argument_env(
+        {"Sheet1!B1"},
+        _get_cell_formula,
+        _get_refs_from_formula,
+        _make_env({}),
+        DynamicRefLimits(max_depth=4),
+    )
+    assert env["Sheet1!B1"].kind is CellKind.ANY
+    assert env["Sheet1!C1"].kind is CellKind.ANY
 
 
 def test_expand_leaf_env_long_formula_chain_is_not_limited_by_expr_max_depth() -> None:


### PR DESCRIPTION
## Summary

Real workbooks can form mutual references in the OFFSET/INDIRECT argument subgraph without Excel circular-reference errors. The previous `cell_type_for` DFS treated a revisit of an address still in `in_progress` as a hard error.

This change returns `CellType(kind=CellKind.ANY)` for that back edge, consistent with other conservative fallbacks when domains cannot be narrowed. Graph construction can proceed; enumeration may still need tighter leaf constraints where precision matters.

## Tests

- New regression: mutual `A1`/`B1` formula refs (issue #54 scenario).
- Renamed and updated the former `cycle_detection_is_stable` test to assert termination with `ANY` instead of an exception.

Closes #54.

Made with [Cursor](https://cursor.com)