### PR TITLE
feat: implement VLOOKUP (#58)

### DIFF
--- a/example/map_lic_dsf_indicators.py
+++ b/example/map_lic_dsf_indicators.py
@@ -150,7 +150,7 @@ Then re-run until the graph builds. Note that if row/column labels or intentiona
 
 The goal is to set sensible constraints that reflect the range of sane values we will allow for the cells. To determine the plausible range of input values, investigate the cells by using enrichment_audit.json (or the heuristic label-scanning tools in src/lic_dsf_labels.py) to see their labels, and fastpyxl to check their current values. In addition to the empty template workbook, workbooks/lic-dsf-template-2025-08-12.xlsm, we also have one filled out with illustrative data: workbooks/dsf-uga.xlsm.
 
-When the template workbook is present, ``check_constraints`` scans constrained cells on sheets that are expected to hold values (not PV/COM/DMX calculation sheets) and raises if any of those cells contain an Excel formula, aside from the documented VLOOKUP exception on START!L10.
+When the template workbook is present, ``check_constraints`` scans constrained cells on sheets that are expected to hold values (not PV/COM/DMX calculation sheets) and raises if any of those cells contain an Excel formula.
 """
 
 LiteralType = cast(Any, Literal)
@@ -188,12 +188,12 @@ for _start, _end in [(918, 939), (942, 963), (966, 987)]:
         LicDsfConstraints.__annotations__[f"PV_Base!A{_row}"] = LiteralType[_letter]
 
 # Language selector and lookup table (feed INDIRECT/VLOOKUP for language-dependent refs).
-# START!L10 = VLOOKUP(K10, lookup!BB4:BC7, 2); evaluator does not support VLOOKUP, so L10 is constrained too.
+# START!L10 = VLOOKUP(K10, lookup!BB4:BC7, 2); evaluated directly by the evaluator.
+# START!K10 is an input (language selection); lookup!BB4:BC7 is constrained because it feeds INDIRECT.
 _LANG = Literal["English", "French", "Portuguese", "Spanish"]
 _LANG_LOOKUP = Literal[
     "English", "French", "Portuguese", "Spanish", "Français", "Portugues", "Español"
 ]
-constrain(LicDsfConstraints, "START!L10", _LANG)
 constrain(LicDsfConstraints, "START!K10", _LANG)
 constrain(LicDsfConstraints, "lookup!BB4:BC7", _LANG_LOOKUP)
 
@@ -1463,11 +1463,6 @@ _SHEETS_EXCLUDED_FROM_FORMULA_CONSTRAINT_CHECK: frozenset[str] = frozenset(
         "PV_baseline_com",
         "PV_stress_com",
     }
-)
-
-# START!L10 = VLOOKUP(...); constrained because the evaluator does not implement VLOOKUP.
-_FORMULA_OK_DYNAMIC_REF_CONSTRAINT_KEYS: frozenset[str] = frozenset(
-    {format_key("START", "L10")}
 )
 
 

--- a/excel_grapher/evaluator/functions/lookup.py
+++ b/excel_grapher/evaluator/functions/lookup.py
@@ -6,6 +6,9 @@ from ..export_runtime.lookup import (
     xl__xlfn_xlookup as _rt_xl__xlfn_xlookup,
 )
 from ..export_runtime.lookup import (
+    xl_hlookup as _rt_xl_hlookup,
+)
+from ..export_runtime.lookup import (
     xl_index as _rt_xl_index,
 )
 from ..export_runtime.lookup import (
@@ -14,7 +17,9 @@ from ..export_runtime.lookup import (
 from ..export_runtime.lookup import (
     xl_match as _rt_xl_match,
 )
-from ..helpers import excel_casefold, to_native, to_number
+from ..export_runtime.lookup import (
+    xl_vlookup as _rt_xl_vlookup,
+)
 from ..types import CellValue, XlError
 from . import register
 
@@ -37,43 +42,6 @@ def xl_match(
     return _rt_xl_match(lookup_value, lookup_array, match_type)
 
 
-def _values_match(a: CellValue, b: CellValue) -> bool:
-    """Check if two values match (case-insensitive for strings)."""
-    if isinstance(a, str) and isinstance(b, str):
-        return excel_casefold(a) == excel_casefold(b)
-    # For numbers, compare numerically
-    an = to_number(a)
-    bn = to_number(b)
-    if not isinstance(an, XlError) and not isinstance(bn, XlError):
-        return an == bn
-    # Fallback to direct comparison
-    return a == b
-
-
-def _compare_values(a: CellValue, b: CellValue) -> int:
-    """Compare two values. Returns <0 if a<b, 0 if a==b, >0 if a>b."""
-    # For numbers, compare numerically
-    an = to_number(a)
-    bn = to_number(b)
-    if not isinstance(an, XlError) and not isinstance(bn, XlError):
-        if an < bn:
-            return -1
-        if an > bn:
-            return 1
-        return 0
-    # For strings, compare case-insensitively
-    if isinstance(a, str) and isinstance(b, str):
-        af = excel_casefold(a)
-        bf = excel_casefold(b)
-        if af < bf:
-            return -1
-        if af > bf:
-            return 1
-        return 0
-    # Mixed types - numbers < strings
-    return 0
-
-
 @register("LOOKUP")
 def xl_lookup(
     lookup_value: CellValue,
@@ -91,42 +59,7 @@ def xl_vlookup(
     range_lookup: CellValue = True,
 ) -> CellValue:
     """Search for a value in the first column and return a value in the same row from another column."""
-    # Convert col_index_num
-    cn = to_number(col_index_num)
-    if isinstance(cn, XlError):
-        return cn
-    col_index = int(cn)
-
-    if col_index < 1:
-        return XlError.VALUE
-
-    rows, cols = table_array.shape
-    if col_index > cols:
-        return XlError.REF
-
-    # Determine match type
-    exact_match = not range_lookup
-
-    # Search first column
-    first_col = table_array[:, 0]
-
-    if exact_match:
-        # Exact match
-        for i, val in enumerate(first_col):
-            if _values_match(lookup_value, val):
-                return to_native(table_array[i, col_index - 1])
-        return XlError.NA
-    else:
-        # Approximate match - find largest value <= lookup_value
-        last_match_idx = None
-        for i, val in enumerate(first_col):
-            if _compare_values(val, lookup_value) <= 0:
-                last_match_idx = i
-            else:
-                break
-        if last_match_idx is None:
-            return XlError.NA
-        return to_native(table_array[last_match_idx, col_index - 1])
+    return _rt_xl_vlookup(lookup_value, table_array, col_index_num, range_lookup)
 
 
 @register("HLOOKUP")
@@ -137,42 +70,7 @@ def xl_hlookup(
     range_lookup: CellValue = True,
 ) -> CellValue:
     """Search for a value in the first row and return a value in the same column from another row."""
-    # Convert row_index_num
-    rn = to_number(row_index_num)
-    if isinstance(rn, XlError):
-        return rn
-    row_index = int(rn)
-
-    if row_index < 1:
-        return XlError.VALUE
-
-    rows, cols = table_array.shape
-    if row_index > rows:
-        return XlError.REF
-
-    # Determine match type
-    exact_match = not range_lookup
-
-    # Search first row
-    first_row = table_array[0, :]
-
-    if exact_match:
-        # Exact match
-        for i, val in enumerate(first_row):
-            if _values_match(lookup_value, val):
-                return to_native(table_array[row_index - 1, i])
-        return XlError.NA
-    else:
-        # Approximate match - find largest value <= lookup_value
-        last_match_idx = None
-        for i, val in enumerate(first_row):
-            if _compare_values(val, lookup_value) <= 0:
-                last_match_idx = i
-            else:
-                break
-        if last_match_idx is None:
-            return XlError.NA
-        return to_native(table_array[row_index - 1, last_match_idx])
+    return _rt_xl_hlookup(lookup_value, table_array, row_index_num, range_lookup)
 
 
 @register("_XLFN.XLOOKUP")

--- a/tests/evaluator/test_lookup_parity.py
+++ b/tests/evaluator/test_lookup_parity.py
@@ -30,6 +30,50 @@ def _make_graph(*nodes: Node) -> DependencyGraph:
     return graph
 
 
+def test_vlookup_parity_exact_and_approximate() -> None:
+    graph = _make_graph(
+        # Table: A1:B5
+        _make_node("S!A1", None, 10),
+        _make_node("S!A2", None, 20),
+        _make_node("S!A3", None, 30),
+        _make_node("S!A4", None, 40),
+        _make_node("S!A5", None, 50),
+        _make_node("S!B1", None, "ten"),
+        _make_node("S!B2", None, "twenty"),
+        _make_node("S!B3", None, "thirty"),
+        _make_node("S!B4", None, "forty"),
+        _make_node("S!B5", None, "fifty"),
+        # Exact match
+        _make_node("S!C1", "=VLOOKUP(20, S!A1:B5, 2, FALSE)", None),
+        _make_node("S!C2", "=VLOOKUP(25, S!A1:B5, 2, FALSE)", None),
+        # Approximate match (range_lookup=TRUE)
+        _make_node("S!C3", "=VLOOKUP(25, S!A1:B5, 2, TRUE)", None),
+        _make_node("S!C4", "=VLOOKUP(5, S!A1:B5, 2, TRUE)", None),
+        _make_node("S!C5", "=VLOOKUP(100, S!A1:B5, 2, TRUE)", None),
+        # Return column 1
+        _make_node("S!C6", "=VLOOKUP(30, S!A1:B5, 1, FALSE)", None),
+        # Case-insensitive string lookup
+        _make_node("S!D1", None, "Alpha"),
+        _make_node("S!D2", None, "Beta"),
+        _make_node("S!D3", None, "Gamma"),
+        _make_node("S!E1", None, 1),
+        _make_node("S!E2", None, 2),
+        _make_node("S!E3", None, 3),
+        _make_node("S!F1", "=VLOOKUP(\"alpha\", S!D1:E3, 2, FALSE)", None),
+    )
+
+    result = assert_codegen_matches_evaluator(
+        graph, ["S!C1", "S!C2", "S!C3", "S!C4", "S!C5", "S!C6", "S!F1"]
+    )
+    assert result.generated_results["S!C1"] == "twenty"
+    assert result.generated_results["S!C2"] == XlError.NA
+    assert result.generated_results["S!C3"] == "twenty"
+    assert result.generated_results["S!C4"] == XlError.NA
+    assert result.generated_results["S!C5"] == "fifty"
+    assert result.generated_results["S!C6"] == 30
+    assert result.generated_results["S!F1"] == 1
+
+
 def test_lookup_parity_vector_and_array_forms() -> None:
     graph = _make_graph(
         _make_node("S!A1", None, 1),


### PR DESCRIPTION
## Summary

- Refactors `xl_vlookup` and `xl_hlookup` in `evaluator/functions/lookup.py` to delegate to their `export_runtime` counterparts, matching the pattern used by `INDEX`, `MATCH`, `LOOKUP`, and `XLOOKUP`; removes the duplicate inline implementations and local `_values_match`/`_compare_values` helpers
- Adds `test_vlookup_parity_exact_and_approximate` covering exact match, approximate match, boundary conditions, and case-insensitive string lookup (evaluator vs codegen parity)
- Removes the constraint on formula cell `START!L10` in the example — `VLOOKUP` is now evaluated directly; removes the dead `_FORMULA_OK_DYNAMIC_REF_CONSTRAINT_KEYS` frozenset and updates stale comments

Closes #58

## Test plan

- [x] `uv run pytest tests/evaluator/test_lookup_parity.py::test_vlookup_parity_exact_and_approximate` — new parity test passes
- [x] `uv run pytest tests/` — all 534 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)