### PR TITLE
Fail loudly on malformed bindings and duplicate shard ids

### DIFF
--- a/excel_grapher/series_bindings/compute_codegen.py
+++ b/excel_grapher/series_bindings/compute_codegen.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -120,10 +121,15 @@ def emit_computes_block(
     }
     failed: list[str] = []
     for resolved in report["series"]:
-        if not resolved["leaves"]:
-            continue
         if not resolved["ok"]:
             failed.append(resolved["series_id"])
+            continue
+        if not resolved["leaves"]:
+            warnings.warn(
+                f"No resolved output cells for series {resolved['series_id']!r}; skipping compute emission",
+                UserWarning,
+                stacklevel=2,
+            )
             continue
         series = by_id.get(resolved["series_id"])
         if series is None:

--- a/excel_grapher/series_bindings/load.py
+++ b/excel_grapher/series_bindings/load.py
@@ -104,6 +104,7 @@ def merge_series_binding_documents(documents: list[dict[str, Any]]) -> dict[str,
         series = doc.get("series")
         if not isinstance(series, list) or not series:
             raise SeriesBindingsLoadError(f"Document {index} must contain a non-empty series list")
+        seen_ids_in_document: set[str] = set()
 
         for entry in series:
             if not isinstance(entry, dict):
@@ -113,6 +114,11 @@ def merge_series_binding_documents(documents: list[dict[str, Any]]) -> dict[str,
                 raise SeriesBindingsLoadError(
                     f"Each series entry requires string id (shard {index})"
                 )
+            if series_id in seen_ids_in_document:
+                raise SeriesBindingsLoadError(
+                    f"Duplicate series id {series_id!r} within shard {index}"
+                )
+            seen_ids_in_document.add(series_id)
             normalized = normalize_series_entry(entry)
             if series_id in series_by_id:
                 try:

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -71,7 +71,7 @@ def normalize_bindings_document(document: dict[str, Any]) -> dict[str, Any]:
     series_list = out.get("series")
     if not isinstance(series_list, list):
         return out
-    out["series"] = [normalize_series_entry(s) for s in series_list if isinstance(s, dict)]
+    out["series"] = [normalize_series_entry(s) if isinstance(s, dict) else s for s in series_list]
     return out
 
 

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -344,6 +344,15 @@ def resolve_series_binding(
         series_id=series_id,
     )
     issues.extend(overlap_issues)
+    if not addresses:
+        issues.append(
+            make_issue(
+                "warning",
+                "no_resolved_cells",
+                f"No resolved {direction} cells in data_range after graph intersection",
+                series_id=series_id,
+            )
+        )
 
     structure = series.get("structure") or {}
     measure = structure.get("measure") or {}

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -181,10 +182,15 @@ def emit_setters_block(
     }
     failed: list[str] = []
     for resolved in report["series"]:
-        if not resolved["leaves"]:
-            continue
         if not resolved["ok"] and not resolved["requires_address"]:
             failed.append(resolved["series_id"])
+            continue
+        if not resolved["leaves"]:
+            warnings.warn(
+                f"No resolved input cells for series {resolved['series_id']!r}; skipping setter emission",
+                UserWarning,
+                stacklevel=2,
+            )
             continue
         series = by_id.get(resolved["series_id"])
         if series is None:

--- a/tests/unit/series_bindings/test_compute_codegen.py
+++ b/tests/unit/series_bindings/test_compute_codegen.py
@@ -6,17 +6,19 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import xlsxwriter
 
 from excel_grapher.grapher import create_dependency_graph
 from excel_grapher.runtime.cache import EvalContext, coerce_inputs_dict, xl_cell
 from excel_grapher.series_bindings import (
     Records,
+    WorkbookSeriesBindings,
     expand_data_range,
     load_series_bindings,
     resolve_series_binding,
 )
-from excel_grapher.series_bindings.compute_codegen import emit_compute_function
+from excel_grapher.series_bindings.compute_codegen import emit_compute_function, emit_computes_block
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
 
@@ -127,3 +129,40 @@ def test_emit_compute_borvelia_includes_frequency(tmp_path: Path) -> None:
     assert len(records) == 5
     assert all(r["FREQUENCY"] == "A" for r in records)
     assert {r["TIME_PERIOD"] for r in records} == {1, 2, 3, 4, 5}
+
+
+def test_emit_computes_block_warns_when_output_has_no_graph_overlap(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula.xlsx"
+    _write_formula_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, ["Sheet1!B2"], load_values=True)
+    bindings = cast(
+        WorkbookSeriesBindings,
+        {
+            "schema_version": "1.2.0",
+            "series": [
+                {
+                    "id": "scaled_output",
+                    "sheet": "Sheet1",
+                    "data_range": "Sheet1!C2",
+                    "layout": "scalar",
+                    "output": {"compute": {"name": "compute_scaled_output"}},
+                    "structure": {
+                        "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+                        "dimensions": [
+                            {
+                                "concept": "LABEL",
+                                "role": "key",
+                                "scope": "series",
+                                "bind": {"kind": "constant", "value": "scaled"},
+                            }
+                        ],
+                    },
+                    "key": ["LABEL"],
+                }
+            ],
+        },
+    )
+    with pytest.warns(UserWarning, match="No resolved output cells"):
+        lines = emit_computes_block(graph, wb_path, bindings)
+
+    assert "def compute_scaled_output(" not in "\n".join(lines)

--- a/tests/unit/series_bindings/test_load.py
+++ b/tests/unit/series_bindings/test_load.py
@@ -54,10 +54,17 @@ def test_merge_directory_shards(tmp_path: Path) -> None:
     assert ids == ["row_b", "row_a"]
 
 
-def test_merge_composes_identical_series_id() -> None:
+def test_merge_composes_identical_series_id_across_shards() -> None:
     doc = parse_bindings_file(FIXTURES / "shard_inputs.yaml")
     merged = merge_series_binding_documents([doc, doc])
     assert len(merged["series"]) == 1
+
+
+def test_merge_rejects_duplicate_series_id_within_single_document() -> None:
+    doc = parse_bindings_file(FIXTURES / "shard_inputs.yaml")
+    doc["series"].append(dict(doc["series"][0]))
+    with pytest.raises(SeriesBindingsLoadError, match="Duplicate series id"):
+        merge_series_binding_documents([doc])
 
 
 def test_merge_rejects_conflicting_series_id() -> None:

--- a/tests/unit/series_bindings/test_normalize.py
+++ b/tests/unit/series_bindings/test_normalize.py
@@ -72,6 +72,38 @@ def test_schema_requires_at_least_one_direction() -> None:
         validate_bindings_document(doc)
 
 
+def test_schema_rejects_non_mapping_series_entry() -> None:
+    from excel_grapher.series_bindings import SeriesBindingsSchemaError, validate_bindings_document
+
+    doc = {
+        "schema_version": "1.2.0",
+        "series": [
+            {
+                "id": "ok",
+                "sheet": "S",
+                "data_range": "S!A1",
+                "layout": "scalar",
+                "input": {"setter": {"name": "set_ok"}},
+                "structure": {
+                    "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+                    "dimensions": [
+                        {
+                            "concept": "X",
+                            "role": "key",
+                            "scope": "cell",
+                            "bind": {"kind": "data_cell"},
+                        }
+                    ],
+                },
+                "key": ["X"],
+            },
+            123,
+        ],
+    }
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
 def test_load_merged_input_output_directory(tmp_path: Path) -> None:
     shard_dir = tmp_path / "shards"
     shard_dir.mkdir()

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -165,6 +165,7 @@ def test_emit_setters_block_skips_series_without_graph_leaf_overlap(tmp_path: Pa
     graph = create_dependency_graph(wb_path, ["Inputs!A2"], load_values=True)
     bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
 
-    lines = emit_setters_block(graph, wb_path, bindings)
+    with pytest.warns(UserWarning, match="No resolved input cells"):
+        lines = emit_setters_block(graph, wb_path, bindings)
 
     assert "def set_borvelia_primary_balance(" not in "\n".join(lines)


### PR DESCRIPTION
## Summary
- preserve non-mapping `series` entries during normalization so schema validation fails loudly on malformed manifests instead of silently dropping bad entries
- reject duplicate `series[].id` values within a single shard/document while keeping cross-shard composition behavior intact
- keep zero-overlap input/output bindings non-fatal but explicit by emitting warnings in codegen and a `no_resolved_cells` warning issue from resolution

## Test plan
- [x] `uv run pytest tests/unit/series_bindings/test_normalize.py tests/unit/series_bindings/test_load.py tests/unit/series_bindings/test_setter_codegen.py tests/unit/series_bindings/test_compute_codegen.py`
- [x] `uv run pytest tests/unit/series_bindings/test_resolve.py tests/unit/series_bindings/test_resolve_output.py`

Made with [Cursor](https://cursor.com)