### PR TITLE
fix: guard fallback product-enumeration against combinatorial explosion

### DIFF
--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import re
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
@@ -78,6 +79,35 @@ def constrain(constraints: type[Any], address: str, annotation: Any) -> None:
 
 @dataclass(frozen=True)
 class DynamicRefLimits:
+    """Tuneable safety limits for dynamic-reference inference.
+
+    Pass a custom instance via the ``limits`` parameter of
+    :meth:`DynamicRefConfig.from_constraints`,
+    :meth:`DynamicRefConfig.from_constraints_and_workbook`, or
+    :meth:`DynamicRefConfig.from_workbook` to override any of these defaults.
+
+    Attributes:
+        max_branches: Maximum number of discrete value assignments explored
+            during constraint enumeration.  This cap is applied in two places:
+
+            * **Per-dependency domain size** – a single cell constrained to an
+              integer interval wider than *max_branches* values cannot be
+              enumerated; the caller must either tighten the constraint or rely
+              on the symbolic (abstract) analysis path.
+            * **Cartesian-product size** – when a formula cell falls back to
+              brute-force evaluation over all combinations of its dependencies'
+              domains, the product of those domain sizes must not exceed
+              *max_branches*.  If it does, a :class:`DynamicRefError` is raised
+              immediately (rather than hanging) with a breakdown of which
+              dependencies contributed to the explosion.  Raise this limit or
+              tighten the offending constraints to resolve the error.
+
+            Default: ``1024``.
+        max_cells: Maximum number of cells collected when expanding a range
+            reference.  Default: ``10_000``.
+        max_depth: Maximum AST-evaluation recursion depth.  Default: ``10``.
+    """
+
     max_branches: int = 1024
     max_cells: int = 10_000
     max_depth: int = 10
@@ -449,6 +479,23 @@ def expand_leaf_env_to_argument_env(
                 else:
                     cache[addr] = CellType(kind=CellKind.ANY)
                     return cache[addr]
+            total_branches = math.prod(len(v) for v in domains.values())
+            if total_branches > limits.max_branches:
+                dep_sizes = ", ".join(
+                    f"{r!r}: {len(domains[r])}" for r in sorted(domains)
+                )
+                unsupported_hint = (
+                    f" First unsupported construct: {unsupported}."
+                    if unsupported is not None
+                    else ""
+                )
+                raise DynamicRefError(
+                    f"Formula cell {addr!r} fallback enumeration would require "
+                    f"{total_branches} branches (limit {limits.max_branches}). "
+                    f"Dependency domain sizes: {dep_sizes}.{unsupported_hint} "
+                    f"Tighten constraints on one or more dependencies, simplify "
+                    f"the formula, or extend numeric abstract analysis to cover it."
+                )
             result_values: set[Any] = set()
             last_unsupported: Unsupported | None = None
             for assignment in product(*(domains[r] for r in refs)):

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -1667,6 +1667,45 @@ def test_expand_leaf_env_percent_expression_stays_in_abstract_path() -> None:
     assert out.enum.values == frozenset({0, 1})
 
 
+def test_expand_leaf_env_cartesian_product_branch_limit_error() -> None:
+    """Fallback product-enumeration raises DynamicRefError when the Cartesian
+    product of dependency domains exceeds max_branches, instead of hanging."""
+    # 5 * 5 = 25 combinations, which exceeds max_branches=8.
+    leaf_env = _make_env(
+        {
+            "Sheet1!A1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({1, 2, 3, 4, 5})),
+            ),
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({10, 20, 30, 40, 50})),
+            ),
+        }
+    )
+
+    def _get_cell_formula(addr: str) -> str | None:
+        # ROUND is not handled by numeric abstract analysis, forcing the fallback path.
+        return "=ROUND(Sheet1!A1+Sheet1!B1,0)" if addr == "Sheet1!C1" else None
+
+    def _get_refs_from_formula(formula: str, sheet: str) -> set[str]:
+        return {"Sheet1!A1", "Sheet1!B1"}
+
+    with pytest.raises(DynamicRefError) as exc_info:
+        dynamic_refs_mod.expand_leaf_env_to_argument_env(
+            {"Sheet1!C1"},
+            _get_cell_formula,
+            _get_refs_from_formula,
+            leaf_env,
+            DynamicRefLimits(max_branches=8),
+        )
+
+    msg = str(exc_info.value)
+    assert "Sheet1!C1" in msg  # names the formula cell
+    assert "25" in msg          # actual product size
+    assert "8" in msg           # the limit
+
+
 def test_infer_numeric_domain_parity_never_raises() -> None:
     limits = DynamicRefLimits(max_branches=64, max_depth=12)
     env: CellTypeEnv = {


### PR DESCRIPTION
## Summary

- Adds a pre-flight check before the `product()` loop in `expand_leaf_env_to_argument_env`: if the Cartesian product of all dependency domains exceeds `limits.max_branches`, raise `DynamicRefError` immediately instead of iterating for an effectively unbounded time
- Error message includes the total branch count, per-dependency domain sizes, and the first unsupported construct (if symbolic analysis fell through because of it) — enough info to debug both bad user constraints and gaps in excel-grapher's abstract analysis
- Adds a docstring to `DynamicRefLimits` documenting all three fields and explaining both enforcement points for `max_branches` (per-dependency domain size and Cartesian-product size), including how to pass a custom instance to override the defaults

## Test plan

- [x] `test_expand_leaf_env_cartesian_product_branch_limit_error` — two 5-value enum deps, `max_branches=8`, formula using `ROUND` (unsupported by symbolic path); confirms error is raised and message contains cell address, product size, and limit
- [x] Full `tests/grapher/test_dynamic_refs.py` suite (76 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)