### PR TITLE
Avoid eager INDEX range reads on pruned graph cells

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -902,6 +902,15 @@ class CodeGenerator:
         if upper_name == "OFFSET":
             return self._emit_offset(node)
 
+        # INDEX over a literal range: use reference indexing when the result is a single cell
+        if (
+            upper_name == "INDEX"
+            and node.args
+            and isinstance(node.args[0], RangeNode)
+            and self._index_range_result_is_scalar(node.args[0], node)
+        ):
+            return self._emit_index_scalar_range(node)
+
         # ROW needs special handling - references should not be evaluated
         if upper_name == "ROW":
             return self._emit_row(node)
@@ -1213,6 +1222,50 @@ class CodeGenerator:
             _, r1, c1, r2, c2 = self._range_coords(ref_node.start, ref_node.end)
             return (r2 - r1 + 1, c2 - c1 + 1)
         return (1, 1)
+
+    def _index_range_result_is_scalar(self, range_node: RangeNode, node: FunctionCallNode) -> bool:
+        """True when INDEX(range, ...) resolves to a single cell (not a row/column slice)."""
+        _, r1, c1, r2, c2 = self._range_coords(range_node.start, range_node.end)
+        nrows = r2 - r1 + 1
+        ncols = c2 - c1 + 1
+
+        row_arg = node.args[1] if len(node.args) > 1 else None
+        col_arg = node.args[2] if len(node.args) > 2 else None
+        row_omitted = row_arg is None or isinstance(row_arg, EmptyArgNode)
+        col_omitted = col_arg is None or isinstance(col_arg, EmptyArgNode)
+
+        if row_omitted and col_omitted:
+            return nrows == 1 and ncols == 1
+        if row_omitted:
+            return nrows == 1
+        if col_omitted:
+            return ncols == 1
+        return True
+
+    def _emit_range_ref_tuple(self, range_node: RangeNode) -> str:
+        """Emit a range as an (sheet, r1, c1, r2, c2) tuple for xl_index_ref / xl_offset."""
+        base_sheet, r1, c1, r2, c2 = self._range_coords(range_node.start, range_node.end)
+        self._offset_runtime_sheets.add(base_sheet)
+        return f"({repr(base_sheet)}, {r1}, {c1}, {r2}, {c2})"
+
+    def _emit_index_scalar_range(self, node: FunctionCallNode) -> str:
+        """Emit INDEX over a literal range when the result is a single cell."""
+        base = node.args[0]
+        assert isinstance(base, RangeNode)
+        base_ref_info = self._emit_range_ref_tuple(base)
+        row_expr = (
+            "None"
+            if len(node.args) < 2 or isinstance(node.args[1], EmptyArgNode)
+            else self._emit_ast(node.args[1])
+        )
+        col_expr = (
+            "None"
+            if len(node.args) < 3 or isinstance(node.args[2], EmptyArgNode)
+            else self._emit_ast(node.args[2])
+        )
+        self._needs_offset_runtime = True
+        self._needs_index_ref_runtime = True
+        return f"xl_offset(ctx, xl_index_ref({base_ref_info}, {row_expr}, {col_expr}), 0.0, 0.0)"
 
     def _range_coords(self, start: str, end: str) -> tuple[str, int, int, int, int]:
         """Parse a range into (sheet, start_row, start_col, end_row, end_col).
@@ -1585,6 +1638,14 @@ class CodeGenerator:
             elif upper_name == "OFFSET":
                 if not self._can_offset_be_static(node):
                     funcs.add("xl_offset")
+            elif (
+                upper_name == "INDEX"
+                and node.args
+                and isinstance(node.args[0], RangeNode)
+                and self._index_range_result_is_scalar(node.args[0], node)
+            ):
+                funcs.add("xl_offset")
+                funcs.add("xl_index_ref")
             else:
                 funcs.add(excel_func_to_python(node.name))
 
@@ -1598,7 +1659,15 @@ class CodeGenerator:
                 "SUMPRODUCT": set(range(10)),
             }
             if upper_name in numpy_array_args:
+                skip_index_array = (
+                    upper_name == "INDEX"
+                    and node.args
+                    and isinstance(node.args[0], RangeNode)
+                    and self._index_range_result_is_scalar(node.args[0], node)
+                )
                 for i, arg in enumerate(node.args):
+                    if skip_index_array and upper_name == "INDEX":
+                        break
                     if i in numpy_array_args[upper_name] and isinstance(arg, RangeNode):
                         funcs.add("numpy")
                         break

--- a/excel_grapher/runtime/offset_runtime.py
+++ b/excel_grapher/runtime/offset_runtime.py
@@ -99,7 +99,7 @@ def xl_index_ref(
 
 def xl_offset(
     ctx: EvalContext,
-    ref_info: tuple[str, int, int] | tuple[str, int, int, int, int],
+    ref_info: tuple[str, int, int] | tuple[str, int, int, int, int] | XlError,
     rows: CellValue,
     cols: CellValue,
     height: CellValue | None = None,
@@ -112,11 +112,16 @@ def xl_offset(
     if isinstance(cc, XlError):
         return cc
 
+    if isinstance(ref_info, XlError):
+        return ref_info
+
     match ref_info:
         case (sheet, base_row, base_col):
             base_end_row, base_end_col = base_row, base_col
         case (sheet, base_row, base_col, base_end_row, base_end_col):
             pass
+        case _:
+            return XlError.VALUE
 
     base_h = int(base_end_row - base_row + 1)
     base_w = int(base_end_col - base_col + 1)

--- a/tests/integration/evaluator/test_index_parity.py
+++ b/tests/integration/evaluator/test_index_parity.py
@@ -85,3 +85,17 @@ def test_index_omit_col_returns_row_for_match() -> None:
     result = assert_codegen_matches_evaluator(graph, ["S!E1"])
     assert result.evaluator_results["S!E1"] == 2
     assert result.generated_results["S!E1"] == 2
+
+
+def test_index_scalar_out_of_bounds_returns_ref_error() -> None:
+    """Out-of-bounds scalar INDEX should return #REF! instead of raising."""
+    graph = _make_graph(
+        _make_node("S!A1", "1", None),
+        _make_node("S!B1", "2", None),
+        _make_node("S!A2", "3", None),
+        _make_node("S!B2", "4", None),
+        _make_node("S!C1", "=INDEX(S!A1:S!B2,3,1)", None),
+    )
+    result = assert_codegen_matches_evaluator(graph, ["S!C1"])
+    assert result.evaluator_results["S!C1"] == XlError.REF
+    assert result.generated_results["S!C1"] == XlError.REF

--- a/tests/integration/exporter/test_codegen_integration.py
+++ b/tests/integration/exporter/test_codegen_integration.py
@@ -8,10 +8,19 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Literal
 
+import fastpyxl
 import pytest
 
-from excel_grapher import CycleError, DependencyGraph, Node, create_dependency_graph
+from excel_grapher import (
+    CycleError,
+    DependencyGraph,
+    DynamicRefConfig,
+    Node,
+    create_dependency_graph,
+)
 from excel_grapher.core.address_keys import (
     normalize_key as normalize_address,
 )
@@ -222,6 +231,41 @@ class TestGeneratedCodeExecution:
         result = assert_codegen_matches_evaluator(graph, targets)
         assert result.generated_results["S!B1"] is True
         assert result.generated_results["S!B2"] is False
+
+    def test_index_match_with_pruned_description_column_matches_evaluator(self) -> None:
+        """INDEX range codegen must not require pruned lookup-description cells (issue #201)."""
+        with TemporaryDirectory() as tmp:
+            workbook = Path(tmp) / "lookup_codegen_gap.xlsx"
+            wb = fastpyxl.Workbook()
+            ws = wb.active
+            ws.title = "Inputs"
+            ws["A1"] = "country"
+            ws["B1"] = "debt"
+            ws["C1"] = "description"
+            ws["A2"] = "Borvelia"
+            ws["B2"] = 60
+            ws["C2"] = "stylized emerging market"
+            ws["E1"] = "Borvelia"
+            ws["F1"] = "=INDEX(A2:C2, MATCH(E1, A2:A2, 0), 2)"
+            wb.save(workbook)
+
+            dynamic_refs = DynamicRefConfig.from_constraints(
+                {
+                    "Inputs!E1": Literal["Borvelia"],
+                    "Inputs!A2": Literal["Borvelia"],
+                },
+                {},
+            )
+            graph = create_dependency_graph(
+                workbook,
+                ["Inputs!F1"],
+                load_values=True,
+                dynamic_refs=dynamic_refs,
+            )
+            assert "Inputs!C2" not in graph
+
+            result = assert_codegen_matches_evaluator(graph, ["Inputs!F1"])
+            assert "xl_cell(ctx, 'Inputs!C2')" not in result.generated_code
 
 
 class TestGeneratedCodeWithRealWorkbook:

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -1123,3 +1123,33 @@ class TestGeneratedCodeExecution:
         result = namespace["compute_all"]()
 
         assert result["Sheet1!B1:Sheet1!C1"].tolist() == [[20.0, 30.0]]
+
+
+class TestIndexPrunedRangeCodegen:
+    """INDEX over a range must not read graph-pruned cells (issue #201)."""
+
+    def test_index_range_codegen_skips_pruned_cells_and_runs(self) -> None:
+        graph = _make_graph(
+            _make_node("Inputs!A2", None, "Borvelia"),
+            _make_node("Inputs!B2", None, 60),
+            _make_node("Inputs!C2", None, "stylized emerging market"),
+            _make_node("Inputs!E1", None, "Borvelia"),
+            _make_node(
+                "Inputs!F1",
+                "=INDEX(Inputs!A2:Inputs!C2, MATCH(Inputs!E1, Inputs!A2:Inputs!A2, 0), 2)",
+                None,
+            ),
+        )
+        graph.add_edge("Inputs!F1", "Inputs!A2")
+        graph.add_edge("Inputs!F1", "Inputs!B2")
+        graph.add_edge("Inputs!F1", "Inputs!E1")
+
+        gen = CodeGenerator(graph)
+        code = gen.generate(["Inputs!F1"])
+
+        assert "xl_cell(ctx, 'Inputs!C2')" not in code
+
+        namespace: dict = {}
+        exec(code, namespace)
+        result = namespace["compute_all"]()
+        assert "Inputs!F1" in result


### PR DESCRIPTION
## Summary
- add a scalar `INDEX(range, ...)` codegen path that emits `xl_index_ref` + `xl_offset`, avoiding eager `xl_cell(...)` reads for pruned range members
- harden runtime `xl_offset` to propagate `XlError` reference inputs (instead of raising Python exceptions) and return `XlError.VALUE` for malformed refs
- add regression coverage for issue #201 (pruned `INDEX` range cells) plus a parity test for out-of-bounds scalar `INDEX` returning `#REF!`

## Test plan
- [x] `uv run pytest tests/integration/evaluator/test_index_parity.py tests/integration/exporter/test_codegen_integration.py::TestGeneratedCodeExecution::test_index_match_with_pruned_description_column_matches_evaluator tests/unit/exporter/test_codegen.py::TestIndexPrunedRangeCodegen -q`
- [x] `uv run pytest tests/integration/exporter tests/integration/evaluator/test_index_parity.py -q`

Closes #201.

Made with [Cursor](https://cursor.com)