### PR TITLE
Fix cross-sheet OFFSET dynamic dependencies

### DIFF
--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -3541,16 +3541,7 @@ def _infer_single_indirect_call(
 
         # Derive per-call bounds so sheet-qualified references are not rejected.
         sheet_for_bounds = _sheet_from_indirect_text(text_value, current_sheet=current_sheet)
-        if bounds is None:
-            local_bounds = GlobalWorkbookBounds(sheet=sheet_for_bounds)
-        else:
-            local_bounds = GlobalWorkbookBounds(
-                sheet=sheet_for_bounds,
-                min_row=bounds.min_row,
-                max_row=bounds.max_row,
-                min_col=bounds.min_col,
-                max_col=bounds.max_col,
-            )
+        local_bounds = _bounds_for_sheet(bounds, sheet=sheet_for_bounds)
 
         result = indirect_text_to_range(text_value, a1_flag, bounds=local_bounds)
         if isinstance(result, ExcelRange):

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -371,6 +371,22 @@ class GlobalWorkbookBounds(WorkbookBoundsProtocol):
     max_col: int = 16_384  # Excel column limit
 
 
+def _bounds_for_sheet(
+    bounds: WorkbookBoundsProtocol | None,
+    *,
+    sheet: str,
+) -> WorkbookBoundsProtocol:
+    if bounds is None:
+        return GlobalWorkbookBounds(sheet=sheet)
+    return GlobalWorkbookBounds(
+        sheet=sheet,
+        min_row=bounds.min_row,
+        max_row=bounds.max_row,
+        min_col=bounds.min_col,
+        max_col=bounds.max_col,
+    )
+
+
 def _sheet_from_addr(addr: str) -> str:
     """Return sheet part of address (e.g. 'Sheet1!A1' -> 'Sheet1')."""
     if "!" not in addr:
@@ -1068,7 +1084,7 @@ def _infer_single_offset_call(
         assert rows_list is not None
         assert cols_list is not None
         for base_range in base_ranges:
-            base_bounds = GlobalWorkbookBounds(sheet=base_range.sheet) if bounds is None else bounds
+            base_bounds = _bounds_for_sheet(bounds, sheet=base_range.sheet)
             for rv in rows_list:
                 for cv in cols_list:
                     for hv in height_vals:
@@ -1101,7 +1117,7 @@ def _infer_single_offset_call(
     domains = _build_domains(leaf_addrs, cell_type_env, limits)
 
     for base_range in base_ranges:
-        base_bounds = GlobalWorkbookBounds(sheet=base_range.sheet) if bounds is None else bounds
+        base_bounds = _bounds_for_sheet(bounds, sheet=base_range.sheet)
 
         for assignment in _enumerate_assignments(domains.values(), limits):
             addr_to_value = dict(zip(domains.keys(), assignment, strict=False))

--- a/tests/integration/grapher/test_dependency_graph_build.py
+++ b/tests/integration/grapher/test_dependency_graph_build.py
@@ -7,13 +7,15 @@ and target selection produce the graph topology library users depend on.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Annotated, Literal
 
 import fastpyxl
 import pytest
 import xlsxwriter
 from fastpyxl.worksheet.formula import ArrayFormula
 
-from excel_grapher import create_dependency_graph
+from excel_grapher import DynamicRefConfig, create_dependency_graph
+from excel_grapher.core.cell_types import RealBetween
 
 
 def _fixture_path(name: str) -> Path:
@@ -349,3 +351,45 @@ def test_address_like_sheet_names_do_not_add_same_sheet_alias_edges_issue_155(
         f"formula={formula!r} expected={sorted(expected)!r} "
         f"actual={sorted(graph.get_dependencies(target))!r}"
     )
+
+
+def test_cross_sheet_offset_dynamic_dependencies_include_possible_columns_issue_162(
+    tmp_path: Path,
+) -> None:
+    """Regression for gh #162: cross-sheet OFFSET should include all constrained targets."""
+    excel_path = tmp_path / "issue_162_cross_sheet_offset.xlsx"
+    wb = fastpyxl.Workbook()
+    inputs = wb.active
+    assert inputs is not None
+    inputs.title = "Inputs"
+    engine = wb.create_sheet("Engine")
+
+    inputs["B22"] = 1
+    inputs["B26"] = 10
+    inputs["C26"] = 20
+    inputs["D26"] = 30
+    engine["B9"] = "=OFFSET(Inputs!$B$26,0,Inputs!$B$22-1)"
+
+    wb.save(excel_path)
+    wb.close()
+
+    constraints = {
+        "Inputs!B22": Literal[1, 2, 3],
+        "Inputs!B26": Annotated[float, RealBetween(-30.0, 30.0)],
+        "Inputs!C26": Annotated[float, RealBetween(-30.0, 30.0)],
+        "Inputs!D26": Annotated[float, RealBetween(-30.0, 30.0)],
+    }
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Engine!B9"],
+        load_values=True,
+        dynamic_refs=DynamicRefConfig.from_constraints(constraints, {}),
+    )
+
+    assert set(graph.leaf_keys()) >= {
+        "Inputs!B22",
+        "Inputs!B26",
+        "Inputs!C26",
+        "Inputs!D26",
+    }


### PR DESCRIPTION
## Summary
- Fix dynamic OFFSET inference to use bounds scoped to the base range sheet so cross-sheet targets are not dropped.
- Add integration regression coverage for issue #162 (`OFFSET(Inputs!$B$26,0,Inputs!$B$22-1)` with constrained offsets).
- Preserve existing issue #154/#155 regression coverage while adding the new scenario.

## Test plan
- [x] `uv run pytest tests/integration/grapher/test_dependency_graph_build.py -q`
- [x] `uv run pytest -q`

Made with [Cursor](https://cursor.com)