### PR TITLE
Add target-aware nodes and codegen target defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ node = graph.get_node("Sheet1!A10")
 print(node.formula)             # Original formula
 print(node.normalized_formula)  # Sheet-qualified for transpilation
 print(node.value)               # Cached value from Excel
+print(node.is_target)           # True if this node came from original targets
 
 # Iterate over formula cells
 for key, node in graph.formula_nodes():
@@ -236,17 +237,19 @@ for key, node in graph.leaf_node_items():
 # Get sorted keys
 formula_keys = graph.formula_keys()
 leaf_keys = graph.leaf_keys()
+target_keys = graph.target_keys()
 ```
 
 #### `DependencyGraph` filter methods
 
-| Method              | Returns                               | Description                           |
-|---------------------|----------------------------------------|---------------------------------------|
-| `get_node(key)`     | `Node \| None`                       | O(1) lookup by cell address           |
-| `formula_nodes()`   | `Iterator[tuple[NodeKey, Node]]`     | Cells with formulas                   |
-| `leaf_node_items()` | `Iterator[tuple[NodeKey, Node]]`     | Leaf cells (no cell dependencies)     |
-| `formula_keys()`    | `list[NodeKey]`                      | Sorted keys for formula cells         |
-| `leaf_keys()`       | `list[NodeKey]`                      | Sorted keys for leaf cells            |
+| Method              | Returns                                 | Description                           |
+|---------------------|------------------------------------------|---------------------------------------|
+| `get_node(key)`     | `NodeView \| None`                       | O(1) immutable lookup by cell address |
+| `formula_nodes()`   | `Iterator[tuple[NodeKey, Node]]`         | Cells with formulas                   |
+| `leaf_node_items()` | `Iterator[tuple[NodeKey, Node]]`         | Leaf cells (no cell dependencies)     |
+| `formula_keys()`    | `list[NodeKey]`                          | Sorted keys for formula cells         |
+| `leaf_keys()`       | `list[NodeKey]`                          | Sorted keys for leaf cells            |
+| `target_keys()`     | `list[NodeKey]`                          | Sorted keys marked as original targets |
 
 #### `Node` fields
 
@@ -256,6 +259,7 @@ leaf_keys = graph.leaf_keys()
 | `normalized_formula` | `str \| None` | Sheet-qualified formula for transpilation |
 | `value`              | `Any`         | Cached or hardcoded value               |
 | `is_leaf`            | `bool`        | True if the node has no cell dependencies  |
+| `is_target`          | `bool`        | True if the node was one of the original graph targets |
 | `sheet`              | `str`         | Sheet name                              |
 | `column`             | `str`         | Column letter                           |
 | `row`                | `int`         | Row number                              |
@@ -633,6 +637,15 @@ from excel_grapher.exporter import CodeGenerator
 code = CodeGenerator(graph).generate(targets)
 print("\n".join(code.splitlines()[:120]))
 ```
+
+When graph nodes are target-marked (`Node.is_target=True`), `generate()` and `generate_modules()` can infer export targets directly from the graph:
+
+```python
+with CodeGenerator(graph) as gen:
+    code = gen.generate()  # defaults to graph.target_keys()
+```
+
+If neither explicit targets nor target-marked nodes are available, code generation raises a `ValueError`.
 
 You can also emit named entrypoints by passing a mapping of names to target lists:
 

--- a/examples/micro_workbook/example_cases.md
+++ b/examples/micro_workbook/example_cases.md
@@ -55,6 +55,7 @@ DependencyGraph(_nodes={   'Sheet1!B1': Node(sheet='Sheet1',
                                              normalized_formula='=1+1',
                                              value=None,
                                              is_leaf=True,
+                                             is_target=True,
                                              metadata={})},
                 _edges={'Sheet1!B1': set()},
                 _reverse_edges={'Sheet1!B1': set()},
@@ -146,8 +147,9 @@ emulator, we can transpile the graph to standalone Python code using the
 `linear_dependency.py` in the current folder.
 
 ``` python
-code = CodeGenerator(graph).generate(["Sheet1!C2"])
-with open("linear_dependency.py", "w") as f:
+with CodeGenerator(graph) as gen:
+    code = gen.generate()
+with open("linear_dependency.py", "w", encoding="utf-8") as f:
     f.write(code)
 ```
 
@@ -361,8 +363,9 @@ Similarly, if we generate and run standalone Python code with
 ``` python
 import sys
 
-code = CodeGenerator(graph).generate(["Sheet1!C6"])
-with open("must_cycle.py", "w") as f:
+with CodeGenerator(graph) as gen:
+    code = gen.generate()
+with open("must_cycle.py", "w", encoding="utf-8") as f:
     f.write(code)
 
 sys.path.append(".")
@@ -376,9 +379,6 @@ print_text(str(result["Sheet1!C6"]))
 2.0
 ```
 
-    C:\Users\chris\Software\excel-grapher\examples\micro_workbook\must_cycle.py:284: CircularReferenceWarning: Circular reference detected; returning 0 (iterative calculation is disabled).
-      return xl_circular_reference()
-
 For a detailed report on cycles in the graph, we can use the
 `cycle_report` method:
 
@@ -390,9 +390,9 @@ print_text(pformat(report, indent=4, width=100))
 ``` text
 CycleReport(has_must_cycles=True,
             has_may_cycles=False,
-            must_cycles=[{'Sheet1!B6', 'Sheet1!C6'}],
+            must_cycles=[{'Sheet1!C6', 'Sheet1!B6'}],
             may_cycles=[],
-            example_must_cycle_path=['Sheet1!B6', 'Sheet1!C6', 'Sheet1!B6'],
+            example_must_cycle_path=['Sheet1!C6', 'Sheet1!B6', 'Sheet1!C6'],
             example_may_cycle_path=None)
 ```
 

--- a/examples/micro_workbook/example_cases.qmd
+++ b/examples/micro_workbook/example_cases.qmd
@@ -89,8 +89,9 @@ Under the hood, `FormulaEvaluator` parses the graph's Excel formulas and transla
 Instead of running the graph using the `FormulaEvaluator` Excel emulator, we can transpile the graph to standalone Python code using the `CodeGenerator` class. We'll write the code to a file called `linear_dependency.py` in the current folder.
 
 ```{python}
-code = CodeGenerator(graph).generate(["Sheet1!C2"])
-with open("linear_dependency.py", "w") as f:
+with CodeGenerator(graph) as gen:
+    code = gen.generate()
+with open("linear_dependency.py", "w", encoding="utf-8") as f:
     f.write(code)
 ```
 
@@ -195,8 +196,9 @@ Similarly, if we generate and run standalone Python code with `CodeGenerator`, w
 ```{python}
 import sys
 
-code = CodeGenerator(graph).generate(["Sheet1!C6"])
-with open("must_cycle.py", "w") as f:
+with CodeGenerator(graph) as gen:
+    code = gen.generate()
+with open("must_cycle.py", "w", encoding="utf-8") as f:
     f.write(code)
 
 sys.path.append(".")

--- a/examples/micro_workbook/linear_dependency.py
+++ b/examples/micro_workbook/linear_dependency.py
@@ -99,49 +99,6 @@ def _escape_sheet_for_formula(sheet: str) -> str:
     return sheet.replace("'", "''")
 
 
-def _parse_sheet_address(address: str) -> tuple[str, str] | None:
-    if address.startswith("'"):
-        i = 1
-        while i < len(address):
-            if address[i] == "'":
-                if i + 1 < len(address) and address[i + 1] == "'":
-                    i += 2
-                    continue
-                break
-            i += 1
-        sheet = address[: i + 1]
-        rest = address[i + 1 :]
-        if rest.startswith("!"):
-            return sheet, rest[1:]
-        return None
-
-    if "!" in address:
-        sheet, cell = address.rsplit("!", 1)
-        return sheet, cell
-
-    return None
-
-
-def _parse_range_address(address: str) -> tuple[str, str, str] | XlError:
-    if ":" not in address:
-        return XlError.VALUE
-    start_text, end_text = address.split(":", 1)
-    start = _parse_sheet_address(start_text)
-    if start is None:
-        return XlError.VALUE
-    sheet, start_cell = start
-    if "!" in end_text:
-        end = _parse_sheet_address(end_text)
-        if end is None:
-            return XlError.VALUE
-        end_sheet, end_cell = end
-        if end_sheet != sheet:
-            return XlError.VALUE
-    else:
-        end_cell = end_text
-    return sheet, start_cell, end_cell
-
-
 def needs_quoting(sheet: str) -> bool:
     """Return True if a sheet name must be wrapped in single quotes in a formula."""
     return " " in sheet or "-" in sheet or "'" in sheet
@@ -189,6 +146,61 @@ CellValue: TypeAlias = float | int | str | bool | XlError | ExcelRange | np.ndar
 def coerce_inputs_dict(values: Mapping[str, object]) -> dict[str, CellValue]:
     """Widen inferred default-input dicts to ``dict[str, CellValue]`` for :class:`EvalContext`."""
     return cast(dict[str, CellValue], dict(values))
+
+
+def split_sheet_qualified_address(address: str) -> tuple[str, str] | None:
+    """Split ``sheet!coord`` into ``(sheet_name, coord)``.
+
+    Handles quoted sheet names, including Excel's doubled-single-quote escape
+    (``'O''Neil'!A1`` → sheet ``O'Neil``).
+
+    Returns ``None`` when *address* has no sheet qualifier (plain ``A1``).
+    """
+    if address.startswith("'"):
+        i = 1
+        while i < len(address):
+            if address[i] == "'":
+                if i + 1 < len(address) and address[i + 1] == "'":
+                    i += 2
+                    continue
+                break
+            i += 1
+        if i >= len(address):
+            return None
+        sheet = address[1:i].replace("''", "'")
+        rest = address[i + 1 :]
+        if not rest.startswith("!"):
+            return None
+        return sheet, rest[1:]
+
+    if "!" not in address:
+        return None
+    sheet, cell = address.rsplit("!", 1)
+    return sheet, cell
+
+
+def _parse_sheet_address(address: str) -> tuple[str, str] | None:
+    return split_sheet_qualified_address(address)
+
+
+def _parse_range_address(address: str) -> tuple[str, str, str] | XlError:
+    if ":" not in address:
+        return XlError.VALUE
+    start_text, end_text = address.split(":", 1)
+    start = _parse_sheet_address(start_text)
+    if start is None:
+        return XlError.VALUE
+    sheet, start_cell = start
+    if "!" in end_text:
+        end = _parse_sheet_address(end_text)
+        if end is None:
+            return XlError.VALUE
+        end_sheet, end_cell = end
+        if end_sheet != sheet:
+            return XlError.VALUE
+    else:
+        end_cell = end_text
+    return sheet, start_cell, end_cell
 
 
 def to_number(value: CellValue) -> float | XlError:

--- a/examples/micro_workbook/must_cycle.py
+++ b/examples/micro_workbook/must_cycle.py
@@ -99,49 +99,6 @@ def _escape_sheet_for_formula(sheet: str) -> str:
     return sheet.replace("'", "''")
 
 
-def _parse_sheet_address(address: str) -> tuple[str, str] | None:
-    if address.startswith("'"):
-        i = 1
-        while i < len(address):
-            if address[i] == "'":
-                if i + 1 < len(address) and address[i + 1] == "'":
-                    i += 2
-                    continue
-                break
-            i += 1
-        sheet = address[: i + 1]
-        rest = address[i + 1 :]
-        if rest.startswith("!"):
-            return sheet, rest[1:]
-        return None
-
-    if "!" in address:
-        sheet, cell = address.rsplit("!", 1)
-        return sheet, cell
-
-    return None
-
-
-def _parse_range_address(address: str) -> tuple[str, str, str] | XlError:
-    if ":" not in address:
-        return XlError.VALUE
-    start_text, end_text = address.split(":", 1)
-    start = _parse_sheet_address(start_text)
-    if start is None:
-        return XlError.VALUE
-    sheet, start_cell = start
-    if "!" in end_text:
-        end = _parse_sheet_address(end_text)
-        if end is None:
-            return XlError.VALUE
-        end_sheet, end_cell = end
-        if end_sheet != sheet:
-            return XlError.VALUE
-    else:
-        end_cell = end_text
-    return sheet, start_cell, end_cell
-
-
 def needs_quoting(sheet: str) -> bool:
     """Return True if a sheet name must be wrapped in single quotes in a formula."""
     return " " in sheet or "-" in sheet or "'" in sheet
@@ -189,6 +146,61 @@ CellValue: TypeAlias = float | int | str | bool | XlError | ExcelRange | np.ndar
 def coerce_inputs_dict(values: Mapping[str, object]) -> dict[str, CellValue]:
     """Widen inferred default-input dicts to ``dict[str, CellValue]`` for :class:`EvalContext`."""
     return cast(dict[str, CellValue], dict(values))
+
+
+def split_sheet_qualified_address(address: str) -> tuple[str, str] | None:
+    """Split ``sheet!coord`` into ``(sheet_name, coord)``.
+
+    Handles quoted sheet names, including Excel's doubled-single-quote escape
+    (``'O''Neil'!A1`` → sheet ``O'Neil``).
+
+    Returns ``None`` when *address* has no sheet qualifier (plain ``A1``).
+    """
+    if address.startswith("'"):
+        i = 1
+        while i < len(address):
+            if address[i] == "'":
+                if i + 1 < len(address) and address[i + 1] == "'":
+                    i += 2
+                    continue
+                break
+            i += 1
+        if i >= len(address):
+            return None
+        sheet = address[1:i].replace("''", "'")
+        rest = address[i + 1 :]
+        if not rest.startswith("!"):
+            return None
+        return sheet, rest[1:]
+
+    if "!" not in address:
+        return None
+    sheet, cell = address.rsplit("!", 1)
+    return sheet, cell
+
+
+def _parse_sheet_address(address: str) -> tuple[str, str] | None:
+    return split_sheet_qualified_address(address)
+
+
+def _parse_range_address(address: str) -> tuple[str, str, str] | XlError:
+    if ":" not in address:
+        return XlError.VALUE
+    start_text, end_text = address.split(":", 1)
+    start = _parse_sheet_address(start_text)
+    if start is None:
+        return XlError.VALUE
+    sheet, start_cell = start
+    if "!" in end_text:
+        end = _parse_sheet_address(end_text)
+        if end is None:
+            return XlError.VALUE
+        end_sheet, end_cell = end
+        if end_sheet != sheet:
+            return XlError.VALUE
+    else:
+        end_cell = end_text
+    return sheet, start_cell, end_cell
 
 
 def to_number(value: CellValue) -> float | XlError:

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -133,6 +133,23 @@ class CodeGenerator:
         self._used_graph_closure: bool = False
         self._formula_cell_address: str | None = None
 
+    def __enter__(self) -> CodeGenerator:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._reset_transient_state()
+        return None
+
+    def _reset_transient_state(self) -> None:
+        self._emitted.clear()
+        self._needs_offset_runtime = False
+        self._needs_index_ref_runtime = False
+        self._offset_runtime_sheets.clear()
+        self._temp_var_counter = 0
+        self._ast_cache.clear()
+        self._used_graph_closure = False
+        self._formula_cell_address = None
+
     @staticmethod
     def _normalize_entrypoint_name(name: str) -> str:
         return CodeGenerator._normalize_package_name(name)
@@ -1505,7 +1522,7 @@ class CodeGenerator:
 
     def generate(
         self,
-        targets: list[str],
+        targets: Sequence[str] | None = None,
         *,
         entrypoints: Mapping[str, Sequence[str]] | None = None,
         constant_types: set[str] | None = None,
@@ -1528,7 +1545,7 @@ class CodeGenerator:
             Standalone Python source code as a string.
         """
         normalized_entrypoints = self._normalize_entrypoints(entrypoints)
-        normalized_targets = [normalize_address(t) for t in targets]
+        normalized_targets = self._resolve_targets(targets)
         entrypoint_targets: list[str] = []
         seen_targets: set[str] = set()
         for entrypoint_list in normalized_entrypoints.values():
@@ -1665,7 +1682,7 @@ class CodeGenerator:
 
     def generate_modules(
         self,
-        targets: list[str],
+        targets: Sequence[str] | None = None,
         *,
         entrypoints: Mapping[str, Sequence[str]] | None = None,
         package_name: str = "exported",
@@ -1690,7 +1707,7 @@ class CodeGenerator:
         """
         pkg = self._normalize_package_name(package_name)
         normalized_entrypoints = self._normalize_entrypoints(entrypoints)
-        normalized_targets = [normalize_address(t) for t in targets]
+        normalized_targets = self._resolve_targets(targets)
         entrypoint_targets: list[str] = []
         seen_targets: set[str] = set()
         for entrypoint_list in normalized_entrypoints.values():
@@ -1915,11 +1932,7 @@ class CodeGenerator:
         blank_ranges: Sequence[str] | None = None,
     ) -> GenerationParts:
         """Generate shared intermediate artifacts for single-file and modular exports."""
-        # Reset state for this generation
-        self._needs_offset_runtime = False
-        self._offset_runtime_sheets.clear()
-        self._ast_cache.clear()
-        self._used_graph_closure = False
+        self._reset_transient_state()
 
         blank_rects = normalize_blank_range_specs(blank_ranges)
 
@@ -2041,6 +2054,19 @@ class CodeGenerator:
             "used_xl_functions": frozenset(used_xl_functions),
             "blank_rects": blank_rects,
         }
+
+    def _resolve_targets(self, targets: Sequence[str] | None) -> list[str]:
+        if targets is not None:
+            return [normalize_address(t) for t in targets]
+        target_keys = getattr(self.graph, "target_keys", None)
+        inferred_targets: list[str] = []
+        if callable(target_keys):
+            inferred_targets = list(target_keys())
+        if not inferred_targets:
+            raise ValueError(
+                "No export targets were provided and the graph has no target-marked nodes."
+            )
+        return [normalize_address(t) for t in inferred_targets]
 
     def _collect_all_cells(self, targets: list[str]) -> list[str]:
         """Collect an ordered list of addresses to emit for the given targets.

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -1149,6 +1149,7 @@ def create_dependency_graph(
         named_range_ranges=named_range_ranges,
         max_range_cells=max_range_cells,
     )
+    target_root_keys = {format_key(sh, a1) for sh, a1 in target_roots}
     for sh, a1 in target_roots:
         q.append((sh, a1, 0))
 
@@ -1224,6 +1225,7 @@ def create_dependency_graph(
                 normalized_formula=normalized,
                 value=value,
                 is_leaf=is_leaf,
+                is_target=key in target_root_keys,
             )
             graph.add_node(node)
 

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -250,6 +250,10 @@ class DependencyGraph:
         """Return sorted list of keys for nodes with no dependency edges (leaves)."""
         return sorted(k for k, node in self._nodes.items() if node.is_leaf)
 
+    def target_keys(self) -> list[NodeKey]:
+        """Return sorted list of keys marked as original build targets."""
+        return sorted(k for k, node in self._nodes.items() if node.is_target)
+
     def roots(self) -> Iterator[NodeKey]:
         for key in self._nodes:
             if not self._reverse_edges.get(key):

--- a/excel_grapher/grapher/node.py
+++ b/excel_grapher/grapher/node.py
@@ -27,6 +27,7 @@ class Node:
     normalized_formula: str | None
     value: Any
     is_leaf: bool
+    is_target: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -59,6 +60,7 @@ class NodeView:
     normalized_formula: str | None
     value: Any
     is_leaf: bool
+    is_target: bool
     metadata: Mapping[str, Any]
 
     @property
@@ -84,5 +86,6 @@ def node_to_view(node: Node) -> NodeView:
         normalized_formula=node.normalized_formula,
         value=node.value,
         is_leaf=node.is_leaf,
+        is_target=node.is_target,
         metadata=MappingProxyType(dict(node.metadata)),
     )

--- a/tests/integration/exporter/test_codegen_export_no_diagnostics.py
+++ b/tests/integration/exporter/test_codegen_export_no_diagnostics.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core.address_keys import parse_address
 from excel_grapher.exporter.codegen import CodeGenerator
@@ -74,5 +76,54 @@ def test_codegen_export_has_no_ty_or_ruff_diagnostics(tmp_path: Path) -> None:
         ruff = _run(["uv", "run", "ruff", "check", str(export_file)], cwd=repo_root)
         assert ruff.returncode == 0, f"ruff failed after --fix:\n{ruff.stdout}\n{ruff.stderr}"
         assert ruff.stderr.strip() == ""
+    finally:
+        export_file.unlink(missing_ok=True)
+
+
+@pytest.mark.xfail(
+    reason="CodeGenerator import ordering is not Ruff-clean without --fix (I001).",
+    strict=False,
+)
+def test_codegen_export_is_ruff_clean_without_fix(tmp_path: Path) -> None:
+    """Track raw generated-file Ruff hygiene without auto-fixes."""
+    repo_root = Path(__file__).resolve().parents[3]
+
+    graph = _make_graph(_make_node("S!A1", None, 1.0))
+    code = CodeGenerator(graph).generate(["S!A1"])
+
+    export_file = tmp_path / "exported_codegen.py"
+    export_file.write_text(code, encoding="utf-8")
+
+    try:
+        ruff = _run(["uv", "run", "ruff", "check", str(export_file)], cwd=repo_root)
+        assert ruff.returncode == 0, f"ruff failed:\n{ruff.stdout}\n{ruff.stderr}"
+        assert ruff.stderr.strip() == ""
+    finally:
+        export_file.unlink(missing_ok=True)
+
+
+@pytest.mark.xfail(
+    reason="CodeGenerator output is not Ruff-format-clean without rewriting imports.",
+    strict=False,
+)
+def test_codegen_export_is_ruff_format_clean_without_fix(tmp_path: Path) -> None:
+    """Track whether raw generated code is already `ruff format --check` clean."""
+    repo_root = Path(__file__).resolve().parents[3]
+
+    graph = _make_graph(_make_node("S!A1", None, 1.0))
+    code = CodeGenerator(graph).generate(["S!A1"])
+
+    export_file = tmp_path / "exported_codegen.py"
+    export_file.write_text(code, encoding="utf-8")
+
+    try:
+        ruff_format = _run(
+            ["uv", "run", "ruff", "format", "--check", str(export_file)],
+            cwd=repo_root,
+        )
+        assert ruff_format.returncode == 0, (
+            f"ruff format --check failed:\n{ruff_format.stdout}\n{ruff_format.stderr}"
+        )
+        assert ruff_format.stderr.strip() == ""
     finally:
         export_file.unlink(missing_ok=True)

--- a/tests/integration/grapher/test_dependency_graph_targets.py
+++ b/tests/integration/grapher/test_dependency_graph_targets.py
@@ -136,6 +136,21 @@ def test_targets_accept_mixed_cells_ranges_and_named_ranges(
         assert key in graph, f"expected expanded root {key!r} in graph"
 
 
+def test_target_nodes_are_marked_with_is_target_metadata(tmp_path: Path) -> None:
+    """Expanded target roots should be marked target-aware on graph nodes."""
+    excel_path = tmp_path / "target_metadata.xlsx"
+    _build_grid_workbook(excel_path)
+
+    graph = create_dependency_graph(excel_path, ["Sheet1!C2"], load_values=False)
+    target_node = graph.get_node("Sheet1!C2")
+    assert target_node is not None
+    assert target_node.is_target is True
+
+    dependency_only = graph.get_node("Sheet1!B2")
+    assert dependency_only is not None
+    assert dependency_only.is_target is False
+
+
 def test_targets_deduplicate_overlaps(tmp_path: Path) -> None:
     """Overlapping target inputs do not duplicate nodes."""
     excel_path = tmp_path / "overlap_targets.xlsx"

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -409,6 +409,35 @@ class TestEmitCell:
 class TestGenerate:
     """Tests for generate() method."""
 
+    def test_generate_defaults_to_graph_targets(self):
+        """generate() should use graph target metadata when targets are omitted."""
+        graph = _make_graph(
+            _make_node("Sheet1!A1", None, 10.0),
+            _make_node("Sheet1!B1", "=Sheet1!A1*2", None),
+            _make_node("Sheet1!C1", "=Sheet1!A1+1", None),
+        )
+        b1 = graph._get_internal_node("Sheet1!B1")
+        c1 = graph._get_internal_node("Sheet1!C1")
+        assert b1 is not None
+        assert c1 is not None
+        b1.is_target = True
+        c1.is_target = False
+        graph.add_edge("Sheet1!B1", "Sheet1!A1")
+        graph.add_edge("Sheet1!C1", "Sheet1!A1")
+
+        code = CodeGenerator(graph).generate()
+
+        assert "TARGETS = {" in code
+        assert "    'Sheet1!B1': xl_cell," in code
+        assert "    'Sheet1!C1': xl_cell," not in code
+
+    def test_generate_without_targets_raises_when_graph_has_no_targets(self):
+        """generate() without explicit targets should fail on targetless graphs."""
+        graph = _make_graph(_make_node("Sheet1!A1", None, 100.0))
+
+        with pytest.raises(ValueError, match="No export targets were provided"):
+            _ = CodeGenerator(graph).generate()
+
     def test_generate_caches_parsed_asts(self, monkeypatch):
         """generate() should not repeatedly parse the same cell formulas."""
         graph = _make_graph(
@@ -435,6 +464,26 @@ class TestGenerate:
 
         # Only formula cells should be parsed, and each should be parsed once.
         assert len(calls) == 2
+
+
+class TestCodeGeneratorContextManager:
+    def test_context_manager_clears_transient_codegen_state(self):
+        graph = _make_graph(
+            _make_node("Sheet1!A1", None, 10.0),
+            _make_node("Sheet1!B1", "=Sheet1!A1*2", None),
+        )
+        graph.add_edge("Sheet1!B1", "Sheet1!A1")
+        gen = CodeGenerator(graph)
+
+        with gen as scoped:
+            _ = scoped.generate(["Sheet1!B1"])
+            assert scoped._ast_cache
+            assert scoped._emitted
+
+        assert gen._ast_cache == {}
+        assert gen._emitted == set()
+        assert gen._formula_cell_address is None
+        assert gen._temp_var_counter == 0
 
     def test_generate_includes_imports(self):
         """Generated code should include necessary imports."""


### PR DESCRIPTION
## Summary
- Add `Node.is_target` metadata, expose `DependencyGraph.target_keys()`, and mark expanded build roots as targets in `create_dependency_graph(...)`.
- Update `CodeGenerator` to support context manager lifecycle cleanup and to default `generate()` / `generate_modules()` targets from graph target metadata when explicit targets are omitted.
- Add TDD coverage for target marking, default-target generation behavior, context manager semantics, and document the new API behavior in `README.md`.

## Test plan
- [x] `uv run pytest tests/unit/exporter/test_codegen.py::TestGenerate::test_generate_defaults_to_graph_targets tests/unit/exporter/test_codegen.py::TestGenerate::test_generate_without_targets_raises_when_graph_has_no_targets tests/unit/exporter/test_codegen.py::TestCodeGeneratorContextManager::test_context_manager_clears_transient_codegen_state tests/integration/grapher/test_dependency_graph_targets.py::test_target_nodes_are_marked_with_is_target_metadata`
- [x] `uv run pytest tests/unit/grapher/test_graph_api.py tests/unit/grapher/test_graph_serialization.py tests/unit/exporter/test_codegen.py`
- [x] `uv run pytest tests/integration/exporter/test_codegen_export_modular.py tests/integration/grapher/test_dependency_graph_targets.py`

Closes #168.

Made with [Cursor](https://cursor.com)