### PR TITLE
Handle TRUE()/FALSE() as zero-arg function calls in evaluator and codegen

### DIFF
--- a/excel_grapher/evaluator/codegen.py
+++ b/excel_grapher/evaluator/codegen.py
@@ -720,6 +720,12 @@ class CodeGenerator:
         if upper_name == "COLUMNS":
             return self._emit_columns(node)
 
+        # TRUE()/FALSE() as zero-arg function calls
+        if upper_name in {"TRUE", "_XLFN.TRUE"}:
+            return "True"
+        if upper_name in {"FALSE", "_XLFN.FALSE"}:
+            return "False"
+
         # Functions that need numpy arrays for their array/table arguments
         # Maps function name -> set of argument indices that need np.array wrapping
         numpy_array_args: dict[str, set[int]] = {

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -284,6 +284,10 @@ class FormulaEvaluator:
                 return self._eval_column(node.args)
             if name == "COLUMNS":
                 return self._eval_columns(node.args)
+            if name in {"TRUE", "_XLFN.TRUE"}:
+                return True
+            if name in {"FALSE", "_XLFN.FALSE"}:
+                return False
 
             args = [self._evaluate_ast(a) for a in node.args]
             # Resolve ExcelRange objects to numpy arrays

--- a/tests/evaluator/test_functions.py
+++ b/tests/evaluator/test_functions.py
@@ -35,6 +35,26 @@ def _make_graph(*nodes: Node) -> DependencyGraph:
 # --- Logic function tests ---
 
 
+def test_true_false_as_function_calls() -> None:
+    """TRUE() and FALSE() as zero-arg function calls should return booleans."""
+    graph = _make_graph(
+        _make_node("S!A1", "=TRUE()", None),
+        _make_node("S!A2", "=FALSE()", None),
+        _make_node("S!A3", "=IF(TRUE(), 1, 2)", None),
+        _make_node("S!A4", "=VLOOKUP(1, S!B1:S!C2, 2, FALSE())", None),
+        _make_node("S!B1", None, 1),
+        _make_node("S!B2", None, 2),
+        _make_node("S!C1", None, "found"),
+        _make_node("S!C2", None, "other"),
+    )
+    with FormulaEvaluator(graph) as ev:
+        result = ev.evaluate(["S!A1", "S!A2", "S!A3", "S!A4"])
+        assert result["S!A1"] is True
+        assert result["S!A2"] is False
+        assert result["S!A3"] == 1
+        assert result["S!A4"] == "found"
+
+
 def test_iserror() -> None:
     """Test ISERROR function."""
     graph = _make_graph(

--- a/tests/exporter/test_codegen_integration.py
+++ b/tests/exporter/test_codegen_integration.py
@@ -120,6 +120,19 @@ class TestGeneratedCodeExecution:
         assert result.generated_results["S!B1"] == 10
         assert result.generated_results["S!B2"] == 5
 
+    def test_generated_code_true_false_function_calls(self) -> None:
+        """TRUE() and FALSE() as zero-arg function calls should codegen correctly."""
+        graph = _make_graph(
+            _make_node("S!A1", "=TRUE()", None),
+            _make_node("S!A2", "=FALSE()", None),
+            _make_node("S!A3", "=IF(TRUE(), 10, 20)", None),
+        )
+        targets = ["S!A1", "S!A2", "S!A3"]
+        result = assert_codegen_matches_evaluator(graph, targets)
+        assert result.generated_results["S!A1"] is True
+        assert result.generated_results["S!A2"] is False
+        assert result.generated_results["S!A3"] == 10
+
     def test_generated_code_if_uses_excel_boolean_coercion(self) -> None:
         """IF should use Excel-style boolean coercion (e.g., 'FALSE' -> False)."""
         graph = _make_graph(


### PR DESCRIPTION
## Summary

- Fixes #83
- `TRUE()` / `FALSE()` (with parentheses) are parsed as `FunctionCallNode` rather than `BoolNode`, but were not handled in the evaluator or codegen dispatch, causing `NotImplementedError: Excel function not implemented: TRUE/FALSE`
- Added short-circuit cases for `TRUE`, `FALSE`, `_XLFN.TRUE`, and `_XLFN.FALSE` in both the interpreter (`evaluator.py`) and code-generation (`codegen.py`) paths, returning the Python literals directly

## Test plan

- [x] `test_true_false_as_function_calls` — evaluator handles `=TRUE()`, `=FALSE()`, `=IF(TRUE(),...)`, and `=VLOOKUP(..., FALSE())`
- [x] `test_generated_code_true_false_function_calls` — codegen produces correct output and matches evaluator results
- [x] Full test suite passes (360 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)