### PR TITLE
fix(grapher): absolute cross-sheet refs and address-like sheet names

### DIFF
--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -38,8 +38,9 @@ _SHEET_CELL_RE = re.compile(
     r"(?:'(?P<qs>[^']+)'|(?P<us>[A-Za-z][A-Za-z0-9_]*))!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)"
 )
 # Do not treat ``Col`` in ``Sheet!$Col$Row`` as a local ref: the column letter can follow ``!$``.
+# Sheet tokens may look like A1 (e.g. ``S2`` / ``'S2'``); do not match those as local refs.
 _LOCAL_CELL_RE = re.compile(
-    r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])"
+    r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])"
 )
 _FUNC_LIKE = {"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"}
 
@@ -387,7 +388,7 @@ def normalize_formula(
         return _format_ref(current_sheet, col, int(row))
 
     result = re.sub(
-        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])",
+        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
         replace_local_cell,
         result,
     )
@@ -570,7 +571,7 @@ class FormulaNormalizer:
             return _format_ref(current_sheet, col, int(row))
 
         result = re.sub(
-            r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])",
+            r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
             replace_local_cell,
             result,
         )

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -37,8 +37,9 @@ class CellRef:
 _SHEET_CELL_RE = re.compile(
     r"(?:'(?P<qs>[^']+)'|(?P<us>[A-Za-z][A-Za-z0-9_]*))!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)"
 )
+# Do not treat ``Col`` in ``Sheet!$Col$Row`` as a local ref: the column letter can follow ``!$``.
 _LOCAL_CELL_RE = re.compile(
-    r"(?<![!A-Za-z0-9_])\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])"
+    r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])"
 )
 _FUNC_LIKE = {"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"}
 
@@ -55,7 +56,7 @@ _RANGE_UNQUOTED_BOTH_ENDPOINTS_RE = re.compile(
     r"(?<![A-Za-z_])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*(?P=sheet)!\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
 )
 _RANGE_LOCAL_RE = re.compile(
-    r"(?<![!A-Za-z0-9_])\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])"
+    r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])"
 )
 
 
@@ -344,7 +345,7 @@ def normalize_formula(
         return f"{ref1}:{ref2}"
 
     result = re.sub(
-        r"(?<![!A-Za-z0-9_])\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
+        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
         replace_local_range,
         result,
     )
@@ -386,7 +387,7 @@ def normalize_formula(
         return _format_ref(current_sheet, col, int(row))
 
     result = re.sub(
-        r"(?<![!A-Za-z0-9_])\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])",
+        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])",
         replace_local_cell,
         result,
     )
@@ -535,7 +536,7 @@ class FormulaNormalizer:
             return f"{ref1}:{ref2}"
 
         result = re.sub(
-            r"(?<![!A-Za-z0-9_])\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
+            r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
             replace_local_range,
             result,
         )
@@ -569,7 +570,7 @@ class FormulaNormalizer:
             return _format_ref(current_sheet, col, int(row))
 
         result = re.sub(
-            r"(?<![!A-Za-z0-9_])\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])",
+            r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_])",
             replace_local_cell,
             result,
         )

--- a/tests/integration/grapher/test_dependency_graph_build.py
+++ b/tests/integration/grapher/test_dependency_graph_build.py
@@ -266,3 +266,36 @@ def test_offset_invalid_base_error_includes_cell_address(tmp_path: Path) -> None
             excel_path, ["Sheet1!A1"], load_values=False, use_cached_dynamic_refs=True
         )
     assert "A1" in str(exc_info.value)
+
+
+def test_absolute_cross_sheet_refs_no_spurious_same_sheet_edge_issue_154(
+    tmp_path: Path,
+) -> None:
+    """Regression for gh #154: Sheet!$Col$Row must not add CurrentSheet!ColRow."""
+    cases: list[tuple[str, set[str], str]] = [
+        ("=Inputs!$B$5", {"Inputs!B5"}, "Inputs"),
+        ("=A1+Inputs!$B$5", {"Engine!A1", "Inputs!B5"}, "Inputs"),
+        ("=IF(A1>=Inputs!$B$5,1,0)", {"Engine!A1", "Inputs!B5"}, "Inputs"),
+        ("=A1+Inputs!B5", {"Engine!A1", "Inputs!B5"}, "Inputs"),
+        ("='Input Sheet'!$B$5", {"'Input Sheet'!B5"}, "Input Sheet"),
+        ("=A1+'Input Sheet'!$B$5", {"Engine!A1", "'Input Sheet'!B5"}, "Input Sheet"),
+    ]
+    for idx, (formula, expected, dep_sheet) in enumerate(cases):
+        excel_path = tmp_path / f"issue_154_case_{idx}.xlsx"
+        wb = fastpyxl.Workbook()
+        default = wb.active
+        if default is not None:
+            wb.remove(default)
+        engine = wb.create_sheet("Engine")
+        dep_ws = wb.create_sheet(dep_sheet)
+        engine["A1"] = 1
+        engine["A2"] = formula
+        dep_ws["B5"] = 7
+        wb.save(excel_path)
+        wb.close()
+
+        graph = create_dependency_graph(excel_path, ["Engine!A2"], load_values=False)
+        assert graph.get_dependencies("Engine!A2") == expected, (
+            f"formula={formula!r} expected={sorted(expected)!r} "
+            f"actual={sorted(graph.get_dependencies('Engine!A2'))!r}"
+        )

--- a/tests/integration/grapher/test_dependency_graph_build.py
+++ b/tests/integration/grapher/test_dependency_graph_build.py
@@ -299,3 +299,43 @@ def test_absolute_cross_sheet_refs_no_spurious_same_sheet_edge_issue_154(
             f"formula={formula!r} expected={sorted(expected)!r} "
             f"actual={sorted(graph.get_dependencies('Engine!A2'))!r}"
         )
+
+
+@pytest.mark.parametrize(
+    ("current_sheet", "dep_sheet", "formula", "expected"),
+    [
+        ("S1", "S2", "=S2!B5", {"S2!B5"}),
+        ("S1", "S2", "=1+S2!B5", {"S2!B5"}),
+        ("S1", "S2", "='S2'!B5", {"S2!B5"}),
+        ("Sheet1", "AA1", "=AA1!B5", {"AA1!B5"}),
+        ("Sheet1", "Inputs", "=Inputs!B5", {"Inputs!B5"}),
+    ],
+    ids=["s2-ref", "s2-ref-with-prefix", "quoted-s2-ref", "aa1-ref", "inputs-control"],
+)
+def test_address_like_sheet_names_do_not_add_same_sheet_alias_edges_issue_155(
+    tmp_path: Path,
+    current_sheet: str,
+    dep_sheet: str,
+    formula: str,
+    expected: set[str],
+) -> None:
+    excel_path = tmp_path / "issue_155_case.xlsx"
+    wb = fastpyxl.Workbook()
+    default = wb.active
+    if default is not None:
+        wb.remove(default)
+
+    current = wb.create_sheet(current_sheet)
+    dep = wb.create_sheet(dep_sheet)
+    current["A2"] = formula
+    dep["B5"] = 7
+
+    wb.save(excel_path)
+    wb.close()
+
+    target = f"{current_sheet}!A2"
+    graph = create_dependency_graph(excel_path, [target], load_values=False)
+    assert graph.get_dependencies(target) == expected, (
+        f"formula={formula!r} expected={sorted(expected)!r} "
+        f"actual={sorted(graph.get_dependencies(target))!r}"
+    )

--- a/tests/integration/grapher/test_dependency_graph_build.py
+++ b/tests/integration/grapher/test_dependency_graph_build.py
@@ -307,10 +307,20 @@ def test_absolute_cross_sheet_refs_no_spurious_same_sheet_edge_issue_154(
         ("S1", "S2", "=S2!B5", {"S2!B5"}),
         ("S1", "S2", "=1+S2!B5", {"S2!B5"}),
         ("S1", "S2", "='S2'!B5", {"S2!B5"}),
+        ("S1", "S2", "='S2'!$B$5", {"S2!B5"}),
         ("Sheet1", "AA1", "=AA1!B5", {"AA1!B5"}),
+        ("Sheet1", "AA1", "=AA1!$B$5", {"AA1!B5"}),
         ("Sheet1", "Inputs", "=Inputs!B5", {"Inputs!B5"}),
     ],
-    ids=["s2-ref", "s2-ref-with-prefix", "quoted-s2-ref", "aa1-ref", "inputs-control"],
+    ids=[
+        "s2-ref",
+        "s2-ref-with-prefix",
+        "quoted-s2-ref",
+        "quoted-s2-absolute-ref",
+        "aa1-ref",
+        "aa1-absolute-ref",
+        "inputs-control",
+    ],
 )
 def test_address_like_sheet_names_do_not_add_same_sheet_alias_edges_issue_155(
     tmp_path: Path,

--- a/tests/unit/grapher/test_parser.py
+++ b/tests/unit/grapher/test_parser.py
@@ -171,3 +171,11 @@ class TestParseCellRefsAbsoluteCrossSheet:
             (None, "A", 1),
             ("Input Sheet", "B", 5),
         }
+
+    def test_sheet_name_resembling_cell_ref_unquoted_issue_155(self) -> None:
+        refs = parse_cell_refs("=S2!B5")
+        assert refs == [CellRef(sheet="S2", column="B", row=5)]
+
+    def test_sheet_name_resembling_cell_ref_quoted_issue_155(self) -> None:
+        refs = parse_cell_refs("='S2'!B5")
+        assert refs == [CellRef(sheet="S2", column="B", row=5)]

--- a/tests/unit/grapher/test_parser.py
+++ b/tests/unit/grapher/test_parser.py
@@ -179,3 +179,10 @@ class TestParseCellRefsAbsoluteCrossSheet:
     def test_sheet_name_resembling_cell_ref_quoted_issue_155(self) -> None:
         refs = parse_cell_refs("='S2'!B5")
         assert refs == [CellRef(sheet="S2", column="B", row=5)]
+
+    def test_sheet_name_resembling_cell_ref_with_spans_issue_155(self) -> None:
+        pairs = parse_cell_refs_with_spans("='S2'!B5")
+        assert len(pairs) == 1
+        ref, span = pairs[0]
+        assert ref == CellRef(sheet="S2", column="B", row=5)
+        assert span == (1, len("='S2'!B5"))

--- a/tests/unit/grapher/test_parser.py
+++ b/tests/unit/grapher/test_parser.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from excel_grapher.grapher.parser import (
+    CellRef,
+    parse_cell_refs,
+    parse_cell_refs_with_spans,
     parse_range_refs_with_spans,
     split_top_level_choose,
     split_top_level_if,
@@ -127,3 +130,44 @@ class TestParseRangeRefsWithSpans:
         assert end.sheet == "Sheet1"
         assert end.column == "A"
         assert end.row == 12
+
+
+class TestParseCellRefsAbsoluteCrossSheet:
+    """Absolute cross-sheet refs must not yield a duplicate local cell (issue #154)."""
+
+    def test_absolute_cross_sheet_single_cell(self) -> None:
+        refs = parse_cell_refs("=Inputs!$B$5")
+        assert refs == [CellRef(sheet="Inputs", column="B", row=5)]
+
+    def test_absolute_cross_sheet_with_spans(self) -> None:
+        pairs = parse_cell_refs_with_spans("=Inputs!$B$5")
+        assert len(pairs) == 1
+        ref, span = pairs[0]
+        assert ref == CellRef(sheet="Inputs", column="B", row=5)
+        assert span == (1, len("=Inputs!$B$5"))
+
+    def test_relative_cross_sheet_control(self) -> None:
+        refs = parse_cell_refs("=Inputs!B5")
+        assert refs == [CellRef(sheet="Inputs", column="B", row=5)]
+
+    def test_local_absolute_still_parsed(self) -> None:
+        refs = parse_cell_refs("=$B$5")
+        assert refs == [CellRef(sheet=None, column="B", row=5)]
+
+    def test_absolute_cross_sheet_plus_local(self) -> None:
+        refs = parse_cell_refs("=Inputs!$B$5+A1")
+        assert set((r.sheet, r.column, r.row) for r in refs) == {
+            ("Inputs", "B", 5),
+            (None, "A", 1),
+        }
+
+    def test_absolute_cross_sheet_quoted_sheet_with_spaces(self) -> None:
+        refs = parse_cell_refs("='Input Sheet'!$B$5")
+        assert refs == [CellRef(sheet="Input Sheet", column="B", row=5)]
+
+    def test_absolute_cross_sheet_quoted_sheet_with_spaces_plus_local(self) -> None:
+        refs = parse_cell_refs("=A1+'Input Sheet'!$B$5")
+        assert set((r.sheet, r.column, r.row) for r in refs) == {
+            (None, "A", 1),
+            ("Input Sheet", "B", 5),
+        }


### PR DESCRIPTION
## Summary

Fixes absolute cross-sheet parsing so formulas like `Sheet!$B$5` no longer create spurious same-sheet edges (issue #154).

Fixes address-like sheet-name parsing so tokens like `S2`/`AA1` in `S2!B5` and `AA1!B5` are not misread as local refs (issue #155).

## Commits
1. `fix(grapher): stop spurious local refs after Sheet!$ in absolute cross-sheet addresses`
2. `fix(grapher): avoid parsing sheet tokens like S2 as local refs before !`
3. `test(grapher): harden regressions for address-like sheet refs`

## Test plan
- `uv run pytest tests/unit/grapher tests/integration/grapher`
- `uv run pytest tests/integration/grapher/test_dependency_graph_build.py tests/unit/grapher/test_parser.py -q`

Closes #154
Closes #155

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Regex changes in formula parsing/normalization alter how dependencies are discovered; mistakes could silently drop or add edges in the dependency graph across many workbooks.
> 
> **Overview**
> Fixes dependency extraction for cross-sheet references so `Sheet!$B$5` and sheet names that look like cell addresses (e.g. `S2!B5`) no longer create a **spurious same-sheet dependency edge**.
> 
> Tightens the local cell/range regexes (and matching normalization substitutions) to avoid mis-tokenizing characters after `!$` and to stop treating sheet tokens followed by `!` as local refs, and adds unit + integration regression coverage for issues #154/#155 (including quoted sheet names with spaces).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 988070ec6f6b34c82717a201fb3b7bc75b6fa921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->