### PR TITLE
Add workbook-order NodeKey sorting helpers

### DIFF
--- a/excel_grapher/core/address_keys.py
+++ b/excel_grapher/core/address_keys.py
@@ -11,6 +11,10 @@ evaluator/exporter can import them without violating layering rules.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable, Sequence
+
+from fastpyxl.utils.cell import column_index_from_string, coordinate_from_string
+
 
 def needs_quoting(sheet: str) -> bool:
     """Return True if a sheet name must be wrapped in single quotes in a formula."""
@@ -89,3 +93,33 @@ def normalize_key(key: str) -> str:
     """
     sheet, cell = parse_address(key)
     return format_key(sheet, cell)
+
+
+def make_node_key_sort_key(
+    sheet_order: Sequence[str],
+) -> Callable[[str], tuple[int, str, int, int]]:
+    """Build a key function for workbook-aligned ``NodeKey`` sorting.
+
+    Keys are ordered by:
+    1) workbook sheet order (from ``sheet_order``),
+    2) row number,
+    3) column number.
+
+    Sheets not present in ``sheet_order`` are placed after known sheets and
+    sorted by sheet name.
+    """
+    sheet_rank = {name: idx for idx, name in enumerate(sheet_order)}
+    fallback_rank = len(sheet_rank)
+
+    def _sort_key(node_key: str) -> tuple[int, str, int, int]:
+        sheet, cell = parse_address(node_key)
+        col_letters, row = coordinate_from_string(cell.replace("$", ""))
+        col = int(column_index_from_string(col_letters))
+        return (sheet_rank.get(sheet, fallback_rank), sheet, int(row), col)
+
+    return _sort_key
+
+
+def sort_node_keys(node_keys: Iterable[str], *, sheet_order: Sequence[str]) -> list[str]:
+    """Return ``node_keys`` sorted by workbook sheet order, then row, then column."""
+    return sorted(node_keys, key=make_node_key_sort_key(sheet_order))

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -429,7 +429,7 @@ def create_dependency_graph(
         with open(workbook, "rb") as _f:
             _wb_sha256 = hashlib.file_digest(_f, "sha256").hexdigest()
 
-    graph = DependencyGraph()
+    graph = DependencyGraph(sheet_order=list(wb_formulas.sheetnames))
     for h in hooks or []:
         graph.register_hook(h)
 

--- a/excel_grapher/grapher/export.py
+++ b/excel_grapher/grapher/export.py
@@ -133,7 +133,7 @@ def to_graphviz(
 
     lines: list[str] = ["digraph dependencies {", f"  rankdir={_dot_escape(rankdir)};"]
 
-    for key in graph.sorted_keys():
+    for key in graph.keys(order="workbook"):
         node = graph.get_node(key)
         if node is None:
             continue
@@ -151,8 +151,8 @@ def to_graphviz(
             style = " style=filled fillcolor=yellow"
         lines.append(f'  "{_dot_escape(key)}" [label="{label}" shape={shape}{style}];')
 
-    for key in graph.sorted_keys():
-        for dep in graph.sorted_keys(graph.get_dependencies(key)):
+    for key in graph.keys(order="workbook"):
+        for dep in graph.keys(order="workbook", source=graph.get_dependencies(key)):
             guard = graph.get_edge_guard(key, dep)
             if guard is None:
                 lines.append(f'  "{_dot_escape(key)}" -> "{_dot_escape(dep)}";')
@@ -192,7 +192,7 @@ def to_mermaid(
 
     lines: list[str] = ["flowchart TD"]
 
-    keys = graph.sorted_keys()
+    keys = graph.keys(order="workbook")
     node_keys = keys[: max_nodes if max_nodes > 0 else 0]
 
     for key in node_keys:
@@ -217,7 +217,7 @@ def to_mermaid(
 
     node_set = set(node_keys)
     for key in node_keys:
-        for dep in graph.sorted_keys(graph.get_dependencies(key)):
+        for dep in graph.keys(order="workbook", source=graph.get_dependencies(key)):
             if dep not in node_set:
                 continue
             guard = graph.get_edge_guard(key, dep)

--- a/excel_grapher/grapher/export.py
+++ b/excel_grapher/grapher/export.py
@@ -133,7 +133,7 @@ def to_graphviz(
 
     lines: list[str] = ["digraph dependencies {", f"  rankdir={_dot_escape(rankdir)};"]
 
-    for key in sorted(graph):
+    for key in graph.sorted_keys():
         node = graph.get_node(key)
         if node is None:
             continue
@@ -151,8 +151,8 @@ def to_graphviz(
             style = " style=filled fillcolor=yellow"
         lines.append(f'  "{_dot_escape(key)}" [label="{label}" shape={shape}{style}];')
 
-    for key in sorted(graph):
-        for dep in sorted(graph.get_dependencies(key)):
+    for key in graph.sorted_keys():
+        for dep in graph.sorted_keys(graph.get_dependencies(key)):
             guard = graph.get_edge_guard(key, dep)
             if guard is None:
                 lines.append(f'  "{_dot_escape(key)}" -> "{_dot_escape(dep)}";')
@@ -192,7 +192,7 @@ def to_mermaid(
 
     lines: list[str] = ["flowchart TD"]
 
-    keys = sorted(list(graph))
+    keys = graph.sorted_keys()
     node_keys = keys[: max_nodes if max_nodes > 0 else 0]
 
     for key in node_keys:
@@ -217,7 +217,7 @@ def to_mermaid(
 
     node_set = set(node_keys)
     for key in node_keys:
-        for dep in sorted(graph.get_dependencies(key)):
+        for dep in graph.sorted_keys(graph.get_dependencies(key)):
             if dep not in node_set:
                 continue
             guard = graph.get_edge_guard(key, dep)

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -4,7 +4,7 @@ import heapq
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from excel_grapher.core.address_keys import normalize_key, sort_node_keys
 
@@ -82,12 +82,23 @@ class DependencyGraph:
     def __len__(self) -> int:
         return len(self._nodes)
 
-    def sorted_keys(self, keys: Iterable[NodeKey] | None = None) -> list[NodeKey]:
-        """Return keys in workbook order when available, else lexical order."""
-        key_source: Iterable[NodeKey] = self._nodes if keys is None else keys
-        if self.sheet_order:
-            return sort_node_keys(key_source, sheet_order=self.sheet_order)
-        return sorted(key_source)
+    def keys(
+        self,
+        *,
+        order: Literal["insertion", "lexical", "workbook"] = "insertion",
+        source: Iterable[NodeKey] | None = None,
+    ) -> list[NodeKey]:
+        """Return node keys from ``source`` (or the graph) using the selected order."""
+        key_source: Iterable[NodeKey] = self._nodes if source is None else source
+        if order == "insertion":
+            return list(key_source)
+        if order == "lexical":
+            return sorted(key_source)
+        if order == "workbook":
+            if self.sheet_order:
+                return sort_node_keys(key_source, sheet_order=self.sheet_order)
+            return sorted(key_source)
+        raise ValueError(f"Unsupported key order: {order}")
 
     # ---- edge insertion -----------------------------------------------------
 
@@ -252,15 +263,22 @@ class DependencyGraph:
 
     def formula_keys(self) -> list[NodeKey]:
         """Return sorted list of keys for nodes that contain formulas."""
-        return self.sorted_keys(k for k, node in self._nodes.items() if node.formula is not None)
+        return self.keys(
+            order="workbook",
+            source=(k for k, node in self._nodes.items() if node.formula is not None),
+        )
 
     def leaf_keys(self) -> list[NodeKey]:
         """Return sorted list of keys for nodes with no dependency edges (leaves)."""
-        return self.sorted_keys(k for k, node in self._nodes.items() if node.is_leaf)
+        return self.keys(
+            order="workbook", source=(k for k, node in self._nodes.items() if node.is_leaf)
+        )
 
     def target_keys(self) -> list[NodeKey]:
         """Return sorted list of keys marked as original build targets."""
-        return self.sorted_keys(k for k, node in self._nodes.items() if node.is_target)
+        return self.keys(
+            order="workbook", source=(k for k, node in self._nodes.items() if node.is_target)
+        )
 
     def roots(self) -> Iterator[NodeKey]:
         for key in self._nodes:

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import heapq
 import warnings
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
-from excel_grapher.core.address_keys import normalize_key
+from excel_grapher.core.address_keys import normalize_key, sort_node_keys
 
 from .dependency_provenance import EdgeProvenance, merge_edge_provenance
 from .guard import And, CellRef, Compare, GuardConstraints, GuardExpr, Not, Or, or_guard
@@ -61,6 +61,7 @@ class DependencyGraph:
     _edge_extra: dict[EdgeKey, dict[str, Any]] = field(default_factory=dict)
     _hooks: list[NodeHook] = field(default_factory=list)
     leaf_classification: dict[str, str] | None = None
+    sheet_order: list[str] | None = None
 
     # ---- node insertion and iteration ---------------------------------------
 
@@ -80,6 +81,13 @@ class DependencyGraph:
 
     def __len__(self) -> int:
         return len(self._nodes)
+
+    def sorted_keys(self, keys: Iterable[NodeKey] | None = None) -> list[NodeKey]:
+        """Return keys in workbook order when available, else lexical order."""
+        key_source: Iterable[NodeKey] = self._nodes if keys is None else keys
+        if self.sheet_order:
+            return sort_node_keys(key_source, sheet_order=self.sheet_order)
+        return sorted(key_source)
 
     # ---- edge insertion -----------------------------------------------------
 
@@ -244,15 +252,15 @@ class DependencyGraph:
 
     def formula_keys(self) -> list[NodeKey]:
         """Return sorted list of keys for nodes that contain formulas."""
-        return sorted(k for k, node in self._nodes.items() if node.formula is not None)
+        return self.sorted_keys(k for k, node in self._nodes.items() if node.formula is not None)
 
     def leaf_keys(self) -> list[NodeKey]:
         """Return sorted list of keys for nodes with no dependency edges (leaves)."""
-        return sorted(k for k, node in self._nodes.items() if node.is_leaf)
+        return self.sorted_keys(k for k, node in self._nodes.items() if node.is_leaf)
 
     def target_keys(self) -> list[NodeKey]:
         """Return sorted list of keys marked as original build targets."""
-        return sorted(k for k, node in self._nodes.items() if node.is_target)
+        return self.sorted_keys(k for k, node in self._nodes.items() if node.is_target)
 
     def roots(self) -> Iterator[NodeKey]:
         for key in self._nodes:
@@ -463,6 +471,7 @@ class DependencyGraph:
             "_edge_extra": [(idx[a], idx[b], dict(e)) for (a, b), e in self._edge_extra.items()],
             "_hooks": self._hooks,
             "leaf_classification": self.leaf_classification,
+            "sheet_order": list(self.sheet_order) if self.sheet_order is not None else None,
         }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
@@ -492,6 +501,11 @@ class DependencyGraph:
             self.leaf_classification = {keys[key_index[k]]: v for k, v in lc.items()}
         else:
             self.leaf_classification = None
+        sheet_order = state.get("sheet_order")
+        if sheet_order:
+            self.sheet_order = list(sheet_order)
+        else:
+            self.sheet_order = None
 
     # ---- internal edge mutation --------------------------------------------
 

--- a/excel_grapher/grapher/lightweight_viz.py
+++ b/excel_grapher/grapher/lightweight_viz.py
@@ -37,7 +37,7 @@ def _build_int_adjacencies(
     uncond: list[list[int]] = [[] for _ in range(n)]
     all_e: list[list[int]] = [[] for _ in range(n)]
     for i, fk in enumerate(keys):
-        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
+        for tk in graph.keys(order="workbook", source=graph.get_dependencies(fk)):
             tid = key_id.get(tk)
             if tid is None:
                 continue
@@ -67,7 +67,7 @@ def _edge_list_filtered(
     out: list[tuple[int, int, bool]] = []
     for fk in keys:
         fi = key_id[fk]
-        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
+        for tk in graph.keys(order="workbook", source=graph.get_dependencies(fk)):
             ti = key_id.get(tk)
             if ti is None:
                 continue
@@ -212,7 +212,7 @@ def _build_out_adj_guarded(
     out: list[list[tuple[int, bool]]] = [[] for _ in range(n)]
     for fk in keys:
         fi = key_id[fk]
-        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
+        for tk in graph.keys(order="workbook", source=graph.get_dependencies(fk)):
             ti = key_id.get(tk)
             if ti is None:
                 continue
@@ -730,13 +730,13 @@ def _induced_dependency_subgraph(
     if graph.sheet_order is not None:
         sub.sheet_order = list(graph.sheet_order)
     sub.leaf_classification = graph.leaf_classification
-    for k in graph.sorted_keys(keep_keys):
+    for k in graph.keys(order="workbook", source=keep_keys):
         node = graph._get_internal_node(k)
         if node is None:
             continue
         sub.add_node(node)
-    for fk in graph.sorted_keys(keep_keys):
-        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
+    for fk in graph.keys(order="workbook", source=keep_keys):
+        for tk in graph.keys(order="workbook", source=graph.get_dependencies(fk)):
             if tk not in keep_keys:
                 continue
             edge = graph.get_edge_attrs(fk, tk)
@@ -762,7 +762,7 @@ def build_lightweight_viz_core(
     validate_max_formula_length(max_formula_length)
 
     lim = limits or VizLimits()
-    keys = graph.sorted_keys()
+    keys = graph.keys(order="workbook")
     n = len(keys)
     if n == 0:
         return LightweightVizCore(

--- a/excel_grapher/grapher/lightweight_viz.py
+++ b/excel_grapher/grapher/lightweight_viz.py
@@ -37,7 +37,7 @@ def _build_int_adjacencies(
     uncond: list[list[int]] = [[] for _ in range(n)]
     all_e: list[list[int]] = [[] for _ in range(n)]
     for i, fk in enumerate(keys):
-        for tk in sorted(graph.get_dependencies(fk)):
+        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
             tid = key_id.get(tk)
             if tid is None:
                 continue
@@ -67,7 +67,7 @@ def _edge_list_filtered(
     out: list[tuple[int, int, bool]] = []
     for fk in keys:
         fi = key_id[fk]
-        for tk in sorted(graph.get_dependencies(fk)):
+        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
             ti = key_id.get(tk)
             if ti is None:
                 continue
@@ -212,7 +212,7 @@ def _build_out_adj_guarded(
     out: list[list[tuple[int, bool]]] = [[] for _ in range(n)]
     for fk in keys:
         fi = key_id[fk]
-        for tk in sorted(graph.get_dependencies(fk)):
+        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
             ti = key_id.get(tk)
             if ti is None:
                 continue
@@ -727,14 +727,16 @@ def _induced_dependency_subgraph(
     keep_keys: set[NodeKey],
 ) -> DependencyGraph:
     sub = DependencyGraph()
+    if graph.sheet_order is not None:
+        sub.sheet_order = list(graph.sheet_order)
     sub.leaf_classification = graph.leaf_classification
-    for k in sorted(keep_keys):
+    for k in graph.sorted_keys(keep_keys):
         node = graph._get_internal_node(k)
         if node is None:
             continue
         sub.add_node(node)
-    for fk in sorted(keep_keys):
-        for tk in sorted(graph.get_dependencies(fk)):
+    for fk in graph.sorted_keys(keep_keys):
+        for tk in graph.sorted_keys(graph.get_dependencies(fk)):
             if tk not in keep_keys:
                 continue
             edge = graph.get_edge_attrs(fk, tk)
@@ -760,7 +762,7 @@ def build_lightweight_viz_core(
     validate_max_formula_length(max_formula_length)
 
     lim = limits or VizLimits()
-    keys = sorted(graph)
+    keys = graph.sorted_keys()
     n = len(keys)
     if n == 0:
         return LightweightVizCore(
@@ -795,7 +797,13 @@ def build_lightweight_viz_core(
         )
 
     key_id = {k: i for i, k in enumerate(keys)}
-    sheets_sorted = sorted({node.sheet for k in keys if (node := graph.get_node(k)) is not None})
+    present_sheets = {node.sheet for k in keys if (node := graph.get_node(k)) is not None}
+    if graph.sheet_order is not None:
+        sheets_sorted = [sheet for sheet in graph.sheet_order if sheet in present_sheets]
+        unknown_sheets = sorted(present_sheets - set(sheets_sorted))
+        sheets_sorted.extend(unknown_sheets)
+    else:
+        sheets_sorted = sorted(present_sheets)
     sheet_index_map = {s: i for i, s in enumerate(sheets_sorted)}
     uncond, all_adj = _build_int_adjacencies(graph, keys, key_id)
     selected_adj = all_adj if include_guarded_edges else uncond

--- a/excel_grapher/grapher/subgraph.py
+++ b/excel_grapher/grapher/subgraph.py
@@ -63,7 +63,7 @@ def _normalize_existing_keys(
     if missing:
         names = ", ".join(sorted(missing))
         raise ValueError(f"{arg_name} contains keys not present in graph: {names}")
-    return sorted(keys)
+    return graph.sorted_keys(keys)
 
 
 def _validate_limits(*, max_path_length: int | None, max_paths: int | None) -> None:
@@ -104,7 +104,7 @@ def _collect_path_nodes(
         if current in target_set:
             add_path_nodes(path)
 
-        for dep in sorted(graph.get_dependencies(current)):
+        for dep in graph.sorted_keys(graph.get_dependencies(current)):
             if dep in visited:
                 continue
 
@@ -145,10 +145,12 @@ def _induced_dependency_subgraph(
     graph: DependencyGraph, keep_keys: set[NodeKey]
 ) -> DependencyGraph:
     sub = DependencyGraph()
+    if graph.sheet_order is not None:
+        sub.sheet_order = list(graph.sheet_order)
     if graph.leaf_classification is not None:
         sub.leaf_classification = dict(graph.leaf_classification)
 
-    for key in sorted(keep_keys):
+    for key in graph.sorted_keys(keep_keys):
         node = graph._get_internal_node(key)
         if node is None:
             continue
@@ -165,8 +167,8 @@ def _induced_dependency_subgraph(
             )
         )
 
-    for from_key in sorted(keep_keys):
-        for to_key in sorted(graph.get_dependencies(from_key)):
+    for from_key in graph.sorted_keys(keep_keys):
+        for to_key in graph.sorted_keys(graph.get_dependencies(from_key)):
             if to_key not in keep_keys:
                 continue
             attrs = graph.get_edge_attrs(from_key, to_key)

--- a/excel_grapher/grapher/subgraph.py
+++ b/excel_grapher/grapher/subgraph.py
@@ -63,7 +63,7 @@ def _normalize_existing_keys(
     if missing:
         names = ", ".join(sorted(missing))
         raise ValueError(f"{arg_name} contains keys not present in graph: {names}")
-    return graph.sorted_keys(keys)
+    return graph.keys(order="workbook", source=keys)
 
 
 def _validate_limits(*, max_path_length: int | None, max_paths: int | None) -> None:
@@ -104,7 +104,7 @@ def _collect_path_nodes(
         if current in target_set:
             add_path_nodes(path)
 
-        for dep in graph.sorted_keys(graph.get_dependencies(current)):
+        for dep in graph.keys(order="workbook", source=graph.get_dependencies(current)):
             if dep in visited:
                 continue
 
@@ -150,7 +150,7 @@ def _induced_dependency_subgraph(
     if graph.leaf_classification is not None:
         sub.leaf_classification = dict(graph.leaf_classification)
 
-    for key in graph.sorted_keys(keep_keys):
+    for key in graph.keys(order="workbook", source=keep_keys):
         node = graph._get_internal_node(key)
         if node is None:
             continue
@@ -167,8 +167,8 @@ def _induced_dependency_subgraph(
             )
         )
 
-    for from_key in graph.sorted_keys(keep_keys):
-        for to_key in graph.sorted_keys(graph.get_dependencies(from_key)):
+    for from_key in graph.keys(order="workbook", source=keep_keys):
+        for to_key in graph.keys(order="workbook", source=graph.get_dependencies(from_key)):
             if to_key not in keep_keys:
                 continue
             attrs = graph.get_edge_attrs(from_key, to_key)

--- a/tests/integration/grapher/test_export_graphviz.py
+++ b/tests/integration/grapher/test_export_graphviz.py
@@ -12,6 +12,8 @@ import fastpyxl
 import pytest
 
 from excel_grapher import create_dependency_graph, to_graphviz
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.grapher.node import Node
 
 
 def _make_chain_xlsx(path: Path) -> None:
@@ -84,3 +86,14 @@ def test_to_graphviz_invalid_max_formula_length() -> None:
     )
     with pytest.raises(ValueError, match="max_formula_length"):
         to_graphviz(g, max_formula_length=0)
+
+
+def test_to_graphviz_uses_graph_sheet_order_for_node_listing() -> None:
+    g = DependencyGraph(sheet_order=["Later", "Earlier"])
+    g.add_node(Node("Earlier", "A", 1, None, None, 1, True))
+    g.add_node(Node("Later", "A", 1, None, None, 1, True))
+
+    dot = to_graphviz(g)
+    later_idx = dot.index('"Later!A1" [')
+    earlier_idx = dot.index('"Earlier!A1" [')
+    assert later_idx < earlier_idx

--- a/tests/integration/grapher/test_export_lightweight_viz_html.py
+++ b/tests/integration/grapher/test_export_lightweight_viz_html.py
@@ -75,6 +75,15 @@ def test_write_html_core_only_no_overlays(tmp_path: Path) -> None:
     assert "Core only" in text
 
 
+def test_build_core_uses_graph_sheet_order_for_sheet_indices() -> None:
+    g = DependencyGraph(sheet_order=["Z", "A"])
+    g.add_node(_n("A", "A", 1, leaf=True, formula=None))
+    g.add_node(_n("Z", "A", 1, leaf=True, formula=None))
+
+    core = build_lightweight_viz_core(g, limits=VizLimits(), layout_input=None)
+    assert core.sheets == ("Z", "A")
+
+
 def test_write_html_creates_file(tmp_path: Path) -> None:
     p = _payload()
     out = tmp_path / "v.html"

--- a/tests/unit/core/test_address_keys.py
+++ b/tests/unit/core/test_address_keys.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from excel_grapher.core.address_keys import make_node_key_sort_key, sort_node_keys
+
+
+def test_sort_node_keys_respects_workbook_sheet_order_then_row_then_column() -> None:
+    sheet_order = ["Inputs", "Calc", "Summary"]
+    keys = [
+        "Calc!B2",
+        "Inputs!C1",
+        "Inputs!A1",
+        "Calc!A2",
+        "Summary!A1",
+        "Calc!A1",
+    ]
+
+    assert sort_node_keys(keys, sheet_order=sheet_order) == [
+        "Inputs!A1",
+        "Inputs!C1",
+        "Calc!A1",
+        "Calc!A2",
+        "Calc!B2",
+        "Summary!A1",
+    ]
+
+
+def test_sort_node_keys_handles_quoted_sheet_names_in_workbook_order() -> None:
+    sheet_order = ["Main", "Data Set", "O'Neil"]
+    keys = [
+        "'Data Set'!A1",
+        "'O''Neil'!A1",
+        "Main!A1",
+    ]
+
+    assert sort_node_keys(keys, sheet_order=sheet_order) == [
+        "Main!A1",
+        "'Data Set'!A1",
+        "'O''Neil'!A1",
+    ]
+
+
+def test_make_node_key_sort_key_places_unknown_sheets_after_known() -> None:
+    key_fn = make_node_key_sort_key(sheet_order=["Known"])
+    keys = ["Known!A1", "Other!A1", "Another!A1"]
+
+    assert sorted(keys, key=key_fn) == ["Known!A1", "Another!A1", "Other!A1"]

--- a/tests/unit/grapher/test_graph_api.py
+++ b/tests/unit/grapher/test_graph_api.py
@@ -183,13 +183,13 @@ def test_get_dependencies_normalizes_key() -> None:
     assert g.get_dependencies("'My Sheet'!B1") == frozenset({"'My Sheet'!A1"})
 
 
-def test_sorted_keys_uses_workbook_sheet_order_then_row_then_column() -> None:
+def test_keys_order_workbook_uses_sheet_order_then_row_then_column() -> None:
     g = DependencyGraph(sheet_order=["Later", "Earlier"])
     g.add_node(_leaf("Earlier", "B", 2))
     g.add_node(_leaf("Earlier", "A", 1))
     g.add_node(_leaf("Later", "A", 2))
 
-    assert g.sorted_keys() == ["Later!A2", "Earlier!A1", "Earlier!B2"]
+    assert g.keys(order="workbook") == ["Later!A2", "Earlier!A1", "Earlier!B2"]
 
 
 # -------------------------------------------------------------------

--- a/tests/unit/grapher/test_graph_api.py
+++ b/tests/unit/grapher/test_graph_api.py
@@ -183,6 +183,15 @@ def test_get_dependencies_normalizes_key() -> None:
     assert g.get_dependencies("'My Sheet'!B1") == frozenset({"'My Sheet'!A1"})
 
 
+def test_sorted_keys_uses_workbook_sheet_order_then_row_then_column() -> None:
+    g = DependencyGraph(sheet_order=["Later", "Earlier"])
+    g.add_node(_leaf("Earlier", "B", 2))
+    g.add_node(_leaf("Earlier", "A", 1))
+    g.add_node(_leaf("Later", "A", 2))
+
+    assert g.sorted_keys() == ["Later!A2", "Earlier!A1", "Earlier!B2"]
+
+
 # -------------------------------------------------------------------
 # get_edge_attrs / get_edge_guard: typed container + normalization
 # -------------------------------------------------------------------

--- a/tests/unit/grapher/test_graph_serialization.py
+++ b/tests/unit/grapher/test_graph_serialization.py
@@ -139,6 +139,14 @@ def test_pickle_round_trip_preserves_leaf_classification() -> None:
     assert restored.leaf_classification == {"Sheet1!A1": "input", "Sheet1!B1": "constant"}
 
 
+def test_pickle_round_trip_preserves_sheet_order() -> None:
+    g = _make_test_graph()
+    g.sheet_order = ["Sheet2", "Sheet1"]
+
+    restored: DependencyGraph = pickle.loads(pickle.dumps(g))
+    assert restored.sheet_order == ["Sheet2", "Sheet1"]
+
+
 # -------------------------------------------------------------------
 # Compact storage: no per-edge wrapper dicts in pickle stream
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `make_node_key_sort_key` and `sort_node_keys` in `excel_grapher/core/address_keys.py`
- sort node keys by workbook sheet order, then row, then column index
- add unit tests covering workbook ordering, quoted sheet names, and unknown-sheet fallback ordering

## Test plan
- [x] `uv run pytest tests/unit/core/test_address_keys.py`
- [x] pre-commit hooks on commit (`ruff check`, `ruff format --check`, `ty check`)

Made with [Cursor](https://cursor.com)