### PR TITLE
Fix top-edge scan region bounds and merged-header handling

### DIFF
--- a/excel_grapher/grapher/label_detection.py
+++ b/excel_grapher/grapher/label_detection.py
@@ -463,11 +463,11 @@ def _left_edge_then_up_row_labels(
     return dedupe_preserve_order(list(reversed(collected)))
 
 
-def _find_topmost_label_row(ws: Worksheet, row: int, col: int) -> int | None:
+def _find_topmost_label_row(ws: Worksheet, row: int, col: int, min_row: int = 1) -> int | None:
     """Return the topmost text/year label row above ``row`` on ``col``; stops at blanks."""
     topmost: int | None = None
     current_row = row - 1
-    while current_row >= 1:
+    while current_row >= min_row:
         cell_value = _scan_cell_value(ws, current_row, col)
         if cell_value is None or (isinstance(cell_value, str) and cell_value.strip() == ""):
             break
@@ -481,12 +481,13 @@ def _find_topmost_label_row(ws: Worksheet, row: int, col: int) -> int | None:
 def _top_edge_then_left_column_labels(
     ws: Worksheet, row: int, col: int, rp: RegionLabelParams | None
 ) -> list[str]:
-    label_row_idx = _find_topmost_label_row(ws, row, col)
+    min_row = (rp.min_row if rp is not None and rp.min_row is not None else 1) or 1
+    label_row_idx = _find_topmost_label_row(ws, row, col, min_row=min_row)
     if label_row_idx is None:
         return []
 
-    current_cell = ws.cell(row=label_row_idx, column=col)
-    current_text = _left_then_up_label_text(current_cell.value)
+    current_cell_value = _scan_cell_value(ws, label_row_idx, col)
+    current_text = _left_then_up_label_text(current_cell_value)
     if current_text is None:
         return []
 
@@ -498,8 +499,8 @@ def _top_edge_then_left_column_labels(
 
     current_col = col - 1
     while current_col >= min_col:
-        cell = ws.cell(row=label_row_idx, column=current_col)
-        text = _left_then_up_label_text(cell.value)
+        cell_value = _scan_cell_value(ws, label_row_idx, current_col)
+        text = _left_then_up_label_text(cell_value)
         if text is None:
             break
         collected.append(text)

--- a/tests/integration/user_flows/test_label_detection.py
+++ b/tests/integration/user_flows/test_label_detection.py
@@ -785,3 +785,66 @@ def test_top_edge_then_left_scan_collects_column_hierarchy(
     metadata = _labels(path, "Sheet1!C2", label_detection=cfg)
     assert _row_labels(metadata) == []
     assert _column_labels(metadata) == ["Country", "GDP", "Real"]
+
+
+def test_top_edge_then_left_scan_respects_region_min_row(
+    label_workbook_factory: WorkbookFactory,
+) -> None:
+    def _populate(ws, _wb) -> None:
+        ws.write("A4", "Country")
+        ws.write("B4", "GDP")
+        ws.write("C4", "Real")
+        ws.write("C5", "Q1")
+        ws.write_number("C6", 15.31)
+
+    path = label_workbook_factory(_populate)
+    cfg = LabelDetectionConfig(
+        enabled=True,
+        rules=(
+            BehaviorRule(
+                name="topEdgeThenLeftMinRow",
+                selector=RegionSelector(
+                    include=region_specs_from_ranges(["Sheet1!A5:C6"]),
+                ),
+                behaviors=("top_edge_then_left_scan",),
+                stop_after_match=True,
+                region_params=RegionLabelParams(
+                    label_columns=("A", "B", "C"),
+                    min_row=5,
+                    max_row=6,
+                ),
+            ),
+        ),
+        fallback_behaviors=(),
+    )
+    metadata = _labels(path, "Sheet1!C6", label_detection=cfg)
+    assert _row_labels(metadata) == []
+    assert _column_labels(metadata) == ["Q1"]
+
+
+def test_top_edge_then_left_scan_reads_merged_header_anchors(
+    label_workbook_factory: WorkbookFactory,
+) -> None:
+    def _populate(ws, _wb) -> None:
+        ws.merge_range("A1:B1", "Country")
+        ws.write("C1", "Real")
+        ws.write_number("C2", 15.31)
+
+    path = label_workbook_factory(_populate)
+    cfg = LabelDetectionConfig(
+        enabled=True,
+        rules=(
+            BehaviorRule(
+                name="topEdgeThenLeftMerged",
+                selector=RegionSelector(
+                    include=region_specs_from_ranges(["Sheet1!A1:C2"]),
+                ),
+                behaviors=("top_edge_then_left_scan",),
+                stop_after_match=True,
+            ),
+        ),
+        fallback_behaviors=(),
+    )
+    metadata = _labels(path, "Sheet1!C2", label_detection=cfg)
+    assert _row_labels(metadata) == []
+    assert _column_labels(metadata) == ["Country", "Real"]

--- a/tests/unit/grapher/test_label_detection.py
+++ b/tests/unit/grapher/test_label_detection.py
@@ -9,6 +9,7 @@ from excel_grapher.grapher.label_detection import (
     BehaviorRule,
     LabelDetectionConfig,
     LabelDetectionState,
+    RegionLabelParams,
     RegionSelector,
     RegionSpec,
     build_label_behavior_registry,
@@ -601,5 +602,97 @@ def test_top_edge_then_left_scan_collects_column_hierarchy(tmp_path) -> None:
         )
         assert row == []
         assert col == ["Country", "GDP", "Real"]
+    finally:
+        wv.close()
+
+
+def test_top_edge_then_left_scan_respects_region_min_row(tmp_path) -> None:
+    pytest.importorskip("xlsxwriter")
+    import xlsxwriter
+
+    path = tmp_path / "top_edge_then_left_scan_min_row.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("S")
+    ws.write_string(3, 0, "Country")
+    ws.write_string(3, 1, "GDP")
+    ws.write_string(3, 2, "Real")
+    ws.write_string(4, 2, "Q1")
+    ws.write_number(5, 2, 1)
+    wb.close()
+
+    import fastpyxl
+
+    wv = fastpyxl.load_workbook(path, data_only=True)
+    try:
+        wsv = wv["S"]
+        cfg = LabelDetectionConfig(
+            enabled=True,
+            rules=(
+                BehaviorRule(
+                    name="r",
+                    selector=RegionSelector(include=(RegionSpec("S", 5, 6, 1, 3),)),
+                    behaviors=("top_edge_then_left_scan",),
+                    stop_after_match=True,
+                    region_params=RegionLabelParams(
+                        label_columns=("A", "B", "C"),
+                        min_row=5,
+                        max_row=6,
+                    ),
+                ),
+            ),
+            fallback_behaviors=(),
+        )
+        reg = build_label_behavior_registry(None)
+        st = LabelDetectionState()
+        row, col = collect_labels_for_node(
+            key="S!C6",
+            sheet="S",
+            row=6,
+            col=3,
+            cfg=cfg,
+            registry=reg,
+            state=st,
+            ws_values=wsv,
+            ws_formulas=wsv,
+        )
+        assert row == []
+        assert col == ["Q1"]
+    finally:
+        wv.close()
+
+
+def test_top_edge_then_left_scan_reads_merged_header_anchors(tmp_path) -> None:
+    pytest.importorskip("xlsxwriter")
+    import xlsxwriter
+
+    path = tmp_path / "top_edge_then_left_scan_merged.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("S")
+    ws.merge_range("A1:B1", "Country")
+    ws.write_string(0, 2, "Real")
+    ws.write_number(1, 2, 1)
+    wb.close()
+
+    import fastpyxl
+
+    wv = fastpyxl.load_workbook(path, data_only=True)
+    try:
+        wsv = wv["S"]
+        cfg = LabelDetectionConfig(enabled=True, fallback_behaviors=("top_edge_then_left_scan",))
+        reg = build_label_behavior_registry(None)
+        st = LabelDetectionState()
+        row, col = collect_labels_for_node(
+            key="S!C2",
+            sheet="S",
+            row=2,
+            col=3,
+            cfg=cfg,
+            registry=reg,
+            state=st,
+            ws_values=wsv,
+            ws_formulas=wsv,
+        )
+        assert row == []
+        assert col == ["Country", "Real"]
     finally:
         wv.close()


### PR DESCRIPTION
## Summary
- ensure `top_edge_then_left_scan` respects `RegionLabelParams.min_row` so upward traversal stays within configured regions
- use merged-anchor-aware cell reads in `top_edge_then_left_scan` so merged headers are collected consistently
- add unit and integration regression tests for min-row scoping and merged-header traversal

## Test plan
- [x] `uv run pytest tests/unit/grapher/test_label_detection.py -k \"top_edge_then_left_scan and (min_row or merged or collects_column_hierarchy)\"`
- [x] `uv run pytest tests/integration/user_flows/test_label_detection.py -k \"top_edge_then_left_scan and (min_row or merged or collects_column_hierarchy)\"`
- [x] `uv run pytest tests/unit/grapher/test_label_detection.py -k \"left_edge_then_up or top_edge_then_left\"`
- [x] `uv run pytest tests/integration/user_flows/test_label_detection.py -k \"left_edge_then_up or top_edge_then_left\"`


Made with [Cursor](https://cursor.com)