### PR TITLE
Add NormalizedAddress type alias (closes #191) (#193)

### DIFF
--- a/excel_grapher/core/__init__.py
+++ b/excel_grapher/core/__init__.py
@@ -5,6 +5,7 @@ Representation-agnostic types and logic used by both the evaluator runtime
 and the standalone export runtime.
 """
 
+from .address_keys import NormalizedAddress
 from .coercions import (
     excel_casefold,
     flatten,
@@ -38,6 +39,7 @@ from .operators import (
 from .types import CellValue, ExcelRange, XlError
 
 __all__ = [
+    "NormalizedAddress",
     "CellValue",
     "ExcelRange",
     "XlError",

--- a/excel_grapher/core/address_keys.py
+++ b/excel_grapher/core/address_keys.py
@@ -2,7 +2,7 @@
 
 These helpers are the single source of truth for translating between the
 external address strings that Excel users write (e.g. ``'Sheet1!A1'``,
-``"'My Sheet'!B2"``) and the canonical ``NodeKey`` form stored in the
+``"'My Sheet'!B2"``) and the canonical :data:`NormalizedAddress` form stored in the
 ``DependencyGraph`` and emitted by generated code.
 
 They live in :mod:`excel_grapher.core` so that both the grapher and the
@@ -12,8 +12,12 @@ evaluator/exporter can import them without violating layering rules.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
+from typing import TypeAlias
 
 from fastpyxl.utils.cell import column_index_from_string, coordinate_from_string
+
+# Canonical sheet-qualified cell (``Sheet1!B1``) or range (``Sheet1!C4:Sheet1!D4``).
+NormalizedAddress: TypeAlias = str
 
 
 def needs_quoting(sheet: str) -> bool:
@@ -69,21 +73,21 @@ def parse_address(address: str) -> tuple[str, str]:
     raise ValueError(f"Address must be sheet-qualified: {address}")
 
 
-def format_key(sheet: str, cell: str) -> str:
+def format_key(sheet: str, cell: str) -> NormalizedAddress:
     """Format a sheet and A1 cell coordinate into a canonical address string."""
     return f"{quote_sheet_if_needed(sheet)}!{cell}"
 
 
-def format_cell_key(sheet: str, column: str, row: int) -> str:
+def format_cell_key(sheet: str, column: str, row: int) -> NormalizedAddress:
     """Format a (sheet, column_letters, row) triple into a canonical address."""
     return f"{quote_sheet_if_needed(sheet)}!{column}{row}"
 
 
-def normalize_key(key: str) -> str:
-    """Normalize an address to the canonical ``NodeKey`` form.
+def normalize_key(key: str) -> NormalizedAddress:
+    """Normalize an address to canonical :data:`NormalizedAddress` form.
 
     Unnecessary quoting is stripped; sheet names with spaces, hyphens, or
-    apostrophes are quoted. The result matches ``Node.key`` exactly.
+    apostrophes are quoted. For single cells, the result matches ``Node.key``.
 
     Examples:
         >>> normalize_key("'Sheet1'!A1")
@@ -97,7 +101,7 @@ def normalize_key(key: str) -> str:
 
 def make_node_key_sort_key(
     sheet_order: Sequence[str],
-) -> Callable[[str], tuple[int, str, int, int]]:
+) -> Callable[[NormalizedAddress], tuple[int, str, int, int]]:
     """Build a key function for workbook-aligned ``NodeKey`` sorting.
 
     Keys are ordered by:
@@ -111,7 +115,7 @@ def make_node_key_sort_key(
     sheet_rank = {name: idx for idx, name in enumerate(sheet_order)}
     fallback_rank = len(sheet_rank)
 
-    def _sort_key(node_key: str) -> tuple[int, str, int, int]:
+    def _sort_key(node_key: NormalizedAddress) -> tuple[int, str, int, int]:
         sheet, cell = parse_address(node_key)
         col_letters, row = coordinate_from_string(cell.replace("$", ""))
         col = int(column_index_from_string(col_letters))
@@ -120,6 +124,8 @@ def make_node_key_sort_key(
     return _sort_key
 
 
-def sort_node_keys(node_keys: Iterable[str], *, sheet_order: Sequence[str]) -> list[str]:
+def sort_node_keys(
+    node_keys: Iterable[NormalizedAddress], *, sheet_order: Sequence[str]
+) -> list[NormalizedAddress]:
     """Return ``node_keys`` sorted by workbook sheet order, then row, then column."""
     return sorted(node_keys, key=make_node_key_sort_key(sheet_order))

--- a/excel_grapher/exporter/embed.py
+++ b/excel_grapher/exporter/embed.py
@@ -347,7 +347,12 @@ def emit_runtime(required_symbols: set[str], *, include_offset_table: bool) -> s
         refs = _referenced_names(node)
         symbol_deps[name] = {r for r in refs if r in symbol_to_node and r != name}
 
-    seed = set(required_symbols) | {"XlError", "ExcelRange", "CellValue"}
+    seed = set(required_symbols) | {
+        "XlError",
+        "ExcelRange",
+        "CellValue",
+        "NormalizedAddress",
+    }
 
     # Close over symbol dependencies.
     needed: set[str] = set()

--- a/excel_grapher/grapher/node.py
+++ b/excel_grapher/grapher/node.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any
+from typing import Any, TypeAlias
 
 import fastpyxl.utils.cell
 
+from excel_grapher.core.address_keys import NormalizedAddress
 from excel_grapher.core.address_keys import format_cell_key as _format_node_key
 
-NodeKey = str  # Always in the form "SheetName!A1" or "'Sheet Name'!A1" for quoted sheets
+# Single-cell graph node identity; same canonical form as NormalizedAddress.
+NodeKey: TypeAlias = NormalizedAddress
 
 
 @dataclass

--- a/tests/unit/core/test_address_keys.py
+++ b/tests/unit/core/test_address_keys.py
@@ -1,6 +1,36 @@
 from __future__ import annotations
 
-from excel_grapher.core.address_keys import make_node_key_sort_key, sort_node_keys
+import typing
+
+from excel_grapher.core.address_keys import (
+    NormalizedAddress,
+    format_cell_key,
+    format_key,
+    make_node_key_sort_key,
+    normalize_key,
+    sort_node_keys,
+)
+from excel_grapher.grapher.node import NodeKey
+
+
+def test_normalized_address_is_str_type_alias() -> None:
+    assert NormalizedAddress is str
+
+
+def test_normalize_key_returns_normalized_address() -> None:
+    hints = typing.get_type_hints(normalize_key)
+    assert hints["return"] is NormalizedAddress
+    result: NormalizedAddress = normalize_key("'Sheet1'!A1")
+    assert result == "Sheet1!A1"
+
+
+def test_format_helpers_return_normalized_address() -> None:
+    assert typing.get_type_hints(format_key)["return"] is NormalizedAddress
+    assert typing.get_type_hints(format_cell_key)["return"] is NormalizedAddress
+
+
+def test_node_key_aliases_normalized_address() -> None:
+    assert NodeKey is NormalizedAddress
 
 
 def test_sort_node_keys_respects_workbook_sheet_order_then_row_then_column() -> None:


### PR DESCRIPTION
* Add NormalizedAddress type alias for canonical Excel addresses

Introduce NormalizedAddress as a documented str alias for sheet-qualified cell and range strings in canonical form. NodeKey now aliases it for graph node identity. Annotate normalize_key, format_key, and format_cell_key with the new type and export it from excel_grapher.core.



* Fix import order in excel_grapher.core for ruff

Move NormalizedAddress import before coercions so pre-commit ruff check passes.

* Include NormalizedAddress in exported runtime embed seed

Codegen copies address_keys helpers into standalone runtime.py files. Ensure the NormalizedAddress type alias is always emitted with those symbols so ty and ruff pass on generated exports.

---------