### PR TITLE
Exclude examples from package install bundles

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,1 +1,0 @@
-"""Example scripts and sample workbooks (not part of the distributed package)."""

--- a/examples/lic_dsf/__init__.py
+++ b/examples/lic_dsf/__init__.py
@@ -1,1 +1,0 @@
-"""LIC-DSF template workflows and extraction scripts."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,16 @@ Repository = "https://github.com/Teal-Insights/excel-grapher"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+exclude = [
+    "/examples",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["excel_grapher"]
+exclude = [
+    "/examples",
+]
 
 [tool.hatch.build.targets.wheel.force-include]
 "excel_grapher/grapher/lightweight_viz_template.html" = "excel_grapher/grapher/lightweight_viz_template.html"
@@ -59,6 +67,9 @@ include = [
     "tests/",
     "README.md",
     "LICENSE",
+]
+exclude = [
+    "/examples",
 ]
 
 # uv's dependency groups for development (separate from optional-dependencies)

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,83 @@
+"""Guards for release artifacts: examples stay out of install bundles."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _example_paths(member_names: list[str]) -> list[str]:
+    return [
+        name
+        for name in member_names
+        if name.startswith("examples/") or "/examples/" in name or name.endswith("/examples")
+    ]
+
+
+def _build_artifacts(out_dir: Path) -> tuple[Path, Path]:
+    subprocess.run(
+        ["uv", "build", "--out-dir", str(out_dir), "--clear"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheels = sorted(out_dir.glob("*.whl"))
+    sdists = sorted(out_dir.glob("*.tar.gz"))
+    assert len(wheels) == 1, wheels
+    assert len(sdists) == 1, sdists
+    return wheels[0], sdists[0]
+
+
+@pytest.fixture(scope="module")
+def built_artifacts(tmp_path_factory: pytest.TempPathFactory) -> tuple[list[str], list[str]]:
+    build_dir = tmp_path_factory.mktemp("packaging-build")
+    wheel_path, sdist_path = _build_artifacts(build_dir)
+    with zipfile.ZipFile(wheel_path) as zf:
+        wheel_members = zf.namelist()
+    with tarfile.open(sdist_path, "r:gz") as tf:
+        sdist_members = [m.name for m in tf.getmembers() if m.isfile()]
+    return wheel_members, sdist_members
+
+
+def test_wheel_does_not_ship_examples(built_artifacts: tuple[list[str], list[str]]) -> None:
+    wheel_members, _ = built_artifacts
+    offenders = _example_paths(wheel_members)
+    assert not offenders, f"wheel must not bundle examples/: {offenders[:20]}"
+
+
+def test_sdist_does_not_ship_examples(built_artifacts: tuple[list[str], list[str]]) -> None:
+    _, sdist_members = built_artifacts
+    offenders = _example_paths(sdist_members)
+    assert not offenders, f"sdist must not bundle examples/: {offenders[:20]}"
+
+
+def test_installed_wheel_does_not_expose_examples_module(tmp_path: Path) -> None:
+    build_dir = tmp_path / "dist"
+    wheel_path, _ = _build_artifacts(build_dir)
+
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    pip = venv_dir / "bin" / "pip"
+    python = venv_dir / "bin" / "python"
+    subprocess.run(
+        [str(pip), "install", "--no-deps", str(wheel_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [str(python), "-I", "-c", "import examples"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, result.stdout + result.stderr


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #187 by ensuring `examples/` never appears in wheel or sdist artifacts and cannot be imported after a normal `pip install` of `excel-grapher`.

## Changes

- Add explicit Hatch `exclude = ["/examples"]` at the global build level and on both wheel and sdist targets (defense in depth alongside the existing `packages = ["excel_grapher"]` wheel config).
- Add `tests/unit/test_packaging.py` to build release artifacts in CI-style tests and assert:
  - no `examples/` paths in the wheel or sdist
  - `import examples` fails in an isolated venv installed from the wheel
- Remove `examples/__init__.py` and `examples/lic_dsf/__init__.py` so the examples tree is not treated as an installable top-level Python package if packaging config changes in the future.

## Testing

- `uv run pytest tests/unit/test_packaging.py -v`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ab3b3bb-f826-431c-972d-85b43127a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ab3b3bb-f826-431c-972d-85b43127a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

