### PR TITLE
Unify formula normalization and enforce normalized_formula invariant

### DIFF
--- a/excel_grapher/core/formula_normalization.py
+++ b/excel_grapher/core/formula_normalization.py
@@ -1,0 +1,197 @@
+"""Canonical Excel formula normalization for sheet-qualified A1 references.
+
+Graph extraction, evaluation, and codegen share these rules so bare cell
+references resolve against the formula cell's sheet and named ranges expand
+consistently before :mod:`excel_grapher.core.formula_ast` parsing.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import cast
+
+from excel_grapher.core.address_keys import format_cell_key
+
+_FUNC_LIKE = frozenset({"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"})
+
+
+def build_named_range_replacement_state(
+    named_ranges: dict[str, tuple[str, str]] | None,
+    named_range_ranges: dict[str, tuple[str, str, str]] | None,
+) -> tuple[dict[str, str], re.Pattern[str] | None]:
+    """Build replacement strings and a single alternation regex for defined names."""
+    named_ranges = named_ranges or {}
+    named_range_ranges = named_range_ranges or {}
+
+    replacements: dict[str, str] = {}
+
+    for name, (sheet, addr) in named_ranges.items():
+        col_match = re.match(r"^([A-Z]{1,3})(\d+)$", addr)
+        if col_match:
+            replacements[name] = format_cell_key(sheet, col_match.group(1), int(col_match.group(2)))
+
+    for name, (sheet, start_a1, end_a1) in named_range_ranges.items():
+        m_start = re.match(r"^([A-Z]{1,3})(\d+)$", start_a1)
+        m_end = re.match(r"^([A-Z]{1,3})(\d+)$", end_a1)
+        if m_start and m_end:
+            start_ref = format_cell_key(sheet, m_start.group(1), int(m_start.group(2)))
+            end_ref = format_cell_key(sheet, m_end.group(1), int(m_end.group(2)))
+            replacements[name] = f"{start_ref}:{end_ref}"
+
+    if not replacements:
+        return {}, None
+
+    names = cast(list[str], sorted(replacements, key=len, reverse=True))
+    alt = "|".join(re.escape(n) for n in names)
+    names_re = re.compile(rf"\b(?:{alt})\b(?!\s*!)")
+    return replacements, names_re
+
+
+def _apply_named_range_replacements(
+    formula: str,
+    replacements: dict[str, str],
+    names_re: re.Pattern[str] | None,
+) -> str:
+    if names_re is None:
+        return formula
+
+    def replace_name(m: re.Match[str]) -> str:
+        return replacements.get(m.group(0), m.group(0))
+
+    return names_re.sub(replace_name, formula)
+
+
+def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
+    """Strip $ markers, qualify ranges and cells, without defined-name substitution."""
+    result = formula
+
+    def replace_quoted_range(m: re.Match[str]) -> str:
+        sheet = m.group("sheet")
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        a = format_cell_key(sheet, c1, int(r1))
+        b = format_cell_key(sheet, c2, int(r2))
+        return f"{a}:{b}"
+
+    result = re.sub(
+        r"'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
+        replace_quoted_range,
+        result,
+    )
+
+    def replace_unquoted_range(m: re.Match[str]) -> str:
+        sheet = m.group("sheet")
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        return f"{sheet}!{c1}{r1}:{sheet}!{c2}{r2}"
+
+    result = re.sub(
+        r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
+        replace_unquoted_range,
+        result,
+    )
+
+    def replace_local_range(m: re.Match[str]) -> str:
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        ref1 = format_cell_key(current_sheet, c1, int(r1))
+        ref2 = format_cell_key(current_sheet, c2, int(r2))
+        return f"{ref1}:{ref2}"
+
+    result = re.sub(
+        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
+        replace_local_range,
+        result,
+    )
+
+    def replace_quoted_cell(m: re.Match[str]) -> str:
+        sheet, col, row = m.group("sheet"), m.group("col"), m.group("row")
+        return format_cell_key(sheet, col, int(row))
+
+    result = re.sub(
+        r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
+        replace_quoted_cell,
+        result,
+    )
+
+    def replace_unquoted_cell(m: re.Match[str]) -> str:
+        sheet, col, row = m.group("sheet"), m.group("col"), m.group("row")
+        return f"{sheet}!{col}{row}"
+
+    result = re.sub(
+        r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
+        replace_unquoted_cell,
+        result,
+    )
+
+    def replace_local_cell(m: re.Match[str]) -> str:
+        col, row = m.group("col"), m.group("row")
+        if col in _FUNC_LIKE:
+            return m.group(0)
+        return format_cell_key(current_sheet, col, int(row))
+
+    result = re.sub(
+        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
+        replace_local_cell,
+        result,
+    )
+
+    return result
+
+
+def normalize_excel_formula_with_name_state(
+    formula: str,
+    current_sheet: str,
+    *,
+    replacements: dict[str, str],
+    names_re: re.Pattern[str] | None,
+) -> str:
+    """Normalize *formula* using pre-built defined-name replacement state."""
+    if not formula or not formula.startswith("="):
+        return formula
+    result = _normalize_excel_formula_base(formula, current_sheet)
+    return _apply_named_range_replacements(result, replacements, names_re)
+
+
+def normalize_excel_formula(
+    formula: str,
+    current_sheet: str,
+    *,
+    named_ranges: dict[str, tuple[str, str]] | None = None,
+    named_range_ranges: dict[str, tuple[str, str, str]] | None = None,
+) -> str:
+    """Normalize a formula string (``=...``) for transpilation and parsing.
+
+    - Same-sheet refs (``A1``) become ``Sheet!A1`` using *current_sheet*.
+    - Resolves defined names when maps are provided.
+    - Strips ``$`` markers and qualifies range endpoints.
+    """
+    if not formula or not formula.startswith("="):
+        return formula
+    repl, names_re = build_named_range_replacement_state(named_ranges, named_range_ranges)
+    return normalize_excel_formula_with_name_state(
+        formula, current_sheet, replacements=repl, names_re=names_re
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedFormula:
+    """Result of preparing a cell formula for AST parsing."""
+
+    normalized_formula: str
+
+
+def prepare_formula(
+    formula: str,
+    current_sheet: str,
+    *,
+    named_ranges: dict[str, tuple[str, str]] | None = None,
+    named_range_ranges: dict[str, tuple[str, str, str]] | None = None,
+) -> PreparedFormula:
+    """Normalize *formula* for the cell on *current_sheet* and return a bundle."""
+    return PreparedFormula(
+        normalized_formula=normalize_excel_formula(
+            formula,
+            current_sheet,
+            named_ranges=named_ranges,
+            named_range_ranges=named_range_ranges,
+        )
+    )

--- a/excel_grapher/evaluator/__init__.py
+++ b/excel_grapher/evaluator/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .errors import ParseError
+from .errors import MissingNormalizedFormulaError, ParseError
 from .types import CellValue, ExcelRange, XlError
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -20,6 +20,7 @@ __all__ = [
     "ExcelRange",
     "XlError",
     "ParseError",
+    "MissingNormalizedFormulaError",
 ]
 
 

--- a/excel_grapher/evaluator/errors.py
+++ b/excel_grapher/evaluator/errors.py
@@ -12,3 +12,14 @@ class ParseError(FormulaExpanderError):
         super().__init__(f"Parse error: {message}. Formula: {formula!r}")
         self.formula = formula
         self.message = message
+
+
+class MissingNormalizedFormulaError(FormulaExpanderError):
+    """Raised when a formula cell lacks ``normalized_formula`` (graph invariant)."""
+
+    def __init__(self, cell_key: str) -> None:
+        super().__init__(
+            f"Cell {cell_key!r} has a formula but normalized_formula is missing; "
+            "rebuild the dependency graph or set normalized_formula."
+        )
+        self.cell_key = cell_key

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -19,7 +19,7 @@ from excel_grapher.grapher.blank_ranges import (
 )
 from excel_grapher.runtime.cache import EvalContext, xl_circular_reference, xl_iterative_compute
 
-from .errors import ParseError
+from .errors import MissingNormalizedFormulaError, ParseError
 from .functions import FUNCTIONS
 from .functions.info import xl_isblank
 from .helpers import (
@@ -242,9 +242,10 @@ class FormulaEvaluator:
                 self.on_cell_evaluated(norm, node.value)
             return node.value
 
-        formula = node.normalized_formula or node.formula
-        if not isinstance(formula, str):
-            raise ParseError(str(formula), "Formula is missing or not a string")
+        nf = node.normalized_formula
+        if nf is None or not isinstance(nf, str) or not nf.strip():
+            raise MissingNormalizedFormulaError(norm)
+        formula = nf.strip()
 
         self._call_stack.append(norm)
         try:

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -15,6 +15,7 @@ from excel_grapher.core.address_keys import (
     parse_address,
     quote_sheet_if_needed,
 )
+from excel_grapher.evaluator.errors import MissingNormalizedFormulaError
 from excel_grapher.evaluator.name_utils import (
     address_to_python_name,
     excel_func_to_python,
@@ -179,8 +180,10 @@ class CodeGenerator:
         if node is None or node.formula is None:
             return None
 
-        formula = node.normalized_formula or node.formula
-        ast = parse(formula)
+        nf = node.normalized_formula
+        if nf is None or not isinstance(nf, str) or not nf.strip():
+            raise MissingNormalizedFormulaError(normalized)
+        ast = parse(nf.strip())
         self._ast_cache[normalized] = ast
         return ast
 

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -5,7 +5,6 @@ import re
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
 
 import fastpyxl.utils.cell
 
@@ -13,6 +12,11 @@ from excel_grapher.core import address_keys as _address_keys
 from excel_grapher.core.address_keys import (
     format_cell_key,
     needs_quoting,
+)
+from excel_grapher.core.formula_normalization import (
+    build_named_range_replacement_state,
+    normalize_excel_formula,
+    normalize_excel_formula_with_name_state,
 )
 
 from .guard import And, Compare, GuardExpr, Literal, Not, Or
@@ -292,139 +296,12 @@ def normalize_formula(
 
     Returns the normalized formula string.
     """
-    if not formula or not formula.startswith("="):
-        return formula
-
-    if named_ranges is None:
-        named_ranges = {}
-    if named_range_ranges is None:
-        named_range_ranges = {}
-
-    result = formula
-
-    # 1) Normalize ranges first (quoted sheet, unquoted sheet, local)
-    # Pattern for 'Sheet Name'!$A$1:$B$2
-    def replace_quoted_range(m: re.Match) -> str:
-        sheet = m.group("sheet")
-        c1 = m.group("c1")
-        r1 = m.group("r1")
-        c2 = m.group("c2")
-        r2 = m.group("r2")
-        a = _format_ref(sheet, c1, int(r1))
-        b = _format_ref(sheet, c2, int(r2))
-        return f"{a}:{b}"
-
-    result = re.sub(
-        r"'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
-        replace_quoted_range,
-        result,
+    return normalize_excel_formula(
+        formula,
+        current_sheet,
+        named_ranges=named_ranges,
+        named_range_ranges=named_range_ranges,
     )
-
-    # Pattern for SheetName!$A$1:$B$2 (unquoted)
-    def replace_unquoted_range(m: re.Match) -> str:
-        sheet = m.group("sheet")
-        c1 = m.group("c1")
-        r1 = m.group("r1")
-        c2 = m.group("c2")
-        r2 = m.group("r2")
-        return f"{sheet}!{c1}{r1}:{sheet}!{c2}{r2}"
-
-    result = re.sub(
-        r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
-        replace_unquoted_range,
-        result,
-    )
-
-    # Pattern for local range A1:B2 -> Sheet!A1:Sheet!B2
-    def replace_local_range(m: re.Match) -> str:
-        c1 = m.group("c1")
-        r1 = m.group("r1")
-        c2 = m.group("c2")
-        r2 = m.group("r2")
-        ref1 = _format_ref(current_sheet, c1, int(r1))
-        ref2 = _format_ref(current_sheet, c2, int(r2))
-        return f"{ref1}:{ref2}"
-
-    result = re.sub(
-        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
-        replace_local_range,
-        result,
-    )
-
-    # 2) Normalize sheet-qualified single-cell refs (strip $)
-    # 'Sheet Name'!$A$1 -> 'Sheet Name'!A1
-    def replace_quoted_cell(m: re.Match) -> str:
-        sheet = m.group("sheet")
-        col = m.group("col")
-        row = m.group("row")
-        return _format_ref(sheet, col, int(row))
-
-    result = re.sub(
-        r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
-        replace_quoted_cell,
-        result,
-    )
-
-    # SheetName!$A$1 -> SheetName!A1
-    def replace_unquoted_cell(m: re.Match) -> str:
-        sheet = m.group("sheet")
-        col = m.group("col")
-        row = m.group("row")
-        return f"{sheet}!{col}{row}"
-
-    result = re.sub(
-        r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
-        replace_unquoted_cell,
-        result,
-    )
-
-    # 3) Normalize local single-cell refs: $A$1, A$1, $A1, A1 -> Sheet!A1
-    def replace_local_cell(m: re.Match) -> str:
-        col = m.group("col")
-        row = m.group("row")
-        # Skip function-like tokens
-        if col in _FUNC_LIKE:
-            return m.group(0)
-        return _format_ref(current_sheet, col, int(row))
-
-    result = re.sub(
-        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
-        replace_local_cell,
-        result,
-    )
-
-    # 4) Resolve named ranges (single cell and range-based)
-    #
-    # We first handle single-cell names, then range-based names. This order ensures
-    # that a cell-style name used inside a larger expression is still normalized
-    # before any potential range-style replacements.
-
-    # Cell-based names: Foo -> Sheet!A1
-    for name, (sheet, addr) in named_ranges.items():
-        col_match = re.match(r"^([A-Z]{1,3})(\d+)$", addr)
-        if not col_match:
-            continue
-        col = col_match.group(1)
-        row = int(col_match.group(2))
-        replacement = _format_ref(sheet, col, row)
-        result = re.sub(rf"\b{re.escape(name)}\b(?!\s*!)", replacement, result)
-
-    # Range-based names: Range1 -> Sheet!A1:Sheet!B2
-    # This is important so that downstream parsers (core.formula_ast) see only
-    # sheet-qualified ranges and never bare identifiers like NumRiskTable.
-    for name, (sheet, start_a1, end_a1) in named_range_ranges.items():
-        m_start = re.match(r"^([A-Z]{1,3})(\d+)$", start_a1)
-        m_end = re.match(r"^([A-Z]{1,3})(\d+)$", end_a1)
-        if not m_start or not m_end:
-            continue
-        start_col, start_row = m_start.group(1), int(m_start.group(2))
-        end_col, end_row = m_end.group(1), int(m_end.group(2))
-        start_ref = _format_ref(sheet, start_col, start_row)
-        end_ref = _format_ref(sheet, end_col, end_row)
-        replacement = f"{start_ref}:{end_ref}"
-        result = re.sub(rf"\b{re.escape(name)}\b(?!\s*!)", replacement, result)
-
-    return result
 
 
 class FormulaNormalizer:
@@ -452,37 +329,10 @@ class FormulaNormalizer:
         named_ranges: dict[str, tuple[str, str]] | None = None,
         named_range_ranges: dict[str, tuple[str, str, str]] | None = None,
     ) -> None:
-        named_ranges = named_ranges or {}
-        named_range_ranges = named_range_ranges or {}
-
-        # Pre-compute replacement strings for every resolvable name.
-        # Cell names and range names are kept in the same dict; cell names
-        # replace with a single ref, range names with "start:end".
-        self._replacements: dict[str, str] = {}
-
-        for name, (sheet, addr) in named_ranges.items():
-            col_match = re.match(r"^([A-Z]{1,3})(\d+)$", addr)
-            if col_match:
-                self._replacements[name] = _format_ref(
-                    sheet, col_match.group(1), int(col_match.group(2))
-                )
-
-        for name, (sheet, start_a1, end_a1) in named_range_ranges.items():
-            m_start = re.match(r"^([A-Z]{1,3})(\d+)$", start_a1)
-            m_end = re.match(r"^([A-Z]{1,3})(\d+)$", end_a1)
-            if m_start and m_end:
-                start_ref = _format_ref(sheet, m_start.group(1), int(m_start.group(2)))
-                end_ref = _format_ref(sheet, m_end.group(1), int(m_end.group(2)))
-                self._replacements[name] = f"{start_ref}:{end_ref}"
-
-        # Build a single alternation regex.  Sort longest-first so that a
-        # longer name (e.g. "RateAdj") is tried before any prefix ("Rate").
-        if self._replacements:
-            names = cast(list[str], sorted(self._replacements, key=len, reverse=True))
-            alt = "|".join(re.escape(n) for n in names)
-            self._names_re: re.Pattern[str] | None = re.compile(rf"\b(?:{alt})\b(?!\s*!)")
-        else:
-            self._names_re = None
+        self._replacements, self._names_re = build_named_range_replacement_state(
+            named_ranges,
+            named_range_ranges,
+        )
 
         # Per-instance cache: (formula, current_sheet) -> normalized string
         self._cache: dict[tuple[str, str], str] = {}
@@ -503,89 +353,12 @@ class FormulaNormalizer:
 
     def _compute(self, formula: str, current_sheet: str) -> str:
         """Run the full normalization pipeline (no caching)."""
-        result = formula
-
-        # 1) Normalize ranges first (quoted sheet, unquoted sheet, local)
-        def replace_quoted_range(m: re.Match) -> str:
-            sheet = m.group("sheet")
-            c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-            a = _format_ref(sheet, c1, int(r1))
-            b = _format_ref(sheet, c2, int(r2))
-            return f"{a}:{b}"
-
-        result = re.sub(
-            r"'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
-            replace_quoted_range,
-            result,
+        return normalize_excel_formula_with_name_state(
+            formula,
+            current_sheet,
+            replacements=self._replacements,
+            names_re=self._names_re,
         )
-
-        def replace_unquoted_range(m: re.Match) -> str:
-            sheet = m.group("sheet")
-            c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-            return f"{sheet}!{c1}{r1}:{sheet}!{c2}{r2}"
-
-        result = re.sub(
-            r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
-            replace_unquoted_range,
-            result,
-        )
-
-        def replace_local_range(m: re.Match) -> str:
-            c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-            ref1 = _format_ref(current_sheet, c1, int(r1))
-            ref2 = _format_ref(current_sheet, c2, int(r2))
-            return f"{ref1}:{ref2}"
-
-        result = re.sub(
-            r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
-            replace_local_range,
-            result,
-        )
-
-        # 2) Normalize sheet-qualified single-cell refs (strip $)
-        def replace_quoted_cell(m: re.Match) -> str:
-            sheet, col, row = m.group("sheet"), m.group("col"), m.group("row")
-            return _format_ref(sheet, col, int(row))
-
-        result = re.sub(
-            r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
-            replace_quoted_cell,
-            result,
-        )
-
-        def replace_unquoted_cell(m: re.Match) -> str:
-            sheet, col, row = m.group("sheet"), m.group("col"), m.group("row")
-            return f"{sheet}!{col}{row}"
-
-        result = re.sub(
-            r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
-            replace_unquoted_cell,
-            result,
-        )
-
-        # 3) Normalize local single-cell refs: $A$1, A$1, $A1, A1 -> Sheet!A1
-        def replace_local_cell(m: re.Match) -> str:
-            col, row = m.group("col"), m.group("row")
-            if col in _FUNC_LIKE:
-                return m.group(0)
-            return _format_ref(current_sheet, col, int(row))
-
-        result = re.sub(
-            r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
-            replace_local_cell,
-            result,
-        )
-
-        # 4) Resolve named ranges in a single pass via the pre-compiled alternation regex.
-        if self._names_re is not None:
-            replacements = self._replacements
-
-            def replace_name(m: re.Match) -> str:
-                return replacements.get(m.group(0), m.group(0))
-
-            result = self._names_re.sub(replace_name, result)
-
-        return result
 
 
 @functools.lru_cache(maxsize=4096)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from excel-grapher!")
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/unit/core/test_formula_normalization.py
+++ b/tests/unit/core/test_formula_normalization.py
@@ -1,0 +1,26 @@
+"""Tests for :mod:`excel_grapher.core.formula_normalization` (canonical normalization)."""
+
+from __future__ import annotations
+
+from excel_grapher.core.formula_normalization import (
+    normalize_excel_formula,
+    prepare_formula,
+)
+from excel_grapher.grapher.parser import FormulaNormalizer, normalize_formula
+
+
+def test_normalize_excel_formula_matches_grapher_normalize_formula() -> None:
+    f = "=Inputs!C16+CHOOSE(Inputs!$B$22,$B$9,0,0)*C10"
+    sheet = "Engine"
+    assert normalize_excel_formula(f, sheet) == normalize_formula(f, sheet)
+
+
+def test_prepare_formula_wraps_normalize_excel_formula() -> None:
+    p = prepare_formula("=A1", "S1")
+    assert p.normalized_formula == "=S1!A1"
+
+
+def test_formula_normalizer_uses_same_pipeline_as_core() -> None:
+    n = FormulaNormalizer()
+    f = "=SUM(A1:B2)+'Other'!C3"
+    assert n.normalize(f, "Here") == normalize_excel_formula(f, "Here")

--- a/tests/unit/evaluator/test_evaluator.py
+++ b/tests/unit/evaluator/test_evaluator.py
@@ -2,6 +2,7 @@ import pytest
 
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core.address_keys import parse_address
+from excel_grapher.evaluator.errors import MissingNormalizedFormulaError
 from excel_grapher.evaluator.evaluator import FormulaEvaluator
 from excel_grapher.evaluator.types import XlError
 from excel_grapher.runtime.cache import CircularReferenceWarning
@@ -29,6 +30,22 @@ def _make_graph(*nodes: Node) -> DependencyGraph:
     for node in nodes:
         graph.add_node(node)
     return graph
+
+
+def test_evaluator_raises_when_normalized_formula_missing() -> None:
+    graph = _make_graph(
+        Node(
+            sheet="S",
+            column="A",
+            row=1,
+            formula="=1+1",
+            normalized_formula=None,
+            value=None,
+            is_leaf=False,
+        )
+    )
+    with FormulaEvaluator(graph) as ev, pytest.raises(MissingNormalizedFormulaError):
+        ev.evaluate("S!A1")
 
 
 def test_evaluator_returns_values_for_non_formula_cells() -> None:

--- a/tests/unit/grapher/test_normalized_formula.py
+++ b/tests/unit/grapher/test_normalized_formula.py
@@ -1,5 +1,8 @@
 """
 Tests for Node.normalized_formula — the transpiler-friendly form of the formula.
+
+Includes dependency extraction and evaluator parity for mixed-sheet formulas
+(GitHub issue #160: bare refs must bind to the formula cell's sheet).
 """
 
 from pathlib import Path
@@ -7,7 +10,7 @@ from pathlib import Path
 import fastpyxl
 from fastpyxl.workbook.defined_name import DefinedName
 
-from excel_grapher import create_dependency_graph
+from excel_grapher import FormulaEvaluator, create_dependency_graph
 
 
 def test_normalized_formula_prefixes_same_sheet_refs(tmp_path: Path) -> None:
@@ -122,3 +125,27 @@ def test_normalized_formula_is_none_for_leaves(tmp_path: Path) -> None:
     assert leaf.is_leaf
     assert leaf.formula is None
     assert leaf.normalized_formula is None
+
+
+def test_mixed_sheet_formula_bare_ref_binds_to_formula_sheet_issue_160(tmp_path: Path) -> None:
+    """Bare ``C10`` after cross-sheet refs + CHOOSE must be Engine!C10, not Inputs!C10."""
+    excel_path = tmp_path / "mixed_sheet_choose.xlsx"
+    wb = fastpyxl.Workbook()
+    engine = wb.active
+    engine.title = "Engine"
+    inputs = wb.create_sheet("Inputs")
+    inputs["C16"].value = 100
+    inputs["B22"].value = 1
+    engine["B9"].value = 2
+    engine["C10"].value = 50
+    engine["C14"].value = "=Inputs!C16+CHOOSE(Inputs!$B$22,$B$9,0,0)*C10"
+    wb.save(excel_path)
+    wb.close()
+
+    graph = create_dependency_graph(excel_path, ["Engine!C14"], load_values=True)
+    deps = sorted(graph.get_dependencies("Engine!C14"))
+    assert "Engine!C10" in deps
+    assert "Inputs!C10" not in deps
+
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate("Engine!C14") == 200.0

--- a/tests/utils/excel_workbook_parity.py
+++ b/tests/utils/excel_workbook_parity.py
@@ -79,9 +79,12 @@ def compare_evaluator_to_excel_cache(
 
     def _formula_for(addr: str) -> str | None:
         node = graph.get_node(addr)
-        if node is None:
+        if node is None or node.formula is None:
             return None
-        return node.normalized_formula or node.formula
+        nf = node.normalized_formula
+        if isinstance(nf, str) and nf.strip():
+            return nf.strip()
+        return node.formula
 
     with FormulaEvaluator(graph) as ev:
         for addr in addresses:


### PR DESCRIPTION
## Summary

Centralizes Excel formula normalization in `excel_grapher.core.formula_normalization` so the grapher, evaluator, and codegen share one implementation. `FormulaNormalizer` / `normalize_formula` delegate to that module.

`FormulaEvaluator` and `CodeGenerator` no longer fall back to raw `node.formula` when `normalized_formula` is missing; they raise `MissingNormalizedFormulaError` so invalid graph state fails fast.

## Issue

Fixes / closes behavior described in https://github.com/Teal-Insights/excel-grapher/issues/160 (bare cell references after cross-sheet `CHOOSE` must resolve on the formula cell’s sheet). Regression lives in `tests/unit/grapher/test_normalized_formula.py` as `test_mixed_sheet_formula_bare_ref_binds_to_formula_sheet_issue_160`.

## Notes

- Staleness checks (recomputed vs stored `normalized_formula`) remain out of scope; see discussion on https://github.com/Teal-Insights/excel-grapher/issues/121.
- `tests/utils/excel_workbook_parity.py` only adjusts how a display string is chosen for mismatch lines.

## Testing

`uv run pytest` (full suite) was run successfully on this branch.

Made with [Cursor](https://cursor.com)