### PR TITLE
fix: add per-call OFFSET fan-out guard (#65)

### DIFF
--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -853,6 +853,11 @@ def _infer_single_offset_call(
                             )
                             if isinstance(result, ExcelRange):
                                 targets |= set(result.cell_addresses())
+                                if len(targets) > limits.max_cells:
+                                    raise DynamicRefError(
+                                        f"Dynamic ref cells from single OFFSET call exceed limit "
+                                        f"({len(targets)} > {limits.max_cells})"
+                                    )
         return targets
 
     leaf_addrs: set[str] = set()
@@ -909,6 +914,11 @@ def _infer_single_offset_call(
             )
             if isinstance(result, ExcelRange):
                 targets |= set(result.cell_addresses())
+                if len(targets) > limits.max_cells:
+                    raise DynamicRefError(
+                        f"Dynamic ref cells from single OFFSET call exceed limit "
+                        f"({len(targets)} > {limits.max_cells})"
+                    )
 
     return targets
 

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -1818,3 +1818,28 @@ def test_index_respects_max_cells_limit() -> None:
             limits=DynamicRefLimits(max_cells=2),
         )
     assert "cells exceed limit" in str(exc_info.value).lower()
+
+
+def test_offset_per_call_max_cells_limit() -> None:
+    """A single OFFSET call that fans out to more cells than max_cells must raise
+    DynamicRefError immediately, not accumulate an unbounded result set."""
+    # OFFSET(Sheet1!A1, 0, Sheet1!B1, 1, 1) where B1 ∈ {0,1,2,3,4} → 5 distinct
+    # target cells.  With max_cells=3 the check should fire.
+    formula = "=OFFSET(Sheet1!A1,0,Sheet1!B1,1,1)"
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.NUMBER,
+                enum=EnumDomain(values=frozenset({0, 1, 2, 3, 4})),
+            )
+        }
+    )
+    with pytest.raises(DynamicRefError) as exc_info:
+        infer_dynamic_offset_targets(
+            formula,
+            current_sheet="Sheet1",
+            cell_type_env=env,
+            limits=DynamicRefLimits(max_cells=3),
+        )
+    assert "cells" in str(exc_info.value).lower()
+    assert "exceed limit" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary

- Adds a `max_cells` check inside `_infer_single_offset_call` for both the fast path (direct domain enumeration) and the fallback Cartesian product path
- A single OFFSET call that expands to more than `DynamicRefLimits.max_cells` targets now raises `DynamicRefError` immediately, rather than accumulating without bound
- The existing cumulative check in `infer_dynamic_offset_targets` remains as a second layer

## Background

Issue #65 identified that a single OFFSET call with a wide enum domain on its col/row argument could fan out to thousands of targets. The previous guard only fired cumulatively across all OFFSET calls in a formula, so one call alone could exceed limits undetected until after expansion.

This fix is consistent with the per-call branch-count guard added in #66: same file, same `DynamicRefLimits` knob, same `DynamicRefError` pattern.

## Test plan

- [ ] `test_offset_per_call_max_cells_limit` — formula `=OFFSET(Sheet1!A1,0,Sheet1!B1,1,1)` with `B1 ∈ {0,1,2,3,4}` (5 targets) and `max_cells=3` raises `DynamicRefError` with message containing "cells" and "exceed limit"
- [x] Full test suite passes (`uv run pytest` — 539 tests)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)