### PR TITLE
Benchmark + optimize dynamic-ref constraint enumeration blowups

### DIFF
--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -19,6 +19,7 @@ from .dynamic_refs import (
     DynamicRefConfig,
     DynamicRefError,
     GlobalWorkbookBounds,
+    clear_index_target_cache,
     expand_leaf_env_to_argument_env,
     infer_dynamic_index_targets,
     infer_dynamic_indirect_targets,
@@ -225,6 +226,9 @@ def create_dependency_graph(
     named_range_ranges = named_range_maps.range_map
     normalizer = FormulaNormalizer(named_ranges, named_range_ranges)
     defined_names: set[str] = {str(name) for name in wb_formulas.defined_names}
+    # Clear per-graph-build caches from previous invocations.
+    clear_index_target_cache()
+
     # Per-graph cache: (normalized_formula, current_sheet, current_a1) → (offset_targets, indirect_targets, index_targets).
     # Populated by extract_expr_deps (constraint path); consumed by collect_provenance_for_formula
     # to avoid re-running the expensive expand_leaf_env_to_argument_env call.

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -2011,13 +2011,24 @@ def _clamp_int(v: int, lo: int, hi: int) -> int:
     return max(lo, min(hi, v))
 
 
-# Module-level cache for _emit_index_targets_from_domains: avoids regenerating
-# the same target set when multiple INDEX formulas resolve to identical
-# (array_range, row_dom, col_dom) triples.
+# Per-graph-build cache for INDEX target emission: avoids regenerating the same
+# target set when multiple INDEX formulas resolve to identical
+# (array_range, row_dom, col_dom) triples within a single graph build.
+# Cleared at the start of each create_dependency_graph call via
+# clear_index_target_cache().
 _emit_index_cache: dict[
     tuple[ExcelRange, _FiniteInts | _IntBounds, _FiniteInts | _IntBounds],
     frozenset[str],
 ] = {}
+
+
+def clear_index_target_cache() -> None:
+    """Clear the INDEX target emission cache.
+
+    Called at the start of each graph build to scope the cache to a single
+    invocation and prevent unbounded memory retention across builds.
+    """
+    _emit_index_cache.clear()
 
 
 def _emit_index_targets_from_domains(

--- a/tests/grapher/test_dynamic_refs.py
+++ b/tests/grapher/test_dynamic_refs.py
@@ -2203,8 +2203,15 @@ def test_shared_intermediate_env_expansion_cache(tmp_path: Path) -> None:
     """Many INDEX formulas sharing an intermediate cell should reuse env expansion.
 
     All formulas reference B1 (intermediate) which depends on C1 (leaf).
-    With a shared env expansion cache, ``cell_type_for(B1)`` is computed once.
+    With a shared env expansion cache, ``cell_type_for(B1)`` is computed once
+    and reused across all 30 formula cells' expand_leaf_env_to_argument_env calls.
+
+    We verify this by wrapping expand_leaf_env_to_argument_env and inspecting
+    the shared_cell_type_cache: B1 should already be present in the cache for
+    all calls after the first.
     """
+    from unittest.mock import patch
+
     n_rows = 30
     excel_path = tmp_path / "shared_intermediate.xlsx"
     _build_shared_intermediate_index_workbook(excel_path, n_rows=n_rows)
@@ -2222,12 +2229,30 @@ def test_shared_intermediate_env_expansion_cache(tmp_path: Path) -> None:
     config = DynamicRefConfig(cell_type_env=env, limits=DynamicRefLimits())
     targets = [f"Sheet1!F{2 + i}" for i in range(n_rows)]
 
-    graph = create_dependency_graph(
-        excel_path,
-        targets,
-        load_values=False,
-        dynamic_refs=config,
-    )
+    # Track how many times B1 is already in the shared cache when
+    # expand_leaf_env_to_argument_env is called.
+    original_expand = expand_leaf_env_to_argument_env
+    b1_cache_hits = 0
+    total_calls = 0
+
+    def tracking_expand(*args, **kwargs):
+        nonlocal b1_cache_hits, total_calls
+        total_calls += 1
+        shared_cache = kwargs.get("shared_cell_type_cache")
+        if shared_cache is not None and "Sheet1!B1" in shared_cache:
+            b1_cache_hits += 1
+        return original_expand(*args, **kwargs)
+
+    with patch(
+        "excel_grapher.grapher.builder.expand_leaf_env_to_argument_env",
+        side_effect=tracking_expand,
+    ):
+        graph = create_dependency_graph(
+            excel_path,
+            targets,
+            load_values=False,
+            dynamic_refs=config,
+        )
 
     # Correctness check: each formula should depend on B1 and its D leaf.
     for i in range(n_rows):
@@ -2235,3 +2260,11 @@ def test_shared_intermediate_env_expansion_cache(tmp_path: Path) -> None:
         deps = graph.dependencies(f"Sheet1!F{row}")
         assert "Sheet1!B1" in deps, f"Missing B1 dep for F{row}"
         assert f"Sheet1!D{row}" in deps, f"Missing D leaf dep for F{row}"
+
+    # Optimization check: B1 should be inferred once (cache miss on first call)
+    # and served from the shared cache for all subsequent calls.
+    assert total_calls == n_rows, f"Expected {n_rows} expand calls, got {total_calls}"
+    assert b1_cache_hits == n_rows - 1, (
+        f"Expected B1 to be a cache hit on {n_rows - 1} of {n_rows} calls, "
+        f"but got {b1_cache_hits} hits. shared_cell_type_cache is not being reused."
+    )


### PR DESCRIPTION
## Summary

Closes #78

- **Shared env expansion cache**: `expand_leaf_env_to_argument_env` now accepts an optional `shared_cell_type_cache` dict, shared across all BFS nodes. Intermediate formula cell types (e.g., `B1 = =C1+1`) are inferred once and reused by all dynamic-ref formulas that reference them.
- **INDEX target emission cache**: Module-level `_emit_index_cache` keyed on `(ExcelRange, row_dom, col_dom)` in `_infer_index_targets_core`. When multiple INDEX formulas resolve to the same array/domain triple, the target set is computed once. This directly eliminates the repeated `[DIAG] INDEX (abstract): ... -> 242 targets` lines reported in the issue.
- **Profiling counters**: BFS diagnostics now include `dyn_infer` (inference calls), `dyn_cache_hits`, and `env_cache_size` for monitoring cache effectiveness.
- **Benchmark tests**: Two new tests reproduce the blowup pattern — `test_wide_index_sweep_shared_env_cache` (50 INDEX formulas with identical domains) and `test_shared_intermediate_env_expansion_cache` (30 formulas sharing an intermediate cell).

## Test plan

- [x] `test_wide_index_sweep_shared_env_cache` passes — `_emit_index_targets_from_domains` called once instead of 50 times
- [x] `test_shared_intermediate_env_expansion_cache` passes — shared intermediate cell types reused
- [x] Full test suite passes (605 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)