### PR TITLE
perf: avoid duplicating dynamic-ref work when capture_dependency_provenance=True (fixes #61)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+Use the `gh` CLI tool to manage issues and pull requests.
+
+Always run Python code with `uv run`. Use `uv add` to add dependencies or `uvx` to use uninstalled Python command line tools.
+
+Always practice test-driven development. Write a stub (if necessary), write a test, watch it fail for the right reason (RED), write the code to make it pass (GREEN), and then refactor to clean up the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-Use the `gh` CLI tool to manage issues and pull requests.
-
-Always run Python code with `uv run`. Use `uv add` to add dependencies or `uvx` to use uninstalled Python command line tools.
-
-Always practice test-driven development. Write a stub (if necessary), write a test, watch it fail for the right reason (RED), write the code to make it pass (GREEN), and then refactor to clean up the code.
+@AGENTS.md

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -182,6 +182,14 @@ def create_dependency_graph(
     :class:`~excel_grapher.grapher.dependency_provenance.EdgeProvenance` under the
     ``\"provenance\"`` key in :meth:`DependencyGraph.edge_attrs` (how the dependency
     arises: direct reference, static range, dynamic OFFSET/INDIRECT).
+
+    **Cost model**: constraint-based dynamic-ref expansion (``dynamic_refs`` set,
+    ``use_cached_dynamic_refs=False``) runs :func:`expand_leaf_env_to_argument_env`
+    once per formula regardless of ``capture_dependency_provenance``.  A shared
+    per-graph cache ensures provenance collection reuses the already-computed
+    expansion instead of repeating it.  Callers doing iterative constraint-tuning
+    workflows can still set ``capture_dependency_provenance=False`` to avoid any
+    provenance overhead (formula-string span collection, branch-union merging, etc.).
     """
 
     def load_wb(data_only: bool) -> fastpyxl.Workbook:
@@ -210,6 +218,10 @@ def create_dependency_graph(
     named_range_ranges = named_range_maps.range_map
     normalizer = FormulaNormalizer(named_ranges, named_range_ranges)
     defined_names: set[str] = {str(name) for name in wb_formulas.defined_names}
+    # Per-graph cache: (normalized_formula, current_sheet, current_a1) → (offset_targets, indirect_targets, index_targets).
+    # Populated by extract_expr_deps (constraint path); consumed by collect_provenance_for_formula
+    # to avoid re-running the expensive expand_leaf_env_to_argument_env call.
+    _dyn_cache: dict[tuple[str, str, str], tuple[set[str], set[str], set[str]]] = {}
     _NAME_TOKEN_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\b(?!\s*!)")
 
     def resolve_cached_value(sheet: str, a1: str) -> object | None:
@@ -348,131 +360,139 @@ def create_dependency_graph(
                                     deps.append((sh, a1))
                                     if is_variable:
                                         argument_addrs.add(format_key(sh, a1))
+                    if calls:
+                        def _refs_in_formula_without_dynamic(formula_str: str, sheet_of_cell: str) -> set[str]:
+                            dyn = _find_function_calls_with_spans(
+                                formula_str if formula_str.startswith("=") else "=" + formula_str,
+                                {"OFFSET", "INDIRECT", "INDEX"},
+                            )
+                            spans = [span for _fn, _inner, span in dyn]
+                            masked = mask_spans(
+                                formula_str if formula_str.startswith("=") else "=" + formula_str,
+                                spans,
+                            )
+                            norm = normalizer.normalize(masked, sheet_of_cell)
+                            out: set[str] = set()
+                            for ref in parse_cell_refs(norm):
+                                sh = ref.sheet if ref.sheet is not None else sheet_of_cell
+                                out.add(format_key(sh, f"{ref.column}{ref.row}"))
+                            for start, end, _span in parse_range_refs_with_spans(norm):
+                                sh = start.sheet if start.sheet is not None else sheet_of_cell
+                                for dep_sheet, dep_a1 in expand_range(
+                                    sheet=sh,
+                                    start_col=start.column,
+                                    start_row=start.row,
+                                    end_col=end.column,
+                                    end_row=end.row,
+                                    max_cells=max_range_cells,
+                                ):
+                                    out.add(format_key(dep_sheet, dep_a1))
+                            return out
 
-                    def _refs_in_formula_without_dynamic(formula_str: str, sheet_of_cell: str) -> set[str]:
-                        dyn = _find_function_calls_with_spans(
-                            formula_str if formula_str.startswith("=") else "=" + formula_str,
-                            {"OFFSET", "INDIRECT", "INDEX"},
+                        all_refs: set[str] = set()
+                        to_visit = set(argument_addrs)
+                        while to_visit:
+                            addr = to_visit.pop()
+                            if addr in all_refs:
+                                continue
+                            all_refs.add(addr)
+                            sh, a1 = _parse_address_to_sheet_a1(addr)
+                            if sh not in wb_formulas.sheetnames:
+                                continue
+                            cell_val = wb_formulas[sh][a1].value
+                            if isinstance(cell_val, str) and cell_val.startswith("="):
+                                to_visit.update(_refs_in_formula_without_dynamic(cell_val, sh))
+                        leaves = set()
+                        for addr in all_refs:
+                            sh, a1 = _parse_address_to_sheet_a1(addr)
+                            if sh not in wb_formulas.sheetnames:
+                                continue
+                            cell_val = wb_formulas[sh][a1].value
+                            if not (isinstance(cell_val, str) and cell_val.startswith("=")):
+                                leaves.add(addr)
+                        missing_leaves = leaves_missing_cell_type_constraints(
+                            leaves, dynamic_refs.cell_type_env
                         )
-                        spans = [span for _fn, _inner, span in dyn]
-                        masked = mask_spans(
-                            formula_str if formula_str.startswith("=") else "=" + formula_str,
-                            spans,
+                        if missing_leaves:
+                            cell_key = format_key(current_sheet, current_a1)
+                            formatted_missing = _format_missing_leaves(missing_leaves)
+                            raise DynamicRefError(
+                                f"Formula at {cell_key} contains OFFSET, INDIRECT, or INDEX; the following leaf "
+                                f"cells that feed them have no constraint: {formatted_missing}. "
+                                "Add constraints only for leaf (non-formula) cells."
+                            )
+                        formula_for_infer = normalizer.normalize(
+                            f if f.startswith("=") else "=" + f,
+                            current_sheet,
                         )
-                        norm = normalizer.normalize(masked, sheet_of_cell)
-                        out: set[str] = set()
-                        for ref in parse_cell_refs(norm):
-                            sh = ref.sheet if ref.sheet is not None else sheet_of_cell
-                            out.add(format_key(sh, f"{ref.column}{ref.row}"))
-                        for start, end, _span in parse_range_refs_with_spans(norm):
-                            sh = start.sheet if start.sheet is not None else sheet_of_cell
-                            for dep_sheet, dep_a1 in expand_range(
-                                sheet=sh,
-                                start_col=start.column,
-                                start_row=start.row,
-                                end_col=end.column,
-                                end_row=end.row,
-                                max_cells=max_range_cells,
-                            ):
-                                out.add(format_key(dep_sheet, dep_a1))
-                        return out
-
-                    all_refs: set[str] = set()
-                    to_visit = set(argument_addrs)
-                    while to_visit:
-                        addr = to_visit.pop()
-                        if addr in all_refs:
-                            continue
-                        all_refs.add(addr)
-                        sh, a1 = _parse_address_to_sheet_a1(addr)
-                        if sh not in wb_formulas.sheetnames:
-                            continue
-                        cell_val = wb_formulas[sh][a1].value
-                        if isinstance(cell_val, str) and cell_val.startswith("="):
-                            to_visit.update(_refs_in_formula_without_dynamic(cell_val, sh))
-                    leaves = set()
-                    for addr in all_refs:
-                        sh, a1 = _parse_address_to_sheet_a1(addr)
-                        if sh not in wb_formulas.sheetnames:
-                            continue
-                        cell_val = wb_formulas[sh][a1].value
-                        if not (isinstance(cell_val, str) and cell_val.startswith("=")):
-                            leaves.add(addr)
-                    missing_leaves = leaves_missing_cell_type_constraints(
-                        leaves, dynamic_refs.cell_type_env
-                    )
-                    if missing_leaves:
-                        cell_key = format_key(current_sheet, current_a1)
-                        formatted_missing = _format_missing_leaves(missing_leaves)
-                        raise DynamicRefError(
-                            f"Formula at {cell_key} contains OFFSET, INDIRECT, or INDEX; the following leaf "
-                            f"cells that feed them have no constraint: {formatted_missing}. "
-                            "Add constraints only for leaf (non-formula) cells."
+                        _col_letter, _current_row = fastpyxl.utils.cell.coordinate_from_string(
+                            current_a1
                         )
-                    def _get_cell_formula(addr: str) -> str | None:
-                        sh, a1 = _parse_address_to_sheet_a1(addr)
-                        if sh not in wb_formulas.sheetnames:
-                            return None
-                        v = wb_formulas[sh][a1].value
-                        if not isinstance(v, str) or not v.startswith("="):
-                            return None
-                        return normalizer.normalize(v, sh)
-                    expanded_env = expand_leaf_env_to_argument_env(
-                        all_refs,
-                        _get_cell_formula,
-                        _refs_in_formula_without_dynamic,
-                        dynamic_refs.cell_type_env,
-                        dynamic_refs.limits,
-                        named_ranges=named_ranges,
-                        named_range_ranges=named_range_ranges,
-                        max_range_cells=max_range_cells,
-                    )
-                    formula_for_infer = normalizer.normalize(f, current_sheet)
-                    _col_letter, _current_row = fastpyxl.utils.cell.coordinate_from_string(
-                        current_a1
-                    )
-                    _current_col = fastpyxl.utils.cell.column_index_from_string(_col_letter)
-                    try:
-                        offset_targets = infer_dynamic_offset_targets(
-                            formula_for_infer,
-                            current_sheet=current_sheet,
-                            cell_type_env=expanded_env,
-                            limits=dynamic_refs.limits,
-                            bounds=bounds,
-                            named_ranges=named_ranges,
-                            named_range_ranges=named_range_ranges,
-                            current_row=_current_row,
-                            current_col=_current_col,
-                        )
-                        indirect_targets = infer_dynamic_indirect_targets(
-                            formula_for_infer,
-                            current_sheet=current_sheet,
-                            cell_type_env=expanded_env,
-                            limits=dynamic_refs.limits,
-                            bounds=bounds,
-                            named_ranges=named_ranges,
-                            named_range_ranges=named_range_ranges,
-                        )
-                        index_targets = infer_dynamic_index_targets(
-                            formula_for_infer,
-                            current_sheet=current_sheet,
-                            cell_type_env=expanded_env,
-                            limits=dynamic_refs.limits,
-                            bounds=bounds,
-                            named_ranges=named_ranges,
-                            named_range_ranges=named_range_ranges,
-                            current_row=_current_row,
-                            current_col=_current_col,
-                        )
-                    except DynamicRefError as exc:
-                        cell_key = format_key(current_sheet, current_a1)
-                        raise DynamicRefError(
-                            f"{exc} (while analyzing dynamic OFFSET/INDIRECT/INDEX for {cell_key}; "
-                            f"normalized formula {formula_for_infer!r})"
-                        ) from exc
-                    for addr in offset_targets | indirect_targets | index_targets:
-                        sh, a1 = _parse_address_to_sheet_a1(addr)
-                        deps.append((sh, a1))
+                        _current_col = fastpyxl.utils.cell.column_index_from_string(_col_letter)
+                        _cache_key = (formula_for_infer, current_sheet, current_a1)
+                        if _cache_key in _dyn_cache:
+                            offset_targets, indirect_targets, index_targets = _dyn_cache[_cache_key]
+                        else:
+                            def _get_cell_formula(addr: str) -> str | None:
+                                sh, a1 = _parse_address_to_sheet_a1(addr)
+                                if sh not in wb_formulas.sheetnames:
+                                    return None
+                                v = wb_formulas[sh][a1].value
+                                if not isinstance(v, str) or not v.startswith("="):
+                                    return None
+                                return normalizer.normalize(v, sh)
+                            expanded_env = expand_leaf_env_to_argument_env(
+                                all_refs,
+                                _get_cell_formula,
+                                _refs_in_formula_without_dynamic,
+                                dynamic_refs.cell_type_env,
+                                dynamic_refs.limits,
+                                named_ranges=named_ranges,
+                                named_range_ranges=named_range_ranges,
+                                max_range_cells=max_range_cells,
+                            )
+                            try:
+                                offset_targets = infer_dynamic_offset_targets(
+                                    formula_for_infer,
+                                    current_sheet=current_sheet,
+                                    cell_type_env=expanded_env,
+                                    limits=dynamic_refs.limits,
+                                    bounds=bounds,
+                                    named_ranges=named_ranges,
+                                    named_range_ranges=named_range_ranges,
+                                    current_row=_current_row,
+                                    current_col=_current_col,
+                                )
+                                indirect_targets = infer_dynamic_indirect_targets(
+                                    formula_for_infer,
+                                    current_sheet=current_sheet,
+                                    cell_type_env=expanded_env,
+                                    limits=dynamic_refs.limits,
+                                    bounds=bounds,
+                                    named_ranges=named_ranges,
+                                    named_range_ranges=named_range_ranges,
+                                )
+                                index_targets = infer_dynamic_index_targets(
+                                    formula_for_infer,
+                                    current_sheet=current_sheet,
+                                    cell_type_env=expanded_env,
+                                    limits=dynamic_refs.limits,
+                                    bounds=bounds,
+                                    named_ranges=named_ranges,
+                                    named_range_ranges=named_range_ranges,
+                                    current_row=_current_row,
+                                    current_col=_current_col,
+                                )
+                            except DynamicRefError as exc:
+                                cell_key = format_key(current_sheet, current_a1)
+                                raise DynamicRefError(
+                                    f"{exc} (while analyzing dynamic OFFSET/INDIRECT/INDEX for {cell_key}; "
+                                    f"normalized formula {formula_for_infer!r})"
+                                ) from exc
+                            _dyn_cache[_cache_key] = (offset_targets, indirect_targets, index_targets)
+                        for addr in offset_targets | indirect_targets | index_targets:
+                            sh, a1 = _parse_address_to_sheet_a1(addr)
+                            deps.append((sh, a1))
             masked = mask_spans(masked, dyn_spans)
 
             # 1) Expand ranges, then mask them so later cell-ref parsing doesn't
@@ -755,6 +775,10 @@ def create_dependency_graph(
             if not is_formula:
                 continue
 
+            # Run extraction first so that the constraint-based dynamic-ref expansion
+            # (_dyn_cache) is populated before provenance collection reads from it.
+            deps_and_guards = extract_deps_with_guards(formula_str, sheet, a1)
+
             prov_map: dict[str, EdgeProvenance] | None = None
             if capture_dependency_provenance:
                 prov_map = collect_provenance_for_formula(
@@ -772,9 +796,10 @@ def create_dependency_graph(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=_dyn_cache,
                 )
 
-            for dep_sheet, dep_a1, guard in extract_deps_with_guards(formula_str, sheet, a1):
+            for dep_sheet, dep_a1, guard in deps_and_guards:
                 dep_key = format_key(dep_sheet, dep_a1)
                 if prov_map is not None:
                     p = prov_map.get(dep_key)

--- a/excel_grapher/grapher/provenance_collect.py
+++ b/excel_grapher/grapher/provenance_collect.py
@@ -95,6 +95,7 @@ def _flat_provenance_one_string(
     wb_formulas: fastpyxl.Workbook,
     resolve_cached_value: Callable[[str, str], object | None],
     span_target: Literal["formula", "normalized"],
+    dynamic_expansion_cache: dict[tuple[str, str, str], tuple[set[str], set[str], set[str]]] | None = None,
 ) -> dict[str, EdgeProvenance]:
     """Mirror extract_expr_deps masking pipeline; accumulate provenance for one formula string starting with '='."""
     if normalizer is None:
@@ -177,118 +178,122 @@ def _flat_provenance_one_string(
                             _merge_into(acc, k, EdgeProvenance(causes=frozenset({dyn_cause})))
                             if is_variable:
                                 argument_addrs.add(k)
+            if calls:
+                def _refs_in_formula_without_dynamic(formula_str: str, sheet_of_cell: str) -> set[str]:
+                    dyn = _find_function_calls_with_spans(
+                        formula_str if formula_str.startswith("=") else "=" + formula_str,
+                        {"OFFSET", "INDIRECT"},
+                    )
+                    spans = [span for _fn, _inner, span in dyn]
+                    masked2 = mask_spans(
+                        formula_str if formula_str.startswith("=") else "=" + formula_str,
+                        spans,
+                    )
+                    norm = normalizer.normalize(masked2, sheet_of_cell)
+                    out: set[str] = set()
+                    for ref in parse_cell_refs(norm):
+                        sh = ref.sheet if ref.sheet is not None else sheet_of_cell
+                        out.add(format_key(sh, f"{ref.column}{ref.row}"))
+                    for start, end, _span in parse_range_refs_with_spans(norm):
+                        sh = start.sheet if start.sheet is not None else sheet_of_cell
+                        for dep_sheet, dep_a1 in expand_range(
+                            sheet=sh,
+                            start_col=start.column,
+                            start_row=start.row,
+                            end_col=end.column,
+                            end_row=end.row,
+                            max_cells=max_range_cells,
+                        ):
+                            out.add(format_key(dep_sheet, dep_a1))
+                    return out
 
-            def _refs_in_formula_without_dynamic(formula_str: str, sheet_of_cell: str) -> set[str]:
-                dyn = _find_function_calls_with_spans(
-                    formula_str if formula_str.startswith("=") else "=" + formula_str,
-                    {"OFFSET", "INDIRECT"},
+                all_refs: set[str] = set()
+                to_visit = set(argument_addrs)
+                while to_visit:
+                    addr = to_visit.pop()
+                    if addr in all_refs:
+                        continue
+                    all_refs.add(addr)
+                    sh, a1 = _parse_address_to_sheet_a1(addr)
+                    if sh not in wb_formulas.sheetnames:
+                        continue
+                    cell_val = wb_formulas[sh][a1].value
+                    if isinstance(cell_val, str) and cell_val.startswith("="):
+                        to_visit.update(_refs_in_formula_without_dynamic(cell_val, sh))
+                leaves: set[str] = set()
+                for addr in all_refs:
+                    sh, a1 = _parse_address_to_sheet_a1(addr)
+                    if sh not in wb_formulas.sheetnames:
+                        continue
+                    cell_val = wb_formulas[sh][a1].value
+                    if not (isinstance(cell_val, str) and cell_val.startswith("=")):
+                        leaves.add(addr)
+                missing_leaves = leaves_missing_cell_type_constraints(
+                    leaves, dynamic_refs.cell_type_env
                 )
-                spans = [span for _fn, _inner, span in dyn]
-                masked2 = mask_spans(
-                    formula_str if formula_str.startswith("=") else "=" + formula_str,
-                    spans,
-                )
-                norm = normalizer.normalize(masked2, sheet_of_cell)
-                out: set[str] = set()
-                for ref in parse_cell_refs(norm):
-                    sh = ref.sheet if ref.sheet is not None else sheet_of_cell
-                    out.add(format_key(sh, f"{ref.column}{ref.row}"))
-                for start, end, _span in parse_range_refs_with_spans(norm):
-                    sh = start.sheet if start.sheet is not None else sheet_of_cell
-                    for dep_sheet, dep_a1 in expand_range(
-                        sheet=sh,
-                        start_col=start.column,
-                        start_row=start.row,
-                        end_col=end.column,
-                        end_row=end.row,
-                        max_cells=max_range_cells,
-                    ):
-                        out.add(format_key(dep_sheet, dep_a1))
-                return out
+                if missing_leaves:
+                    raise DynamicRefError(
+                        f"Provenance: leaf cells feeding OFFSET/INDIRECT have no constraint: {sorted(missing_leaves)}"
+                    )
 
-            all_refs: set[str] = set()
-            to_visit = set(argument_addrs)
-            while to_visit:
-                addr = to_visit.pop()
-                if addr in all_refs:
-                    continue
-                all_refs.add(addr)
-                sh, a1 = _parse_address_to_sheet_a1(addr)
-                if sh not in wb_formulas.sheetnames:
-                    continue
-                cell_val = wb_formulas[sh][a1].value
-                if isinstance(cell_val, str) and cell_val.startswith("="):
-                    to_visit.update(_refs_in_formula_without_dynamic(cell_val, sh))
-            leaves: set[str] = set()
-            for addr in all_refs:
-                sh, a1 = _parse_address_to_sheet_a1(addr)
-                if sh not in wb_formulas.sheetnames:
-                    continue
-                cell_val = wb_formulas[sh][a1].value
-                if not (isinstance(cell_val, str) and cell_val.startswith("=")):
-                    leaves.add(addr)
-            missing_leaves = leaves_missing_cell_type_constraints(
-                leaves, dynamic_refs.cell_type_env
-            )
-            if missing_leaves:
-                raise DynamicRefError(
-                    f"Provenance: leaf cells feeding OFFSET/INDIRECT have no constraint: {sorted(missing_leaves)}"
-                )
+                formula_for_infer = normalizer.normalize(f, current_sheet)
+                _col_letter, _current_row = fastpyxl.utils.cell.coordinate_from_string(current_a1)
+                _current_col = fastpyxl.utils.cell.column_index_from_string(_col_letter)
+                _cache_key = (formula_for_infer, current_sheet, current_a1)
+                if dynamic_expansion_cache is not None and _cache_key in dynamic_expansion_cache:
+                    offset_targets, indirect_targets, _ = dynamic_expansion_cache[_cache_key]
+                else:
+                    def _get_cell_formula(addr: str) -> str | None:
+                        sh, a1 = _parse_address_to_sheet_a1(addr)
+                        if sh not in wb_formulas.sheetnames:
+                            return None
+                        v = wb_formulas[sh][a1].value
+                        if not isinstance(v, str) or not v.startswith("="):
+                            return None
+                        return normalizer.normalize(v, sh)
 
-            def _get_cell_formula(addr: str) -> str | None:
-                sh, a1 = _parse_address_to_sheet_a1(addr)
-                if sh not in wb_formulas.sheetnames:
-                    return None
-                v = wb_formulas[sh][a1].value
-                if not isinstance(v, str) or not v.startswith("="):
-                    return None
-                return normalizer.normalize(v, sh)
-
-            expanded_env = expand_leaf_env_to_argument_env(
-                all_refs,
-                _get_cell_formula,
-                _refs_in_formula_without_dynamic,
-                dynamic_refs.cell_type_env,
-                dynamic_refs.limits,
-                named_ranges=named_ranges,
-                named_range_ranges=named_range_ranges,
-                max_range_cells=max_range_cells,
-            )
-            formula_for_infer = normalizer.normalize(f, current_sheet)
-            _col_letter, _current_row = fastpyxl.utils.cell.coordinate_from_string(current_a1)
-            _current_col = fastpyxl.utils.cell.column_index_from_string(_col_letter)
-            offset_targets = infer_dynamic_offset_targets(
-                formula_for_infer,
-                current_sheet=current_sheet,
-                cell_type_env=expanded_env,
-                limits=dynamic_refs.limits,
-                bounds=bounds,
-                named_ranges=named_ranges,
-                named_range_ranges=named_range_ranges,
-                current_row=_current_row,
-                current_col=_current_col,
-            )
-            indirect_targets = infer_dynamic_indirect_targets(
-                formula_for_infer,
-                current_sheet=current_sheet,
-                cell_type_env=expanded_env,
-                limits=dynamic_refs.limits,
-                bounds=bounds,
-                named_ranges=named_ranges,
-                named_range_ranges=named_range_ranges,
-            )
-            for addr in offset_targets:
-                _merge_into(
-                    acc,
-                    addr,
-                    EdgeProvenance(causes=frozenset({DependencyCause.dynamic_offset})),
-                )
-            for addr in indirect_targets:
-                _merge_into(
-                    acc,
-                    addr,
-                    EdgeProvenance(causes=frozenset({DependencyCause.dynamic_indirect})),
-                )
+                    expanded_env = expand_leaf_env_to_argument_env(
+                        all_refs,
+                        _get_cell_formula,
+                        _refs_in_formula_without_dynamic,
+                        dynamic_refs.cell_type_env,
+                        dynamic_refs.limits,
+                        named_ranges=named_ranges,
+                        named_range_ranges=named_range_ranges,
+                        max_range_cells=max_range_cells,
+                    )
+                    offset_targets = infer_dynamic_offset_targets(
+                        formula_for_infer,
+                        current_sheet=current_sheet,
+                        cell_type_env=expanded_env,
+                        limits=dynamic_refs.limits,
+                        bounds=bounds,
+                        named_ranges=named_ranges,
+                        named_range_ranges=named_range_ranges,
+                        current_row=_current_row,
+                        current_col=_current_col,
+                    )
+                    indirect_targets = infer_dynamic_indirect_targets(
+                        formula_for_infer,
+                        current_sheet=current_sheet,
+                        cell_type_env=expanded_env,
+                        limits=dynamic_refs.limits,
+                        bounds=bounds,
+                        named_ranges=named_ranges,
+                        named_range_ranges=named_range_ranges,
+                    )
+                for addr in offset_targets:
+                    _merge_into(
+                        acc,
+                        addr,
+                        EdgeProvenance(causes=frozenset({DependencyCause.dynamic_offset})),
+                    )
+                for addr in indirect_targets:
+                    _merge_into(
+                        acc,
+                        addr,
+                        EdgeProvenance(causes=frozenset({DependencyCause.dynamic_indirect})),
+                    )
 
     masked = mask_spans(masked, dyn_spans)
 
@@ -375,6 +380,7 @@ def _flat_provenance_formula_and_normalized(
     dynamic_refs: DynamicRefConfig | None,
     wb_formulas: fastpyxl.Workbook,
     resolve_cached_value: Callable[[str, str], object | None],
+    dynamic_expansion_cache: dict[tuple[str, str, str], tuple[set[str], set[str], set[str]]] | None = None,
 ) -> dict[str, EdgeProvenance]:
     raw_map = _flat_provenance_one_string(
         formula_str,
@@ -391,6 +397,7 @@ def _flat_provenance_formula_and_normalized(
         wb_formulas=wb_formulas,
         resolve_cached_value=resolve_cached_value,
         span_target="formula",
+        dynamic_expansion_cache=dynamic_expansion_cache,
     )
     if not normalized or normalized == formula_str:
         return raw_map
@@ -410,6 +417,7 @@ def _flat_provenance_formula_and_normalized(
         wb_formulas=wb_formulas,
         resolve_cached_value=resolve_cached_value,
         span_target="normalized",
+        dynamic_expansion_cache=dynamic_expansion_cache,
     )
     out: dict[str, EdgeProvenance] = {}
     all_keys = set(raw_map) | set(norm_map)
@@ -453,6 +461,7 @@ def collect_provenance_for_formula(
     dynamic_refs: DynamicRefConfig | None,
     wb_formulas: fastpyxl.Workbook,
     resolve_cached_value: Callable[[str, str], object | None],
+    dynamic_expansion_cache: dict[tuple[str, str, str], tuple[set[str], set[str], set[str]]] | None = None,
 ) -> dict[str, EdgeProvenance]:
     """
     Build a map from dependency cell key (``format_key``) to merged :class:`EdgeProvenance`
@@ -481,6 +490,7 @@ def collect_provenance_for_formula(
                 dynamic_refs=dynamic_refs,
                 wb_formulas=wb_formulas,
                 resolve_cached_value=resolve_cached_value,
+                dynamic_expansion_cache=dynamic_expansion_cache,
             ),
             collect_provenance_for_formula(
                 _ensure_leading_equals(then_s),
@@ -497,6 +507,7 @@ def collect_provenance_for_formula(
                 dynamic_refs=dynamic_refs,
                 wb_formulas=wb_formulas,
                 resolve_cached_value=resolve_cached_value,
+                dynamic_expansion_cache=dynamic_expansion_cache,
             ),
         ]
         if else_s:
@@ -515,6 +526,7 @@ def collect_provenance_for_formula(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=dynamic_expansion_cache,
                 )
             )
         return merge_provenance_maps(maps)
@@ -544,6 +556,7 @@ def collect_provenance_for_formula(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=dynamic_expansion_cache,
                 )
             )
             maps.append(
@@ -561,6 +574,7 @@ def collect_provenance_for_formula(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=dynamic_expansion_cache,
                 )
             )
         if default_ifs is not None:
@@ -579,6 +593,7 @@ def collect_provenance_for_formula(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=dynamic_expansion_cache,
                 )
             )
         return merge_provenance_maps(maps)
@@ -601,6 +616,7 @@ def collect_provenance_for_formula(
                 dynamic_refs=dynamic_refs,
                 wb_formulas=wb_formulas,
                 resolve_cached_value=resolve_cached_value,
+                dynamic_expansion_cache=dynamic_expansion_cache,
             )
         ]
         for choice_s in choose_args[1:]:
@@ -619,6 +635,7 @@ def collect_provenance_for_formula(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=dynamic_expansion_cache,
                 )
             )
         return merge_provenance_maps(maps)
@@ -642,6 +659,7 @@ def collect_provenance_for_formula(
                 dynamic_refs=dynamic_refs,
                 wb_formulas=wb_formulas,
                 resolve_cached_value=resolve_cached_value,
+                dynamic_expansion_cache=dynamic_expansion_cache,
             )
         ]
         pairs = switch_args[1:]
@@ -667,6 +685,7 @@ def collect_provenance_for_formula(
                         dynamic_refs=dynamic_refs,
                         wb_formulas=wb_formulas,
                         resolve_cached_value=resolve_cached_value,
+                        dynamic_expansion_cache=dynamic_expansion_cache,
                     )
                 )
         if default_expr is not None:
@@ -685,6 +704,7 @@ def collect_provenance_for_formula(
                     dynamic_refs=dynamic_refs,
                     wb_formulas=wb_formulas,
                     resolve_cached_value=resolve_cached_value,
+                    dynamic_expansion_cache=dynamic_expansion_cache,
                 )
             )
         return merge_provenance_maps(maps)
@@ -704,4 +724,5 @@ def collect_provenance_for_formula(
         dynamic_refs=dynamic_refs,
         wb_formulas=wb_formulas,
         resolve_cached_value=resolve_cached_value,
+        dynamic_expansion_cache=dynamic_expansion_cache,
     )

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -1892,3 +1892,150 @@ def test_offset_per_call_max_cells_limit() -> None:
         )
     assert "cells" in str(exc_info.value).lower()
     assert "exceed limit" in str(exc_info.value).lower()
+
+
+def test_constraint_dynamic_ref_expansion_not_duplicated_with_provenance(
+    tmp_path: Path,
+) -> None:
+    """Flat OFFSET formulas should share dynamic-ref expansion with provenance."""
+    excel_path = tmp_path / "offset_provenance_perf.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number(0, 1, 0)  # B1 base
+    ws.write_number(0, 2, 1)  # C1 = row offset
+    ws.write_formula(0, 0, "=OFFSET(Sheet1!B1,Sheet1!C1,0)", None, 0)  # A1
+    wb.close()
+
+    env = _make_env(
+        {
+            "Sheet1!C1": CellType(
+                kind=CellKind.NUMBER,
+                interval=IntervalDomain(min=0, max=1),
+            )
+        }
+    )
+    config = DynamicRefConfig(cell_type_env=env, limits=DynamicRefLimits())
+
+    graph, call_count = _build_graph_counting_dynamic_expansion(
+        excel_path,
+        ["Sheet1!A1"],
+        dynamic_refs=config,
+    )
+
+    assert call_count == 1, (
+        f"expand_leaf_env_to_argument_env was called {call_count} times; "
+        "expected 1 (shared between extraction and provenance collection)"
+    )
+    assert "Sheet1!B1" in graph.dependencies("Sheet1!A1")
+    assert "Sheet1!C1" in graph.dependencies("Sheet1!A1")
+
+
+def test_constraint_indirect_expansion_not_duplicated_with_provenance(
+    tmp_path: Path,
+) -> None:
+    """Flat INDIRECT formulas should share dynamic-ref expansion with provenance."""
+    excel_path = tmp_path / "indirect_provenance_perf.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_string(0, 1, "Sheet1!B2")  # B1 ref text
+    ws.write_number(1, 1, 7)  # B2 target
+    ws.write_formula(0, 0, "=INDIRECT(Sheet1!B1)", None, 7)  # A1
+    wb.close()
+
+    env = _make_env(
+        {
+            "Sheet1!B1": CellType(
+                kind=CellKind.STRING,
+                enum=EnumDomain(values=frozenset({"Sheet1!B2"})),
+            )
+        }
+    )
+    config = DynamicRefConfig(cell_type_env=env, limits=DynamicRefLimits())
+
+    graph, call_count = _build_graph_counting_dynamic_expansion(
+        excel_path,
+        ["Sheet1!A1"],
+        dynamic_refs=config,
+    )
+
+    assert call_count == 1, (
+        f"expand_leaf_env_to_argument_env was called {call_count} times; "
+        "expected 1 for INDIRECT with provenance enabled"
+    )
+    assert "Sheet1!B1" in graph.dependencies("Sheet1!A1")
+    assert "Sheet1!B2" in graph.dependencies("Sheet1!A1")
+
+
+def test_constraint_branch_dynamic_ref_expansion_not_duplicated_with_provenance(
+    tmp_path: Path,
+) -> None:
+    """Recursive provenance traversal should reuse cached expansion for branch formulas."""
+    excel_path = tmp_path / "if_offset_provenance_perf.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number(0, 1, 10)  # B1 base
+    ws.write_number(1, 1, 20)  # B2 resolved OFFSET target
+    ws.write_number(0, 2, 1)  # C1 row offset
+    ws.write_boolean(0, 3, True)  # D1 IF condition
+    ws.write_formula(0, 0, "=IF(Sheet1!D1,OFFSET(Sheet1!B1,Sheet1!C1,0),0)", None, 20)  # A1
+    wb.close()
+
+    env = _make_env(
+        {
+            "Sheet1!C1": CellType(
+                kind=CellKind.NUMBER,
+                interval=IntervalDomain(min=0, max=1),
+            )
+        }
+    )
+    config = DynamicRefConfig(cell_type_env=env, limits=DynamicRefLimits())
+
+    graph, call_count = _build_graph_counting_dynamic_expansion(
+        excel_path,
+        ["Sheet1!A1"],
+        dynamic_refs=config,
+    )
+
+    assert call_count == 1, (
+        f"expand_leaf_env_to_argument_env was called {call_count} times; "
+        "expected 1 for IF branch provenance recursion"
+    )
+    deps = graph.dependencies("Sheet1!A1")
+    assert "Sheet1!D1" in deps
+    assert "Sheet1!B1" in deps
+    assert "Sheet1!C1" in deps
+    assert "Sheet1!B2" in deps
+
+
+def _build_graph_counting_dynamic_expansion(
+    excel_path: Path,
+    targets: list[str],
+    *,
+    dynamic_refs: DynamicRefConfig,
+):
+    from unittest.mock import patch
+
+    original_expand = expand_leaf_env_to_argument_env
+    call_count = 0
+
+    def counting_expand(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_expand(*args, **kwargs)
+
+    with patch(
+        "excel_grapher.grapher.builder.expand_leaf_env_to_argument_env",
+        side_effect=counting_expand,
+    ), patch(
+        "excel_grapher.grapher.provenance_collect.expand_leaf_env_to_argument_env",
+        side_effect=counting_expand,
+    ):
+        graph = create_dependency_graph(
+            excel_path,
+            targets,
+            load_values=False,
+            dynamic_refs=dynamic_refs,
+            capture_dependency_provenance=True,
+        )
+
+    return graph, call_count


### PR DESCRIPTION
## Summary

- Adds a per-graph `_dyn_cache` dict (keyed by `(normalized_formula, current_sheet, current_a1)`) in `create_dependency_graph`'s closure, populated by `extract_expr_deps` on the first constraint-based expansion pass
- Swaps the BFS loop order so dependency extraction runs **before** provenance collection, ensuring the cache is warm when provenance runs
- Adds `dynamic_expansion_cache` parameter to `collect_provenance_for_formula`, `_flat_provenance_formula_and_normalized`, and `_flat_provenance_one_string`; on a cache hit the expensive `expand_leaf_env_to_argument_env` + inference calls are skipped
- Updates the `create_dependency_graph` docstring to document the cost model

## Test plan

- [x] New regression test `test_constraint_dynamic_ref_expansion_not_duplicated_with_provenance` patches `expand_leaf_env_to_argument_env` in both modules and asserts it is called exactly once per formula (not twice) when `capture_dependency_provenance=True`
- [x] Full test suite (557 tests) passes

Closes #61

🤖 Generated with [Claude Code](https://claude.ai/claude-code)