### PR TITLE
Redesign generate_modules API

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,10 @@ code = CodeGenerator(graph).generate(
 
 This generates `compute_outputs(...)` and `compute_checks(...)` alongside `compute_all(...)`.
 
+For a multi-file package, `generate_modules()` returns a `dict[str, str]` keyed by module filename
+(`__init__.py`, `api.py`, `data.py`, `runtime.py`, `internals.py`). Write those files into a package
+directory of your choice, then import the package as usual.
+
 A (truncated) sketch of the exported code:
 
 ```python

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -159,7 +159,7 @@ class CodeGenerator:
 
     @staticmethod
     def _normalize_entrypoint_name(name: str) -> str:
-        return CodeGenerator._normalize_package_name(name)
+        return CodeGenerator._normalize_identifier(name)
 
     def _graph_sheetnames(self, *, targets: Sequence[str] | None = None) -> list[str]:
         sheet_order = getattr(self.graph, "sheet_order", None)
@@ -1864,7 +1864,6 @@ class CodeGenerator:
         targets: Sequence[str] | None = None,
         *,
         entrypoints: Mapping[str, Sequence[str]] | None = None,
-        package_name: str = "exported",
         constant_types: set[str] | None = None,
         constant_ranges: Sequence[str] | None = None,
         constant_blanks: bool = False,
@@ -1875,18 +1874,16 @@ class CodeGenerator:
     ) -> dict[str, str]:
         """Generate a multi-module Python package for target cells.
 
-        Returns a mapping of file paths (including a normalized package directory) to file
-        contents. The package name is normalized to an importable directory name.
+        Returns a mapping of module filenames to file contents. Callers choose how to
+        lay out files on disk (e.g. a package directory).
 
-        The generated package has six flat files:
+        The generated package has five flat files:
         - __init__.py: exports compute_all and DEFAULT_INPUTS
-        - entrypoint.py: compute_all implementation
-        - inputs.py: DEFAULT_INPUTS
-        - constants.py: CONSTANTS (may be empty)
+        - api.py: compute_all, make_context, and named entrypoint functions
+        - data.py: DEFAULT_INPUTS and CONSTANTS
         - runtime.py: embedded Excel runtime (emit_runtime)
         - internals.py: formula cell functions + resolver dispatch
         """
-        pkg = self._normalize_package_name(package_name)
         normalized_entrypoints = self._normalize_entrypoints(entrypoints)
         normalized_targets = self._resolve_targets(targets)
         entrypoint_targets: list[str] = []
@@ -1936,28 +1933,21 @@ class CodeGenerator:
             for _, handler in entries
         ) or any(handler == "xl_range" for _, handler in targets_entries)
 
-        inputs_py = "\n".join(
-            [
-                "from __future__ import annotations",
-                "",
-                "# --- Default inputs (leaf cells) ---",
-                *parts["inputs_block_lines"][1:],  # drop the comment already included above
-                "",
-            ]
-        )
-
-        runtime_py = runtime_code.rstrip() + "\n"
-
-        constants_lines_out: list[str] = [
+        data_lines_out: list[str] = [
             "from __future__ import annotations",
+            "",
+            "# --- Default inputs (leaf cells) ---",
+            *parts["inputs_block_lines"][1:],  # drop the comment already included above
             "",
         ]
         if parts["constants_block_lines"]:
-            constants_lines_out.extend(parts["constants_block_lines"])
+            data_lines_out.extend(parts["constants_block_lines"])
         else:
-            constants_lines_out.append("CONSTANTS = {}")
-        constants_lines_out.append("")
-        constants_py = "\n".join(constants_lines_out).rstrip() + "\n"
+            data_lines_out.append("CONSTANTS = {}")
+        data_lines_out.append("")
+        data_py = "\n".join(data_lines_out).rstrip() + "\n"
+
+        runtime_py = runtime_code.rstrip() + "\n"
 
         internals_import_names = self._internals_runtime_import_names(
             parts["used_xl_functions"], cell_code_lines
@@ -1982,11 +1972,10 @@ class CodeGenerator:
         runtime_entry_names.sort()
         runtime_imports = self._format_from_runtime_import(runtime_entry_names)
 
-        entrypoint_lines: list[str] = [
+        api_lines: list[str] = [
             "from __future__ import annotations",
             "",
-            "from .constants import CONSTANTS",
-            "from .inputs import DEFAULT_INPUTS",
+            "from .data import CONSTANTS, DEFAULT_INPUTS",
             "from .internals import _resolve_formula",
             runtime_imports,
             "import warnings",
@@ -2013,16 +2002,16 @@ class CodeGenerator:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
             setter_lines = self._emit_series_binding_setters(series_bindings, bindings_workbook)
-            entrypoint_lines.extend(setter_lines)
+            api_lines.extend(setter_lines)
             series_setter_names = self._emitted_function_names(setter_lines)
-            entrypoint_lines.append("")
+            api_lines.append("")
         for name in normalized_entrypoints:
             targets_name = f"TARGETS_{name.upper()}"
-            entrypoint_lines.append(f"{targets_name} = {{")
+            api_lines.append(f"{targets_name} = {{")
             for target, handler in entrypoint_entries[name]:
-                entrypoint_lines.append(f"    {repr(target)}: {handler},")
-            entrypoint_lines.append("}")
-            entrypoint_lines.extend(
+                api_lines.append(f"    {repr(target)}: {handler},")
+            api_lines.append("}")
+            api_lines.extend(
                 [
                     "",
                     "",
@@ -2045,10 +2034,10 @@ class CodeGenerator:
                     "",
                 ]
             )
-        entrypoint_lines.append("TARGETS = {")
+        api_lines.append("TARGETS = {")
         for target, handler in targets_entries:
-            entrypoint_lines.append(f"    {repr(target)}: {handler},")
-        entrypoint_lines.extend(
+            api_lines.append(f"    {repr(target)}: {handler},")
+        api_lines.extend(
             [
                 "}",
                 "",
@@ -2071,19 +2060,19 @@ class CodeGenerator:
                 "",
             ]
         )
-        entrypoint_py = "\n".join(entrypoint_lines)
+        api_py = "\n".join(api_lines)
 
-        entrypoint_exports = ["compute_all", "make_context"]
-        entrypoint_exports.extend(f"compute_{name}" for name in normalized_entrypoints)
-        entrypoint_exports.extend(series_setter_names)
-        entrypoint_imports = ", ".join(entrypoint_exports)
-        all_exports = entrypoint_exports + ["DEFAULT_INPUTS"]
+        api_exports = ["compute_all", "make_context"]
+        api_exports.extend(f"compute_{name}" for name in normalized_entrypoints)
+        api_exports.extend(series_setter_names)
+        api_imports = ", ".join(api_exports)
+        all_exports = api_exports + ["DEFAULT_INPUTS"]
         init_py = "\n".join(
             [
                 "from __future__ import annotations",
                 "",
-                f"from .entrypoint import {entrypoint_imports}  # noqa: F401",
-                "from .inputs import DEFAULT_INPUTS  # noqa: F401",
+                f"from .api import {api_imports}  # noqa: F401",
+                "from .data import DEFAULT_INPUTS  # noqa: F401",
                 "",
                 f"__all__ = {all_exports!r}",
                 "",
@@ -2091,21 +2080,19 @@ class CodeGenerator:
         )
 
         return {
-            f"{pkg}/__init__.py": init_py,
-            f"{pkg}/entrypoint.py": entrypoint_py,
-            f"{pkg}/inputs.py": inputs_py,
-            f"{pkg}/constants.py": constants_py,
-            f"{pkg}/runtime.py": runtime_py,
-            f"{pkg}/internals.py": internals_py,
+            "__init__.py": init_py,
+            "api.py": api_py,
+            "data.py": data_py,
+            "runtime.py": runtime_py,
+            "internals.py": internals_py,
         }
 
     @staticmethod
-    def _normalize_package_name(name: str) -> str:
-        # Keep the name importable as a Python package (identifier-ish).
+    def _normalize_identifier(name: str) -> str:
         out = re.sub(r"[^A-Za-z0-9_]+", "_", name.strip())
         out = re.sub(r"_+", "_", out).strip("_")
         if not out:
-            out = "exported"
+            out = "entrypoint"
         if out[0].isdigit():
             out = "_" + out
         return out.lower()

--- a/tests/integration/exporter/test_codegen_export_modular.py
+++ b/tests/integration/exporter/test_codegen_export_modular.py
@@ -57,19 +57,18 @@ def test_codegen_generate_modules_executes_and_matches_evaluator(tmp_path: Path)
 
     files = CodeGenerator(graph).generate_modules(targets)
     assert set(files.keys()) == {
-        "exported/__init__.py",
-        "exported/constants.py",
-        "exported/entrypoint.py",
-        "exported/inputs.py",
-        "exported/internals.py",
-        "exported/runtime.py",
+        "__init__.py",
+        "api.py",
+        "data.py",
+        "internals.py",
+        "runtime.py",
     }
 
-    for relpath, content in files.items():
+    pkg_dir = tmp_path / "exported"
+    for filename, content in files.items():
         assert "excel_evaluator" not in content
-        out_path = tmp_path / relpath
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(content, encoding="utf-8")
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
 
     sys.path.insert(0, str(tmp_path))
     try:
@@ -87,14 +86,13 @@ def test_codegen_generate_modules_executes_and_matches_evaluator(tmp_path: Path)
         sys.modules.pop("exported", None)
 
 
-def test_codegen_generate_modules_entrypoint_uses_target_map(tmp_path: Path) -> None:
+def test_codegen_generate_modules_api_uses_target_map(tmp_path: Path) -> None:
     graph = _make_graph(_make_node("S!A1", None, 1.0))
     files = CodeGenerator(graph).generate_modules(["S!A1"])
-    entrypoint = files["exported/entrypoint.py"]
-    assert "TARGETS = {" in entrypoint
+    api_py = files["api.py"]
+    assert "TARGETS = {" in api_py
     assert (
-        "    return {target: handler(ctx, target) for target, handler in TARGETS.items()}"
-        in entrypoint
+        "    return {target: handler(ctx, target) for target, handler in TARGETS.items()}" in api_py
     )
 
 
@@ -104,9 +102,9 @@ def test_codegen_generate_modules_entrypoints_exported(tmp_path: Path) -> None:
         _make_node("S!B1", "=S!A1*2", None),
     )
     files = CodeGenerator(graph).generate_modules(["S!B1"], entrypoints={"outputs-a": ["S!B1"]})
-    entrypoint = files["exported/entrypoint.py"]
-    init_py = files["exported/__init__.py"]
-    assert "def compute_outputs_a(inputs=None, *, ctx=None):" in entrypoint
+    api_py = files["api.py"]
+    init_py = files["__init__.py"]
+    assert "def compute_outputs_a(inputs=None, *, ctx=None):" in api_py
     assert "compute_outputs_a" in init_py
 
 
@@ -120,12 +118,12 @@ def test_codegen_generate_modules_entrypoints_emit_named_functions(tmp_path: Pat
         ["S!B1"],
         entrypoints={"outputs": ["S!B1", "S!C1"], "inputs-1": ["S!A1"]},
     )
-    entrypoint = files["exported/entrypoint.py"]
-    init_py = files["exported/__init__.py"]
-    assert "TARGETS_OUTPUTS" in entrypoint
-    assert "TARGETS_INPUTS_1" in entrypoint
-    assert "def compute_outputs(inputs=None, *, ctx=None):" in entrypoint
-    assert "def compute_inputs_1(inputs=None, *, ctx=None):" in entrypoint
+    api_py = files["api.py"]
+    init_py = files["__init__.py"]
+    assert "TARGETS_OUTPUTS" in api_py
+    assert "TARGETS_INPUTS_1" in api_py
+    assert "def compute_outputs(inputs=None, *, ctx=None):" in api_py
+    assert "def compute_inputs_1(inputs=None, *, ctx=None):" in api_py
     assert "compute_outputs" in init_py
     assert "compute_inputs_1" in init_py
 
@@ -140,17 +138,17 @@ def test_codegen_generate_modules_splits_constants(tmp_path: Path) -> None:
         ["Sheet1!A1", "Sheet1!A2", "Sheet1!A3"],
         constant_types={"number"},
     )
-    inputs_py = files["exported/inputs.py"]
-    constants_py = files["exported/constants.py"]
-    entrypoint_py = files["exported/entrypoint.py"]
+    data_py = files["data.py"]
+    api_py = files["api.py"]
 
-    assert "DEFAULT_INPUTS = {" in inputs_py
-    assert "Sheet1!A2" in inputs_py
-    assert "Sheet1!A1" not in inputs_py
-    assert "CONSTANTS = {" in constants_py
-    assert "Sheet1!A1" in constants_py
-    assert "Sheet1!A3" in constants_py
-    assert "merged.update(CONSTANTS)" in entrypoint_py
+    assert "CONSTANTS = {" in data_py
+    inputs_section, _, constants_section = data_py.partition("CONSTANTS = {")
+    assert "DEFAULT_INPUTS = {" in inputs_section
+    assert "Sheet1!A2" in inputs_section
+    assert "Sheet1!A1" not in inputs_section
+    assert "Sheet1!A1" in constants_section
+    assert "Sheet1!A3" in constants_section
+    assert "merged.update(CONSTANTS)" in api_py
 
 
 def test_codegen_generate_modules_constant_blanks(tmp_path: Path) -> None:
@@ -162,15 +160,15 @@ def test_codegen_generate_modules_constant_blanks(tmp_path: Path) -> None:
         ["Sheet1!A1", "Sheet1!A2"],
         constant_blanks=True,
     )
-    inputs_py = files["exported/inputs.py"]
-    constants_py = files["exported/constants.py"]
-    entrypoint_py = files["exported/entrypoint.py"]
+    data_py = files["data.py"]
+    api_py = files["api.py"]
 
-    assert "Sheet1!A2" in inputs_py
-    assert "Sheet1!A1" not in inputs_py
-    assert "CONSTANTS = {" in constants_py
-    assert "Sheet1!A1" in constants_py
-    assert "merged.update(CONSTANTS)" in entrypoint_py
+    assert "CONSTANTS = {" in data_py
+    inputs_section, _, constants_section = data_py.partition("CONSTANTS = {")
+    assert "Sheet1!A2" in inputs_section
+    assert "Sheet1!A1" not in inputs_section
+    assert "Sheet1!A1" in constants_section
+    assert "merged.update(CONSTANTS)" in api_py
 
 
 def test_codegen_generate_modules_has_no_ty_or_ruff_diagnostics(tmp_path: Path) -> None:
@@ -179,11 +177,10 @@ def test_codegen_generate_modules_has_no_ty_or_ruff_diagnostics(tmp_path: Path) 
     graph = _make_graph(_make_node("S!A1", None, 1.0))
     files = CodeGenerator(graph).generate_modules(["S!A1"])
 
-    for relpath, content in files.items():
-        out_path = tmp_path / relpath
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(content, encoding="utf-8")
     pkg_root = tmp_path / "exported"
+    for filename, content in files.items():
+        pkg_root.mkdir(parents=True, exist_ok=True)
+        (pkg_root / filename).write_text(content, encoding="utf-8")
 
     ruff_fix = _run(
         ["uv", "run", "ruff", "check", "--fix", str(pkg_root)],
@@ -213,39 +210,6 @@ def test_codegen_generate_modules_has_no_ty_or_ruff_diagnostics(tmp_path: Path) 
     assert ruff.stderr.strip() == ""
 
 
-def test_codegen_generate_modules_has_no_ty_diagnostics_with_hyphenated_dir(
-    tmp_path: Path,
-) -> None:
-    """Package names should be normalized to importable folder names."""
-    repo_root = Path(__file__).resolve().parents[3]
-
-    graph = _make_graph(_make_node("S!A1", None, 1.0))
-    files = CodeGenerator(graph).generate_modules(["S!A1"], package_name="lic-dsf-template")
-
-    for relpath, content in files.items():
-        out_path = tmp_path / relpath
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(content, encoding="utf-8")
-    pkg_root = tmp_path / "lic_dsf_template"
-
-    ty = _run(
-        [
-            "uv",
-            "run",
-            "ty",
-            "check",
-            "--project",
-            str(repo_root),
-            "--extra-search-path",
-            str(tmp_path),
-            str(pkg_root),
-        ],
-        cwd=repo_root,
-    )
-    assert ty.returncode == 0, f"ty failed:\n{ty.stdout}\n{ty.stderr}"
-    assert ty.stderr.strip() == ""
-
-
 def test_codegen_generate_modules_has_no_ty_diagnostics_for_xlookup(tmp_path: Path) -> None:
     """XLOOKUP should not introduce undefined runtime symbols in generated modules."""
     repo_root = Path(__file__).resolve().parents[3]
@@ -261,11 +225,10 @@ def test_codegen_generate_modules_has_no_ty_diagnostics_for_xlookup(tmp_path: Pa
     )
     files = CodeGenerator(graph).generate_modules(["S!C1"])
 
-    for relpath, content in files.items():
-        out_path = tmp_path / relpath
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(content, encoding="utf-8")
     pkg_root = tmp_path / "exported"
+    for filename, content in files.items():
+        pkg_root.mkdir(parents=True, exist_ok=True)
+        (pkg_root / filename).write_text(content, encoding="utf-8")
 
     ty = _run(
         [

--- a/tests/integration/user_flows/test_series_bindings_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_codegen.py
@@ -108,17 +108,16 @@ def test_generate_modules_exports_series_binding_setters(tmp_path: Path) -> None
 
     files = CodeGenerator(graph).generate_modules(
         targets,
-        package_name="exported_series",
         series_bindings=bindings,
         bindings_workbook=WORKBOOK,
     )
-    assert "def set_borvelia_primary_balance(" in files["exported_series/entrypoint.py"]
-    assert "set_borvelia_primary_balance" in files["exported_series/__init__.py"]
+    assert "def set_borvelia_primary_balance(" in files["api.py"]
+    assert "set_borvelia_primary_balance" in files["__init__.py"]
 
-    for relpath, content in files.items():
-        out_path = tmp_path / relpath
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(content, encoding="utf-8")
+    pkg_dir = tmp_path / "exported_series"
+    for filename, content in files.items():
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
 
     sys.path.insert(0, str(tmp_path))
     try:

--- a/tests/integration/user_flows/test_series_bindings_output_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_output_codegen.py
@@ -130,18 +130,17 @@ def test_generate_modules_exports_output_compute(tmp_path: Path) -> None:
 
     files = CodeGenerator(graph).generate_modules(
         targets,
-        package_name="exported_series_output",
         series_bindings=bindings,
         bindings_workbook=workbook,
     )
-    assert "def compute_borvelia_primary_balance(" in files["exported_series_output/entrypoint.py"]
-    assert "compute_borvelia_primary_balance" in files["exported_series_output/__init__.py"]
-    assert "Record" in files["exported_series_output/entrypoint.py"]
+    assert "def compute_borvelia_primary_balance(" in files["api.py"]
+    assert "compute_borvelia_primary_balance" in files["__init__.py"]
+    assert "Record" in files["api.py"]
 
-    for relpath, content in files.items():
-        out_path = tmp_path / relpath
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(content, encoding="utf-8")
+    pkg_dir = tmp_path / "exported_series_output"
+    for filename, content in files.items():
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
 
     sys.path.insert(0, str(tmp_path))
     try:

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -915,8 +915,8 @@ class TestGenerateNamedRanges:
             _make_node("Sheet1!B3", None, 3.0),
         )
         files = CodeGenerator(graph).generate_modules(["BeeCol"])
-        entrypoint = files["exported/entrypoint.py"]
-        assert "'Sheet1!B1:Sheet1!B3': xl_range" in entrypoint
+        api_py = files["api.py"]
+        assert "'Sheet1!B1:Sheet1!B3': xl_range" in api_py
 
     def test_generate_unknown_defined_name_raises(self):
         graph = self._graph_with_named_ranges(_make_node("Sheet1!A1", None, 1.0))

--- a/tests/unit/exporter/test_codegen_edge_cases.py
+++ b/tests/unit/exporter/test_codegen_edge_cases.py
@@ -517,7 +517,7 @@ class TestNamedRangeRegression:
         # range in normalized_formula, so core.formula_ast.parse succeeds and
         # CodeGenerator can emit a runnable package without raising ParseError.
         files = gen.generate_modules(["'Chart Data'!E11"])
-        assert "exported/entrypoint.py" in files
+        assert "api.py" in files
 
     def test_offset_dynamic_cell_table_excludes_unreachable_sheets(self):
         """Dynamic OFFSET should not force _CELL_TABLE to include unrelated sheets."""


### PR DESCRIPTION
## Summary

- `generate_modules()` now returns bare module filenames (`__init__.py`, `api.py`, `data.py`, `runtime.py`, `internals.py`) instead of paths prefixed with a package directory; the `package_name` argument is removed so callers choose the on-disk layout.
- Renamed `entrypoint.py` → `api.py` and merged `inputs.py` + `constants.py` into `data.py` while keeping separate `DEFAULT_INPUTS` and `CONSTANTS` dicts and the existing `make_context` merge order.
- Updated exporter tests and README; lint xfail cleanup left for a follow-up (per #207).

Closes #207

## Test plan

- [x] `uv run pytest tests/integration/exporter/test_codegen_export_modular.py`
- [x] `uv run pytest tests/unit/exporter/ tests/integration/exporter/`
- [x] Series bindings codegen integration tests (`test_series_bindings_codegen.py`, `test_series_bindings_output_codegen.py`)


Made with [Cursor](https://cursor.com)