### PR TITLE
Rename composite scan and add top_edge_then_left_scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ print(to_graphviz(g))  # GraphViz DOT
 When ``label_detection`` is a ``LabelDetectionConfig`` with ``enabled=True``, each node gets
 ``metadata["row_labels"]`` and ``metadata["column_labels"]`` (lists of strings) at graph build time.
 Built-in behaviors include left/up heuristic scans and region-scoped rules
-(``left_then_up_scan``, ``region_header_rows``); pass custom implementations via
-``label_behaviors``.
+(``left_edge_then_up_scan``, ``top_edge_then_left_scan``, ``region_header_rows``);
+pass custom implementations via ``label_behaviors``.
 
 Include the same settings in graph cache ``extraction_params`` using
 ``label_detection_config_to_jsonable(...)`` so cached graphs invalidate when rules change.

--- a/examples/micro_workbooks/label_detection.md
+++ b/examples/micro_workbooks/label_detection.md
@@ -275,10 +275,11 @@ it.
 The default `LabelDetectionBehavior`s used by `LabelDetectionConfig` are
 `left_edge_scan` and `top_edge_scan`, but there are also others
 registered on the default registry: `full_row_scan`, `full_column_scan`,
-`region_header_rows`, and `left_then_up_scan`. `full_row_scan` and
-`full_column_scan` are bidirectional from the reference cell (scan both
-directions until blanks), with default output ordering of right-to-left
-for rows and bottom-to-top for columns.
+`region_header_rows`, `left_edge_then_up_scan`, and
+`top_edge_then_left_scan`. `full_row_scan` and `full_column_scan` are
+bidirectional from the reference cell (scan both directions until
+blanks), with default output ordering of right-to-left for rows and
+bottom-to-top for columns.
 
 You can configure a `BehaviorRule` with a `RegionSelector` to use these
 behaviors for a specified spreadsheet region, and pass this rule to
@@ -647,7 +648,7 @@ informative. The double-indentation of **A56** indicates that it is a
 child of the single-indented **A54** label, “GDP”, and the unindented
 **A53** label, “United States”. To understand what **B56** represents,
 we need to scan left to collect the row label, then up to collect parent
-labels. This is implemented by the built-in `left_then_up_scan`
+labels. This is implemented by the built-in `left_edge_then_up_scan`
 behavior.
 
 ``` python
@@ -663,7 +664,7 @@ graph: DependencyGraph = create_dependency_graph(
                 selector=RegionSelector(
                     include=region_specs_from_ranges(["Sheet1!A51:B56"]),
                 ),
-                behaviors=("left_then_up_scan", "top_edge_scan"),
+                behaviors=("left_edge_then_up_scan", "top_edge_scan"),
             ),
         ),
     )

--- a/examples/micro_workbooks/label_detection.qmd
+++ b/examples/micro_workbooks/label_detection.qmd
@@ -189,7 +189,7 @@ print_text(
 
 While the default behavior will be to take only left- or top-edge text cells as labels, there may be times when we want all text cells connected to the target cell to be considered as labels. For example, "USA" in this wide-format time series acts like a secondary label because it is an identifier for the row, so we probably want to collect it.
 
-The default `LabelDetectionBehavior`s used by `LabelDetectionConfig` are `left_edge_scan` and `top_edge_scan`, but there are also others registered on the default registry: `full_row_scan`, `full_column_scan`, `region_header_rows`, and `left_then_up_scan`. `full_row_scan` and `full_column_scan` are bidirectional from the reference cell (scan both directions until blanks), with default output ordering of right-to-left for rows and bottom-to-top for columns.
+The default `LabelDetectionBehavior`s used by `LabelDetectionConfig` are `left_edge_scan` and `top_edge_scan`, but there are also others registered on the default registry: `full_row_scan`, `full_column_scan`, `region_header_rows`, `left_edge_then_up_scan`, and `top_edge_then_left_scan`. `full_row_scan` and `full_column_scan` are bidirectional from the reference cell (scan both directions until blanks), with default output ordering of right-to-left for rows and bottom-to-top for columns.
 
 You can configure a `BehaviorRule` with a `RegionSelector` to use these behaviors for a specified spreadsheet region, and pass this rule to `LabelDetectionConfig`:
 
@@ -478,7 +478,7 @@ print_text(
 
 ## 13. Left, then up scans
 
-Rows 51-56 show a small wide-format time series with grouped rows and hierarchical row labels. A simple heuristic left-scan from **B56** would only collect "Real" from **A56**, but this label alone isn't very informative. The double-indentation of **A56** indicates that it is a child of the single-indented **A54** label, "GDP", and the unindented **A53** label, "United States". To understand what **B56** represents, we need to scan left to collect the row label, then up to collect parent labels. This is implemented by the built-in `left_then_up_scan` behavior.
+Rows 51-56 show a small wide-format time series with grouped rows and hierarchical row labels. A simple heuristic left-scan from **B56** would only collect "Real" from **A56**, but this label alone isn't very informative. The double-indentation of **A56** indicates that it is a child of the single-indented **A54** label, "GDP", and the unindented **A53** label, "United States". To understand what **B56** represents, we need to scan left to collect the row label, then up to collect parent labels. This is implemented by the built-in `left_edge_then_up_scan` behavior.
 
 ```{python}
 graph: DependencyGraph = create_dependency_graph(
@@ -493,7 +493,7 @@ graph: DependencyGraph = create_dependency_graph(
                 selector=RegionSelector(
                     include=region_specs_from_ranges(["Sheet1!A51:B56"]),
                 ),
-                behaviors=("left_then_up_scan", "top_edge_scan"),
+                behaviors=("left_edge_then_up_scan", "top_edge_scan"),
             ),
         ),
     )

--- a/excel_grapher/grapher/label_detection.py
+++ b/excel_grapher/grapher/label_detection.py
@@ -12,6 +12,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Literal, Protocol, runtime_checkable
 
+import fastpyxl.utils.cell
 from fastpyxl.worksheet.worksheet import Worksheet
 
 from .blank_ranges import normalize_blank_range_specs
@@ -412,7 +413,7 @@ def _left_then_up_label_text(value: Any) -> str | None:
     return None
 
 
-def _left_then_up_row_labels(
+def _left_edge_then_up_row_labels(
     ws: Worksheet, row: int, col: int, rp: RegionLabelParams | None
 ) -> list[str]:
     label_col_idx = _find_leftmost_label_column(ws, row, col)
@@ -458,6 +459,51 @@ def _left_then_up_row_labels(
             continue
 
         break
+
+    return dedupe_preserve_order(list(reversed(collected)))
+
+
+def _find_topmost_label_row(ws: Worksheet, row: int, col: int) -> int | None:
+    """Return the topmost text/year label row above ``row`` on ``col``; stops at blanks."""
+    topmost: int | None = None
+    current_row = row - 1
+    while current_row >= 1:
+        cell_value = _scan_cell_value(ws, current_row, col)
+        if cell_value is None or (isinstance(cell_value, str) and cell_value.strip() == ""):
+            break
+        text = _left_then_up_label_text(cell_value)
+        if text is not None:
+            topmost = current_row
+        current_row -= 1
+    return topmost
+
+
+def _top_edge_then_left_column_labels(
+    ws: Worksheet, row: int, col: int, rp: RegionLabelParams | None
+) -> list[str]:
+    label_row_idx = _find_topmost_label_row(ws, row, col)
+    if label_row_idx is None:
+        return []
+
+    current_cell = ws.cell(row=label_row_idx, column=col)
+    current_text = _left_then_up_label_text(current_cell.value)
+    if current_text is None:
+        return []
+
+    collected: list[str] = [current_text]
+
+    min_col = 1
+    if rp is not None and rp.label_columns:
+        min_col = min(fastpyxl.utils.cell.column_index_from_string(c) for c in rp.label_columns)
+
+    current_col = col - 1
+    while current_col >= min_col:
+        cell = ws.cell(row=label_row_idx, column=current_col)
+        text = _left_then_up_label_text(cell.value)
+        if text is None:
+            break
+        collected.append(text)
+        current_col -= 1
 
     return dedupe_preserve_order(list(reversed(collected)))
 
@@ -631,14 +677,24 @@ class _RegionHeaderRows:
         return LabelResult(column_labels=tuple(dedupe_preserve_order(col_labels)))
 
 
-class _LeftThenUpScan:
-    name = "left_then_up_scan"
+class _LeftEdgeThenUpScan:
+    name = "left_edge_then_up_scan"
 
     def detect(self, ctx: LabelDetectionContext) -> LabelResult:
         if ctx.ws_values is None:
             return LabelResult()
-        rows = _left_then_up_row_labels(ctx.ws_values, ctx.row, ctx.col, ctx.region_params)
+        rows = _left_edge_then_up_row_labels(ctx.ws_values, ctx.row, ctx.col, ctx.region_params)
         return LabelResult(row_labels=tuple(rows))
+
+
+class _TopEdgeThenLeftScan:
+    name = "top_edge_then_left_scan"
+
+    def detect(self, ctx: LabelDetectionContext) -> LabelResult:
+        if ctx.ws_values is None:
+            return LabelResult()
+        cols = _top_edge_then_left_column_labels(ctx.ws_values, ctx.row, ctx.col, ctx.region_params)
+        return LabelResult(column_labels=tuple(cols))
 
 
 def default_label_behaviors() -> tuple[LabelDetectionBehavior, ...]:
@@ -650,7 +706,8 @@ def default_label_behaviors() -> tuple[LabelDetectionBehavior, ...]:
         _RightEdgeScan(),
         _BottomEdgeScan(),
         _RegionHeaderRows(),
-        _LeftThenUpScan(),
+        _LeftEdgeThenUpScan(),
+        _TopEdgeThenLeftScan(),
     )
 
 

--- a/tests/integration/user_flows/test_label_detection.py
+++ b/tests/integration/user_flows/test_label_detection.py
@@ -525,10 +525,10 @@ def test_right_and_bottom_scans_collect_units_and_source(
     assert any("Source" in label for label in _row_labels(metadata))
 
 
-# --- Left-then-up scans ---
+# --- Left-edge-then-up scans ---
 
 
-def test_left_then_up_scan_collects_indent_hierarchy(
+def test_left_edge_then_up_scan_collects_indent_hierarchy(
     label_workbook_factory: WorkbookFactory,
 ) -> None:
     def _populate(ws, wb) -> None:
@@ -553,7 +553,7 @@ def test_left_then_up_scan_collects_indent_hierarchy(
                 selector=RegionSelector(
                     include=region_specs_from_ranges(["Sheet1!A1:B6"]),
                 ),
-                behaviors=("left_then_up_scan", "top_edge_scan"),
+                behaviors=("left_edge_then_up_scan", "top_edge_scan"),
             ),
         ),
     )
@@ -561,7 +561,7 @@ def test_left_then_up_scan_collects_indent_hierarchy(
     assert _row_labels(metadata) == ["United States", "GDP", "Real"]
 
 
-def test_left_then_up_scan_prioritizes_indent_then_style_rank(
+def test_left_edge_then_up_scan_prioritizes_indent_then_style_rank(
     label_workbook_factory: WorkbookFactory,
 ) -> None:
     def _populate(ws, wb) -> None:
@@ -585,7 +585,7 @@ def test_left_then_up_scan_prioritizes_indent_then_style_rank(
                 selector=RegionSelector(
                     include=region_specs_from_ranges(["Sheet1!A2:B6"]),
                 ),
-                behaviors=("left_then_up_scan", "top_edge_scan"),
+                behaviors=("left_edge_then_up_scan", "top_edge_scan"),
             ),
         ),
         fallback_behaviors=(),
@@ -600,7 +600,7 @@ def test_left_then_up_scan_prioritizes_indent_then_style_rank(
     ]
 
 
-def test_left_then_up_scan_stops_when_no_left_label_column(
+def test_left_edge_then_up_scan_stops_when_no_left_label_column(
     label_workbook_factory: WorkbookFactory,
 ) -> None:
     def _populate(ws, _wb) -> None:
@@ -617,7 +617,7 @@ def test_left_then_up_scan_stops_when_no_left_label_column(
                 selector=RegionSelector(
                     include=region_specs_from_ranges(["Sheet1!B1:D1"]),
                 ),
-                behaviors=("left_then_up_scan",),
+                behaviors=("left_edge_then_up_scan",),
                 stop_after_match=True,
             ),
         ),
@@ -715,7 +715,7 @@ def test_custom_font_weight_hierarchy_row_labels(
     assert _column_labels(metadata) == []
 
 
-def test_left_then_up_scan_parents_year_leaf_when_header_is_bold(
+def test_left_edge_then_up_scan_parents_year_leaf_when_header_is_bold(
     label_workbook_factory: WorkbookFactory,
 ) -> None:
     def _populate(ws, wb) -> None:
@@ -736,7 +736,7 @@ def test_left_then_up_scan_parents_year_leaf_when_header_is_bold(
                 selector=RegionSelector(
                     include=region_specs_from_ranges(["Sheet1!A1:B3"]),
                 ),
-                behaviors=("left_then_up_scan",),
+                behaviors=("left_edge_then_up_scan",),
                 stop_after_match=True,
                 region_params=RegionLabelParams(
                     label_columns=("A",),
@@ -754,3 +754,34 @@ def test_left_then_up_scan_parents_year_leaf_when_header_is_bold(
     )
     assert _row_labels(metadata) == ["Year", "2000"]
     assert _column_labels(metadata) == []
+
+
+def test_top_edge_then_left_scan_collects_column_hierarchy(
+    label_workbook_factory: WorkbookFactory,
+) -> None:
+    def _populate(ws, wb) -> None:
+        indent_1 = wb.add_format({"indent": 1})
+        indent_2 = wb.add_format({"indent": 2})
+        ws.write("A1", "Country")
+        ws.write("B1", "GDP", indent_2)
+        ws.write("C1", "Real", indent_1)
+        ws.write_number("C2", 15.31)
+
+    path = label_workbook_factory(_populate)
+    cfg = LabelDetectionConfig(
+        enabled=True,
+        rules=(
+            BehaviorRule(
+                name="topEdgeThenLeftHierarchy",
+                selector=RegionSelector(
+                    include=region_specs_from_ranges(["Sheet1!A1:C2"]),
+                ),
+                behaviors=("top_edge_then_left_scan",),
+                stop_after_match=True,
+            ),
+        ),
+        fallback_behaviors=(),
+    )
+    metadata = _labels(path, "Sheet1!C2", label_detection=cfg)
+    assert _row_labels(metadata) == []
+    assert _column_labels(metadata) == ["Country", "GDP", "Real"]

--- a/tests/unit/grapher/test_label_detection.py
+++ b/tests/unit/grapher/test_label_detection.py
@@ -121,7 +121,7 @@ def test_collect_labels_rule_stop_skips_fallback() -> None:
     assert row == [] and col == []
 
 
-def test_collect_labels_left_then_up_scan(tmp_path) -> None:
+def test_collect_labels_left_edge_then_up_scan(tmp_path) -> None:
     pytest.importorskip("xlsxwriter")
     import xlsxwriter
 
@@ -144,7 +144,7 @@ def test_collect_labels_left_then_up_scan(tmp_path) -> None:
                 BehaviorRule(
                     name="r",
                     selector=RegionSelector(include=(RegionSpec("S", 1, 3, 1, 5),)),
-                    behaviors=("left_then_up_scan",),
+                    behaviors=("left_edge_then_up_scan",),
                 ),
             ),
             fallback_behaviors=(),
@@ -168,7 +168,7 @@ def test_collect_labels_left_then_up_scan(tmp_path) -> None:
         wv.close()
 
 
-def test_left_then_up_scan_same_indent_same_style_is_skipped(tmp_path) -> None:
+def test_left_edge_then_up_scan_same_indent_same_style_is_skipped(tmp_path) -> None:
     pytest.importorskip("xlsxwriter")
     import xlsxwriter
 
@@ -189,7 +189,7 @@ def test_left_then_up_scan_same_indent_same_style_is_skipped(tmp_path) -> None:
     wv = fastpyxl.load_workbook(path, data_only=True)
     try:
         wsv = wv["S"]
-        cfg = LabelDetectionConfig(enabled=True, fallback_behaviors=("left_then_up_scan",))
+        cfg = LabelDetectionConfig(enabled=True, fallback_behaviors=("left_edge_then_up_scan",))
         reg = build_label_behavior_registry(None)
         st = LabelDetectionState()
         row, col = collect_labels_for_node(
@@ -209,7 +209,7 @@ def test_left_then_up_scan_same_indent_same_style_is_skipped(tmp_path) -> None:
         wv.close()
 
 
-def test_left_then_up_scan_stops_on_same_indent_lower_style(tmp_path) -> None:
+def test_left_edge_then_up_scan_stops_on_same_indent_lower_style(tmp_path) -> None:
     pytest.importorskip("xlsxwriter")
     import xlsxwriter
 
@@ -231,7 +231,7 @@ def test_left_then_up_scan_stops_on_same_indent_lower_style(tmp_path) -> None:
     wv = fastpyxl.load_workbook(path, data_only=True)
     try:
         wsv = wv["S"]
-        cfg = LabelDetectionConfig(enabled=True, fallback_behaviors=("left_then_up_scan",))
+        cfg = LabelDetectionConfig(enabled=True, fallback_behaviors=("left_edge_then_up_scan",))
         reg = build_label_behavior_registry(None)
         st = LabelDetectionState()
         row, col = collect_labels_for_node(
@@ -561,5 +561,45 @@ def test_bottom_edge_scan_collects_text_below(tmp_path) -> None:
         )
         assert row == ["Source: CIA Factbook, 2012"]
         assert col == []
+    finally:
+        wv.close()
+
+
+def test_top_edge_then_left_scan_collects_column_hierarchy(tmp_path) -> None:
+    pytest.importorskip("xlsxwriter")
+    import xlsxwriter
+
+    path = tmp_path / "top_edge_then_left_scan.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("S")
+    i1 = wb.add_format({"indent": 1})
+    i2 = wb.add_format({"indent": 2})
+    ws.write_string(0, 0, "Country")
+    ws.write_string(0, 1, "GDP", i2)
+    ws.write_string(0, 2, "Real", i1)
+    ws.write_number(1, 2, 1)
+    wb.close()
+
+    import fastpyxl
+
+    wv = fastpyxl.load_workbook(path, data_only=True)
+    try:
+        wsv = wv["S"]
+        cfg = LabelDetectionConfig(enabled=True, fallback_behaviors=("top_edge_then_left_scan",))
+        reg = build_label_behavior_registry(None)
+        st = LabelDetectionState()
+        row, col = collect_labels_for_node(
+            key="S!C2",
+            sheet="S",
+            row=2,
+            col=3,
+            cfg=cfg,
+            registry=reg,
+            state=st,
+            ws_values=wsv,
+            ws_formulas=wsv,
+        )
+        assert row == []
+        assert col == ["Country", "GDP", "Real"]
     finally:
         wv.close()


### PR DESCRIPTION
## Summary
- Rename `left_then_up_scan` to `left_edge_then_up_scan` across runtime, tests, and docs.
- Add `top_edge_then_left_scan` to the default label behavior registry as the column-oriented composite behavior requested in issue #175.
- Implement `top_edge_then_left_scan` with horizontal position semantics (top edge row then walk left), intentionally ignoring indentation.

## Test plan
- [x] `uv run pytest tests/unit/grapher/test_label_detection.py tests/integration/user_flows/test_label_detection.py`
- [x] `uv run quarto render examples/micro_workbooks/label_detection.qmd`

Made with [Cursor](https://cursor.com)