### PR TITLE
Add structured series docstring callback registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,43 @@ For a multi-file package, `generate_modules()` returns a `dict[str, str]` keyed 
 (`__init__.py`, `api.py`, `data.py`, `runtime.py`, `internals.py`). Write those files into a package
 directory of your choice, then import the package as usual.
 
+When exporting series bindings, you can attach structured docstrings to generated `set_*` and
+series output `compute_*` functions by registering a callback and passing its name to
+`generate(..., series_docstring_callback=...)` or `generate_modules(..., series_docstring_callback=...)`:
+
+```python
+from excel_grapher.exporter import (
+    CodeGenerator,
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
+
+def my_series_docstring(ctx):
+    # ctx.contract contains deterministic binding facts (fields, examples, layout, etc.)
+    return SeriesFunctionDoc(
+        summary=f"Set {ctx.contract.series_id}.",
+        purpose="Updates workbook inputs from Records.",
+        record_matching="Records match by key fields.",
+        field_descriptions={
+            field: FieldDoc(description=f"Describe {field}.")
+            for field in ctx.contract.required_fields
+        },
+    )
+
+register_series_docstring_callback("my_docs", my_series_docstring, replace=True)
+
+code = CodeGenerator(graph).generate(
+    targets,
+    series_bindings=bindings,
+    bindings_workbook=workbook_path,
+    series_docstring_callback="my_docs",
+)
+```
+
+Callbacks return `SeriesFunctionDoc` prose; the exporter renders deterministic sections such as
+accepted fields, source binding metadata, and example calls. Return `None` to omit a docstring.
+
 A (truncated) sketch of the exported code:
 
 ```python

--- a/examples/micro_workbooks/series_bindings.md
+++ b/examples/micro_workbooks/series_bindings.md
@@ -318,6 +318,78 @@ records = [
 set_borvelia_primary_balance(ctx, records)
 ```
 
+### Structured docstring callback
+
+If you want richer generated docstrings for series APIs, register a
+named callback and pass `series_docstring_callback` to `generate`. The
+callback receives deterministic binding metadata through `ctx.contract`
+and returns prose fields via `SeriesFunctionDoc`.
+
+``` python
+from excel_grapher.exporter import (
+    CodeGenerator,
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
+
+callback_name = "micro_workbook_series_docs"
+
+register_series_docstring_callback(
+    callback_name,
+    lambda ctx: SeriesFunctionDoc(
+        summary=f"Set {ctx.contract.series_id}.",
+        purpose="Updates workbook inputs from Records.",
+        record_matching="Records match cells by key fields.",
+        field_descriptions={
+            field: FieldDoc(description=f"Value for {field}.")
+            for field in ctx.contract.required_fields
+        },
+    ),
+    replace=True,
+)
+
+with CodeGenerator(graph) as gen:
+    code_with_docs = gen.generate(
+        targets,
+        series_bindings=bindings,
+        bindings_workbook=workbook_path,
+        series_docstring_callback=callback_name,
+    )
+
+namespace_with_docs: dict = {}
+exec(code_with_docs, namespace_with_docs)
+doc = namespace_with_docs["set_borvelia_primary_balance"].__doc__
+print(f"```text\n{doc}\n```\n")
+```
+
+``` text
+Set borvelia_primary_balance.
+
+Updates workbook inputs from Records.
+Records match cells by key fields.
+
+Required record fields:
+    TIME_PERIOD: Value for TIME_PERIOD.
+    OBS_VALUE: Value for OBS_VALUE.
+
+Optional record fields:
+    REF_AREA: REF_AREA If supplied, expected value: "Borvelia".
+    INDICATOR: INDICATOR If supplied, expected value: "Primary balance (% of GDP)".
+    UNIT_MEASURE: UNIT_MEASURE If supplied, expected value: "PC_GDP".
+
+Source binding:
+    Workbook range: Sheet1!F5:J5
+    Layout: row_series
+    Value type: float
+
+Example:
+    set_borvelia_primary_balance(ctx, [
+        {'TIME_PERIOD': 1, 'OBS_VALUE': -1.0},
+        {'TIME_PERIOD': 2, 'OBS_VALUE': -0.5},
+    ])
+```
+
 The setter writes into the graph’s input map via
 `EvalContext.set_inputs`. In this notebook, the generated code is
 executed dynamically so the example can verify the same effect:

--- a/examples/micro_workbooks/series_bindings.md
+++ b/examples/micro_workbooks/series_bindings.md
@@ -318,6 +318,18 @@ records = [
 set_borvelia_primary_balance(ctx, records)
 ```
 
+The setter writes into the graph’s input map via
+`EvalContext.set_inputs`. In this notebook, the generated code is
+executed dynamically so the example can verify the same effect:
+
+``` text
+Sheet1!I5 after setter: 7.5
+Sheet1!J5 after setter: 8.0
+```
+
+Periods **4** and **5** correspond to columns I and J; the setter
+updates those leaves without requiring sheet addresses in the records.
+
 ### Structured docstring callback
 
 If you want richer generated docstrings for series APIs, register a
@@ -389,18 +401,6 @@ Example:
         {'TIME_PERIOD': 2, 'OBS_VALUE': -0.5},
     ])
 ```
-
-The setter writes into the graph’s input map via
-`EvalContext.set_inputs`. In this notebook, the generated code is
-executed dynamically so the example can verify the same effect:
-
-``` text
-Sheet1!I5 after setter: 7.5
-Sheet1!J5 after setter: 8.0
-```
-
-Periods **4** and **5** correspond to columns I and J; the setter
-updates those leaves without requiring sheet addresses in the records.
 
 ### Output series
 

--- a/examples/micro_workbooks/series_bindings.qmd
+++ b/examples/micro_workbooks/series_bindings.qmd
@@ -197,6 +197,29 @@ records = [
 
 set_borvelia_primary_balance(ctx, records)
 ```
+The setter writes into the graph's input map via `EvalContext.set_inputs`. In this notebook, the generated code is executed dynamically so the example can verify the same effect:
+
+```{python}
+#| echo: false
+namespace: dict = {}
+exec(code, namespace)
+ctx = namespace["make_context"]()
+namespace["set_borvelia_primary_balance"](
+    ctx,
+    [
+        {"TIME_PERIOD": 4, "OBS_VALUE": 7.5},
+        {"TIME_PERIOD": 5, "OBS_VALUE": 8.0},
+    ],
+)
+print(
+    "```text\n"
+    f"Sheet1!I5 after setter: {ctx.inputs['Sheet1!I5']}\n"
+    f"Sheet1!J5 after setter: {ctx.inputs['Sheet1!J5']}\n"
+    "```\n"
+)
+```
+
+Periods **4** and **5** correspond to columns I and J; the setter updates those leaves without requiring sheet addresses in the records.
 
 ### Structured docstring callback
 
@@ -241,30 +264,6 @@ exec(code_with_docs, namespace_with_docs)
 doc = namespace_with_docs["set_borvelia_primary_balance"].__doc__
 print(f"```text\n{doc}\n```\n")
 ```
-
-The setter writes into the graph's input map via `EvalContext.set_inputs`. In this notebook, the generated code is executed dynamically so the example can verify the same effect:
-
-```{python}
-#| echo: false
-namespace: dict = {}
-exec(code, namespace)
-ctx = namespace["make_context"]()
-namespace["set_borvelia_primary_balance"](
-    ctx,
-    [
-        {"TIME_PERIOD": 4, "OBS_VALUE": 7.5},
-        {"TIME_PERIOD": 5, "OBS_VALUE": 8.0},
-    ],
-)
-print(
-    "```text\n"
-    f"Sheet1!I5 after setter: {ctx.inputs['Sheet1!I5']}\n"
-    f"Sheet1!J5 after setter: {ctx.inputs['Sheet1!J5']}\n"
-    "```\n"
-)
-```
-
-Periods **4** and **5** correspond to columns I and J; the setter updates those leaves without requiring sheet addresses in the records.
 
 ### Output series
 

--- a/examples/micro_workbooks/series_bindings.qmd
+++ b/examples/micro_workbooks/series_bindings.qmd
@@ -198,6 +198,50 @@ records = [
 set_borvelia_primary_balance(ctx, records)
 ```
 
+### Structured docstring callback
+
+If you want richer generated docstrings for series APIs, register a named callback and pass
+`series_docstring_callback` to `generate`. The callback receives deterministic binding metadata
+through `ctx.contract` and returns prose fields via `SeriesFunctionDoc`.
+
+```{python}
+from excel_grapher.exporter import (
+    CodeGenerator,
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
+
+callback_name = "micro_workbook_series_docs"
+
+register_series_docstring_callback(
+    callback_name,
+    lambda ctx: SeriesFunctionDoc(
+        summary=f"Set {ctx.contract.series_id}.",
+        purpose="Updates workbook inputs from Records.",
+        record_matching="Records match cells by key fields.",
+        field_descriptions={
+            field: FieldDoc(description=f"Value for {field}.")
+            for field in ctx.contract.required_fields
+        },
+    ),
+    replace=True,
+)
+
+with CodeGenerator(graph) as gen:
+    code_with_docs = gen.generate(
+        targets,
+        series_bindings=bindings,
+        bindings_workbook=workbook_path,
+        series_docstring_callback=callback_name,
+    )
+
+namespace_with_docs: dict = {}
+exec(code_with_docs, namespace_with_docs)
+doc = namespace_with_docs["set_borvelia_primary_balance"].__doc__
+print(f"```text\n{doc}\n```\n")
+```
+
 The setter writes into the graph's input map via `EvalContext.set_inputs`. In this notebook, the generated code is executed dynamically so the example can verify the same effect:
 
 ```{python}

--- a/excel_grapher/exporter/__init__.py
+++ b/excel_grapher/exporter/__init__.py
@@ -5,6 +5,15 @@ Canonical implementation: :class:`~excel_grapher.exporter.codegen.CodeGenerator`
 The shared runtime embedded in generated code lives at :mod:`excel_grapher.runtime`.
 """
 
+from excel_grapher.series_bindings.docstrings import (
+    FieldDoc,
+    SeriesBindingDocstringContext,
+    SeriesBindingDocstringContract,
+    SeriesFunctionDoc,
+    list_series_docstring_callbacks,
+    register_series_docstring_callback,
+)
+
 from .codegen import CodeGenerator
 from .lightweight_viz import (
     WebVizPayload,
@@ -25,6 +34,10 @@ __all__ = [
     "CodeGenerator",
     "WebVizPayload",
     "to_web_viz_payload",
+    "FieldDoc",
+    "SeriesBindingDocstringContext",
+    "SeriesBindingDocstringContract",
+    "SeriesFunctionDoc",
     "LAYOUT_STRATIFIED_MULTIPARTITE",
     "LAYOUT_SPRING",
     "LAYOUT_FORCEATLAS2",
@@ -33,4 +46,6 @@ __all__ = [
     "LAYOUT_GRAPHVIZ_SFDP",
     "list_web_viz_layouts",
     "register_web_viz_layout",
+    "list_series_docstring_callbacks",
+    "register_series_docstring_callback",
 ]

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -366,10 +366,17 @@ class CodeGenerator:
         self,
         bindings: WorkbookSeriesBindings,
         workbook: Path | str,
+        *,
+        series_docstring_callback: str | None = None,
     ) -> list[str]:
         from excel_grapher.series_bindings.bindings_codegen import emit_series_bindings_block
 
-        return emit_series_bindings_block(cast("DependencyGraph", self.graph), workbook, bindings)
+        return emit_series_bindings_block(
+            cast("DependencyGraph", self.graph),
+            workbook,
+            bindings,
+            series_docstring_callback=series_docstring_callback,
+        )
 
     def derive_input_series(
         self,
@@ -1701,6 +1708,7 @@ class CodeGenerator:
         blank_ranges: Sequence[str] | None = None,
         series_bindings: WorkbookSeriesBindings | None = None,
         bindings_workbook: Path | str | None = None,
+        series_docstring_callback: str | None = None,
     ) -> str:
         """Generate standalone Python code for target cells.
 
@@ -1714,6 +1722,8 @@ class CodeGenerator:
             series_bindings: Optional workbook binding manifest; when set with
                 ``bindings_workbook``, emits ``set_*`` functions that accept Records.
             bindings_workbook: Path to the ``.xlsx`` file used to resolve binds.
+            series_docstring_callback: Optional registered callback name for structured
+                docstrings on generated ``set_*`` and series output ``compute_*`` functions.
 
         Returns:
             Standalone Python source code as a string.
@@ -1805,7 +1815,13 @@ class CodeGenerator:
         if series_bindings is not None:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
-            lines.extend(self._emit_series_binding_setters(series_bindings, bindings_workbook))
+            lines.extend(
+                self._emit_series_binding_setters(
+                    series_bindings,
+                    bindings_workbook,
+                    series_docstring_callback=series_docstring_callback,
+                )
+            )
             lines.append("")
         for name, entrypoint_list in normalized_entrypoints.items():
             targets_name = f"TARGETS_{name.upper()}"
@@ -1871,6 +1887,7 @@ class CodeGenerator:
         blank_ranges: Sequence[str] | None = None,
         series_bindings: WorkbookSeriesBindings | None = None,
         bindings_workbook: Path | str | None = None,
+        series_docstring_callback: str | None = None,
     ) -> dict[str, str]:
         """Generate a multi-module Python package for target cells.
 
@@ -2001,7 +2018,11 @@ class CodeGenerator:
         if series_bindings is not None:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
-            setter_lines = self._emit_series_binding_setters(series_bindings, bindings_workbook)
+            setter_lines = self._emit_series_binding_setters(
+                series_bindings,
+                bindings_workbook,
+                series_docstring_callback=series_docstring_callback,
+            )
             api_lines.extend(setter_lines)
             series_setter_names = self._emitted_function_names(setter_lines)
             api_lines.append("")

--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -9,6 +9,14 @@ from excel_grapher.series_bindings.compute_codegen import (
     emit_computes_block,
     generate_computes_module,
 )
+from excel_grapher.series_bindings.docstrings import (
+    FieldDoc,
+    SeriesBindingDocstringContext,
+    SeriesBindingDocstringContract,
+    SeriesFunctionDoc,
+    list_series_docstring_callbacks,
+    register_series_docstring_callback,
+)
 from excel_grapher.series_bindings.input_series import derive_input_series
 from excel_grapher.series_bindings.load import (
     SeriesBindingsLoadError,
@@ -75,6 +83,10 @@ __all__ = [
     "PLANNED_BIND_KINDS",
     "PLANNED_LAYOUTS",
     "SUPPORTED_SCHEMA_VERSIONS",
+    "FieldDoc",
+    "SeriesBindingDocstringContext",
+    "SeriesBindingDocstringContract",
+    "SeriesFunctionDoc",
     "LeafResolution",
     "ResolutionIssue",
     "ResolutionReport",
@@ -104,9 +116,11 @@ __all__ = [
     "expand_data_range_for_graph",
     "format_schema_errors",
     "generate_setters_module",
+    "list_series_docstring_callbacks",
     "load_series_bindings",
     "merge_series_binding_documents",
     "parse_bindings_file",
+    "register_series_docstring_callback",
     "resolve_series_binding",
     "resolve_series_bindings",
     "validate_bindings_document",

--- a/excel_grapher/series_bindings/bindings_codegen.py
+++ b/excel_grapher/series_bindings/bindings_codegen.py
@@ -15,6 +15,8 @@ def emit_series_bindings_block(
     graph: DependencyGraph,
     workbook: Path | str,
     bindings: WorkbookSeriesBindings,
+    *,
+    series_docstring_callback: str | None = None,
 ) -> list[str]:
     """Emit setter and/or output compute functions for a binding manifest."""
     series_list = [s for s in bindings.get("series", []) if isinstance(s, dict)]
@@ -32,6 +34,7 @@ def emit_series_bindings_block(
                 workbook,
                 bindings,
                 include_type_aliases=include_aliases,
+                series_docstring_callback=series_docstring_callback,
             )
         )
         include_aliases = False
@@ -42,6 +45,7 @@ def emit_series_bindings_block(
                 workbook,
                 bindings,
                 include_type_aliases=include_aliases,
+                series_docstring_callback=series_docstring_callback,
             )
         )
     return lines

--- a/excel_grapher/series_bindings/compute_codegen.py
+++ b/excel_grapher/series_bindings/compute_codegen.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Any
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.docstrings import (
+    emit_docstring_literal,
+    resolve_series_function_docstring,
+)
 from excel_grapher.series_bindings.normalize import has_output_direction
 from excel_grapher.series_bindings.resolve import resolve_series_bindings
 from excel_grapher.series_bindings.types import (
@@ -42,6 +46,11 @@ def _measure_concept(series: dict[str, Any]) -> str:
 def emit_compute_function(
     series: dict[str, Any],
     resolved: SeriesResolution,
+    *,
+    graph: DependencyGraph | None = None,
+    workbook: Path | str | None = None,
+    bindings: WorkbookSeriesBindings | None = None,
+    series_docstring_callback: str | None = None,
 ) -> list[str]:
     """Emit Python source lines for one series binding output compute function."""
     if not resolved["leaves"]:
@@ -68,12 +77,29 @@ def emit_compute_function(
     lines.append("]")
     lines.append("")
     lines.append(f"def {fn_name}(inputs=None, *, ctx=None) -> Records:")
-    doc = (
-        series.get("notes")
-        or series.get("sdmx_notes")
-        or f"Compute records for {resolved['series_id']}."
-    )
-    lines.append(f'    """{doc}"""')
+    if series_docstring_callback is not None and (
+        graph is None or workbook is None or bindings is None
+    ):
+        raise ValueError("series_docstring_callback requires graph, workbook, and bindings context")
+    if graph is not None and workbook is not None and bindings is not None:
+        doc = resolve_series_function_docstring(
+            graph=graph,
+            workbook=workbook,
+            bindings=bindings,
+            series=series,
+            resolution=resolved,
+            function_kind="compute",
+            function_name=fn_name,
+            callback_name=series_docstring_callback,
+        )
+    else:
+        doc = (
+            series.get("notes")
+            or series.get("sdmx_notes")
+            or f"Compute records for {resolved['series_id']}."
+        )
+    if doc is not None:
+        lines.extend(emit_docstring_literal(doc))
     lines.append("    if ctx is None:")
     lines.append("        ctx = make_context(inputs)")
     lines.append("    elif inputs is not None:")
@@ -102,6 +128,7 @@ def emit_computes_block(
     bindings: WorkbookSeriesBindings,
     *,
     include_type_aliases: bool = True,
+    series_docstring_callback: str | None = None,
 ) -> list[str]:
     """Emit all series output compute functions for a validated binding manifest."""
     report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="output")
@@ -134,7 +161,16 @@ def emit_computes_block(
         series = by_id.get(resolved["series_id"])
         if series is None:
             continue
-        lines.extend(emit_compute_function(series, resolved))
+        lines.extend(
+            emit_compute_function(
+                series,
+                resolved,
+                graph=graph,
+                workbook=workbook,
+                bindings=bindings,
+                series_docstring_callback=series_docstring_callback,
+            )
+        )
     if failed:
         raise ValueError(
             f"Cannot codegen output compute functions: resolution failed for {failed!r}"

--- a/excel_grapher/series_bindings/docstrings.py
+++ b/excel_grapher/series_bindings/docstrings.py
@@ -1,0 +1,389 @@
+"""Structured docstring callbacks for generated series-binding API functions."""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
+
+SeriesFunctionKind = Literal["setter", "compute"]
+
+
+@dataclass(frozen=True, slots=True)
+class FieldContract:
+    concept_name: str
+    dtype: str | None
+    required: bool
+    expected_value: object | None
+
+
+@dataclass(frozen=True, slots=True)
+class SeriesBindingDocstringContract:
+    series_id: str
+    function_name: str
+    function_kind: SeriesFunctionKind
+    data_range: str
+    layout: str
+    value_type: str | None
+    required_fields: tuple[str, ...]
+    fields: Mapping[str, FieldContract]
+    example_records: tuple[Mapping[str, object], ...]
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class FieldDoc:
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class SeriesFunctionDoc:
+    summary: str
+    purpose: str
+    record_matching: str
+    field_descriptions: Mapping[str, FieldDoc] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class SeriesBindingDocstringContext:
+    graph: DependencyGraph
+    workbook: Path | str
+    bindings: WorkbookSeriesBindings
+    series: dict[str, Any]
+    resolution: SeriesResolution
+    contract: SeriesBindingDocstringContract
+    function_kind: SeriesFunctionKind
+    function_name: str
+
+
+@runtime_checkable
+class SeriesBindingDocstringCallback(Protocol):
+    def __call__(self, ctx: SeriesBindingDocstringContext) -> SeriesFunctionDoc | None: ...
+
+
+_callbacks: dict[str, SeriesBindingDocstringCallback] = {}
+
+
+def register_series_docstring_callback(
+    name: str,
+    callback: SeriesBindingDocstringCallback,
+    *,
+    replace: bool = False,
+) -> None:
+    if name in _callbacks and not replace:
+        raise ValueError(f"duplicate series docstring callback: {name!r}")
+    _callbacks[name] = callback
+
+
+def list_series_docstring_callbacks() -> tuple[str, ...]:
+    return tuple(sorted(_callbacks))
+
+
+def run_series_docstring_callback(
+    name: str,
+    ctx: SeriesBindingDocstringContext,
+) -> SeriesFunctionDoc | None:
+    if name not in _callbacks:
+        known = ", ".join(sorted(_callbacks))
+        raise ValueError(f"Unknown series docstring callback: {name!r}. Known: {known}")
+    return _callbacks[name](ctx)
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _concept_lookup(bindings: WorkbookSeriesBindings) -> dict[str, dict[str, Any]]:
+    scheme = bindings.get("concept_scheme") or {}
+    concepts = scheme.get("concepts") or []
+    return {
+        str(concept["id"]): concept
+        for concept in concepts
+        if isinstance(concept, dict) and "id" in concept
+    }
+
+
+def _measure_concept(series: dict[str, Any]) -> str:
+    measure = (series.get("structure") or {}).get("measure") or {}
+    return str(measure.get("concept") or "OBS_VALUE")
+
+
+def _expected_record_values(series: dict[str, Any]) -> dict[str, object]:
+    expected = dict(series.get("series_context") or {})
+    for attribute in (series.get("structure") or {}).get("attributes") or []:
+        if isinstance(attribute, dict) and "value" in attribute:
+            expected[str(attribute["concept"])] = attribute["value"]
+    return expected
+
+
+def _record_field_names(series: dict[str, Any]) -> list[str]:
+    measure = _measure_concept(series)
+    dimensions = [
+        str(dimension["concept"])
+        for dimension in (series.get("structure") or {}).get("dimensions") or []
+        if isinstance(dimension, dict) and "concept" in dimension
+    ]
+    attributes = [
+        str(attribute["concept"])
+        for attribute in (series.get("structure") or {}).get("attributes") or []
+        if isinstance(attribute, dict) and "concept" in attribute
+    ]
+    required = [*(series.get("key") or []), measure]
+    return _unique([*required, *dimensions, *attributes])
+
+
+def _field_dtype(
+    series: dict[str, Any],
+    concepts: dict[str, dict[str, Any]],
+    field_name: str,
+) -> str | None:
+    measure = (series.get("structure") or {}).get("measure") or {}
+    if field_name == _measure_concept(series):
+        measure_dtype = measure.get("dtype")
+        if measure_dtype is not None:
+            return str(measure_dtype)
+        concept = concepts.get(field_name)
+        if concept is not None and concept.get("dtype") is not None:
+            return str(concept["dtype"])
+        return None
+    concept = concepts.get(field_name)
+    if concept is not None and concept.get("dtype") is not None:
+        return str(concept["dtype"])
+    return None
+
+
+def _example_records_from_resolution(
+    resolution: SeriesResolution,
+    required_fields: tuple[str, ...],
+    *,
+    max_records: int = 2,
+) -> tuple[dict[str, object], ...]:
+    examples: list[dict[str, object]] = []
+    for leaf in resolution["leaves"][:max_records]:
+        record = leaf["record"]
+        examples.append({field_name: record[field_name] for field_name in required_fields})
+    return tuple(examples)
+
+
+def derive_doc_contract(
+    series: dict[str, Any],
+    *,
+    function_kind: SeriesFunctionKind,
+    function_name: str,
+    resolution: SeriesResolution,
+    bindings: WorkbookSeriesBindings,
+) -> SeriesBindingDocstringContract:
+    concepts = _concept_lookup(bindings)
+    measure = _measure_concept(series)
+    required_fields = tuple(str(field) for field in (series.get("key") or [])) + (measure,)
+    expected_values = _expected_record_values(series)
+    field_contracts: dict[str, FieldContract] = {}
+    for field_name in _record_field_names(series):
+        concept = concepts.get(field_name)
+        concept_name = (
+            str(concept["name"]) if concept is not None and concept.get("name") else field_name
+        )
+        field_contracts[field_name] = FieldContract(
+            concept_name=concept_name,
+            dtype=_field_dtype(series, concepts, field_name),
+            required=field_name in required_fields,
+            expected_value=expected_values.get(field_name),
+        )
+
+    return SeriesBindingDocstringContract(
+        series_id=str(series.get("id", "")),
+        function_name=function_name,
+        function_kind=function_kind,
+        data_range=str(series.get("data_range", "")),
+        layout=str(series.get("layout", "")),
+        value_type=_field_dtype(series, concepts, measure),
+        required_fields=required_fields,
+        fields=field_contracts,
+        example_records=_example_records_from_resolution(resolution, required_fields),
+        notes=str(series.get("notes") or series.get("sdmx_notes") or ""),
+    )
+
+
+def _field_description_line(
+    doc: SeriesFunctionDoc,
+    field_name: str,
+    field_contract: FieldContract,
+) -> str:
+    field_doc = doc.field_descriptions.get(field_name)
+    description = field_doc.description if field_doc is not None else field_contract.concept_name
+    expected_value = field_contract.expected_value
+    if expected_value is None:
+        return f"{field_name}: {description}"
+    return f'{field_name}: {description} If supplied, expected value: "{expected_value}".'
+
+
+def _render_record(record: Mapping[str, object]) -> str:
+    fields = ", ".join(f"{field_name!r}: {value!r}" for field_name, value in record.items())
+    return f"{{{fields}}}"
+
+
+def _render_example_call(
+    contract: SeriesBindingDocstringContract,
+) -> list[str]:
+    if contract.function_kind == "setter":
+        lines = [f"{contract.function_name}(ctx, ["]
+        for record in contract.example_records:
+            lines.append(f"    {_render_record(record)},")
+        lines.append("])")
+        return lines
+    return [f"{contract.function_name}(ctx=ctx)"]
+
+
+def render_series_function_doc(
+    doc: SeriesFunctionDoc,
+    *,
+    contract: SeriesBindingDocstringContract,
+    series: Mapping[str, Any],
+) -> str:
+    required = [name for name, field in contract.fields.items() if field.required]
+    optional = [name for name, field in contract.fields.items() if not field.required]
+    example_lines = _render_example_call(contract)
+
+    lines = [
+        doc.summary,
+        "",
+        doc.purpose,
+        doc.record_matching,
+        "",
+        "Required record fields:",
+        *[f"    {_field_description_line(doc, name, contract.fields[name])}" for name in required],
+    ]
+    if optional:
+        lines.extend(
+            [
+                "",
+                "Optional record fields:",
+                *[
+                    f"    {_field_description_line(doc, name, contract.fields[name])}"
+                    for name in optional
+                ],
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "Source binding:",
+            f"    Workbook range: {series.get('data_range', contract.data_range)}",
+            f"    Layout: {series.get('layout', contract.layout)}",
+            f"    Value type: {contract.value_type if contract.value_type is not None else 'unspecified'}",
+            "",
+            "Example:",
+            *[f"    {line}" for line in example_lines],
+        ]
+    )
+    return "\n".join(lines)
+
+
+def emit_docstring_literal(doc: str) -> list[str]:
+    escaped = doc.replace('"""', '\\"""')
+    if "\n" not in escaped:
+        return [f'    """{escaped}"""']
+    body = textwrap.indent(escaped, "    ")
+    return [f'    """{body.lstrip()}', '    """']
+
+
+def _default_docstring(
+    series: dict[str, Any],
+    *,
+    function_kind: SeriesFunctionKind,
+    series_id: str,
+) -> str:
+    notes = series.get("notes") or series.get("sdmx_notes")
+    if notes:
+        return str(notes)
+    if function_kind == "setter":
+        return f"Apply records for {series_id}."
+    return f"Compute records for {series_id}."
+
+
+def _series_notes_callback(ctx: SeriesBindingDocstringContext) -> SeriesFunctionDoc | None:
+    notes = ctx.contract.notes
+    if not notes:
+        return None
+    return SeriesFunctionDoc(
+        summary=notes,
+        purpose="",
+        record_matching="",
+        field_descriptions={},
+    )
+
+
+def resolve_series_function_docstring(
+    *,
+    graph: DependencyGraph,
+    workbook: Path | str,
+    bindings: WorkbookSeriesBindings,
+    series: dict[str, Any],
+    resolution: SeriesResolution,
+    function_kind: SeriesFunctionKind,
+    function_name: str,
+    callback_name: str | None,
+) -> str | None:
+    if callback_name is None:
+        return _default_docstring(
+            series,
+            function_kind=function_kind,
+            series_id=str(resolution["series_id"]),
+        )
+
+    contract = derive_doc_contract(
+        series,
+        function_kind=function_kind,
+        function_name=function_name,
+        resolution=resolution,
+        bindings=bindings,
+    )
+    ctx = SeriesBindingDocstringContext(
+        graph=graph,
+        workbook=workbook,
+        bindings=bindings,
+        series=series,
+        resolution=resolution,
+        contract=contract,
+        function_kind=function_kind,
+        function_name=function_name,
+    )
+    structured = run_series_docstring_callback(callback_name, ctx)
+    if structured is None:
+        return None
+    return render_series_function_doc(structured, contract=contract, series=series)
+
+
+def _register_builtin_callbacks() -> None:
+    register_series_docstring_callback("series_notes", _series_notes_callback)
+
+
+_register_builtin_callbacks()
+
+__all__ = [
+    "FieldContract",
+    "FieldDoc",
+    "SeriesBindingDocstringCallback",
+    "SeriesBindingDocstringContext",
+    "SeriesBindingDocstringContract",
+    "SeriesFunctionDoc",
+    "SeriesFunctionKind",
+    "derive_doc_contract",
+    "emit_docstring_literal",
+    "list_series_docstring_callbacks",
+    "register_series_docstring_callback",
+    "render_series_function_doc",
+    "resolve_series_function_docstring",
+    "run_series_docstring_callback",
+]

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.docstrings import (
+    emit_docstring_literal,
+    resolve_series_function_docstring,
+)
 from excel_grapher.series_bindings.normalize import has_input_direction
 from excel_grapher.series_bindings.resolve import resolve_series_bindings
 from excel_grapher.series_bindings.types import (
@@ -63,6 +67,11 @@ def _allowed_record_fields(
 def emit_setter_function(
     series: dict[str, Any],
     resolved: SeriesResolution,
+    *,
+    graph: DependencyGraph | None = None,
+    workbook: Path | str | None = None,
+    bindings: WorkbookSeriesBindings | None = None,
+    series_docstring_callback: str | None = None,
 ) -> list[str]:
     """Emit Python source lines for one series binding setter."""
     if not resolved["leaves"]:
@@ -101,12 +110,29 @@ def emit_setter_function(
     lines.append("    *,")
     lines.append(f"    strict: bool = {strict!r},")
     lines.append(") -> None:")
-    doc = (
-        series.get("notes")
-        or series.get("sdmx_notes")
-        or f"Apply records for {resolved['series_id']}."
-    )
-    lines.append(f'    """{doc}"""')
+    if series_docstring_callback is not None and (
+        graph is None or workbook is None or bindings is None
+    ):
+        raise ValueError("series_docstring_callback requires graph, workbook, and bindings context")
+    if graph is not None and workbook is not None and bindings is not None:
+        doc = resolve_series_function_docstring(
+            graph=graph,
+            workbook=workbook,
+            bindings=bindings,
+            series=series,
+            resolution=resolved,
+            function_kind="setter",
+            function_name=fn_name,
+            callback_name=series_docstring_callback,
+        )
+    else:
+        doc = (
+            series.get("notes")
+            or series.get("sdmx_notes")
+            or f"Apply records for {resolved['series_id']}."
+        )
+    if doc is not None:
+        lines.extend(emit_docstring_literal(doc))
     lines.append(f"    key_fields = {tuple(key_fields)!r}")
     lines.append(f"    allow_address = {allow_address!r}")
     lines.append(f"    requires_address = {requires_address!r}")
@@ -163,6 +189,7 @@ def emit_setters_block(
     bindings: WorkbookSeriesBindings,
     *,
     include_type_aliases: bool = True,
+    series_docstring_callback: str | None = None,
 ) -> list[str]:
     """Emit all series setter functions for a validated binding manifest."""
     report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="input")
@@ -195,7 +222,16 @@ def emit_setters_block(
         series = by_id.get(resolved["series_id"])
         if series is None:
             continue
-        lines.extend(emit_setter_function(series, resolved))
+        lines.extend(
+            emit_setter_function(
+                series,
+                resolved,
+                graph=graph,
+                workbook=workbook,
+                bindings=bindings,
+                series_docstring_callback=series_docstring_callback,
+            )
+        )
     if failed:
         raise ValueError(f"Cannot codegen setters: resolution failed for {failed!r}")
     return lines

--- a/tests/integration/user_flows/test_series_bindings_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_codegen.py
@@ -9,7 +9,12 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
 
-from excel_grapher.exporter import CodeGenerator
+from excel_grapher.exporter import (
+    CodeGenerator,
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
 from excel_grapher.grapher import create_dependency_graph
 from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
 
@@ -97,6 +102,45 @@ def test_codegen_includes_setters_and_updates_inputs() -> None:
     ctx = make_context()
     set_borvelia_primary_balance(ctx, [{"TIME_PERIOD": 4, "OBS_VALUE": 7.5}])
     assert ctx.inputs["Sheet1!I5"] == 7.5
+
+
+def test_generate_applies_series_docstring_callback() -> None:
+    callback_name = "_test_integration_setter_docstring"
+    register_series_docstring_callback(
+        callback_name,
+        lambda ctx: SeriesFunctionDoc(
+            summary=f"Set {ctx.contract.series_id}.",
+            purpose="Integration test purpose.",
+            record_matching="Match by TIME_PERIOD.",
+            field_descriptions={
+                "TIME_PERIOD": FieldDoc(description="Reporting year."),
+                "OBS_VALUE": FieldDoc(description="Observed value."),
+            },
+        ),
+    )
+    bindings = validate_bindings_document(deepcopy(BINDINGS_DOCUMENT))
+    targets: list[str] = []
+    for series in bindings["series"]:
+        targets.extend(expand_data_range(series["data_range"], workbook=WORKBOOK))
+    graph = create_dependency_graph(WORKBOOK, targets, load_values=True)
+
+    with CodeGenerator(graph) as gen:
+        code = gen.generate(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=WORKBOOK,
+            series_docstring_callback=callback_name,
+        )
+
+    ns: dict[str, object] = {}
+    exec(code, ns)
+    setter = cast(
+        Callable[[Any, list[dict[str, object]]], None],
+        ns["set_borvelia_primary_balance"],
+    )
+    assert setter.__doc__ is not None
+    assert "Set borvelia_primary_balance." in setter.__doc__
+    assert "Required record fields:" in setter.__doc__
 
 
 def test_generate_modules_exports_series_binding_setters(tmp_path: Path) -> None:

--- a/tests/integration/user_flows/test_series_bindings_output_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_output_codegen.py
@@ -11,7 +11,12 @@ from typing import Any, cast
 
 import xlsxwriter
 
-from excel_grapher.exporter import CodeGenerator
+from excel_grapher.exporter import (
+    CodeGenerator,
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
 from excel_grapher.grapher import create_dependency_graph
 from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
 
@@ -119,6 +124,44 @@ def test_codegen_includes_output_compute_and_setter(tmp_path: Path) -> None:
     by_period = {cast(int, r["TIME_PERIOD"]): r for r in records}
     assert by_period[4]["OBS_VALUE"] == 7.5
     assert by_period[5]["OBS_VALUE"] == 5.0
+
+
+def test_generate_applies_series_docstring_callback_to_output_compute(
+    tmp_path: Path,
+) -> None:
+    callback_name = "_test_integration_compute_docstring"
+    register_series_docstring_callback(
+        callback_name,
+        lambda ctx: SeriesFunctionDoc(
+            summary=f"Compute {ctx.contract.series_id}.",
+            purpose="Integration test purpose.",
+            record_matching="One record per output cell.",
+            field_descriptions={
+                "TIME_PERIOD": FieldDoc(description="Reporting year."),
+                "OBS_VALUE": FieldDoc(description="Computed value."),
+            },
+        ),
+    )
+    workbook = tmp_path / "series_bindings_output.xlsx"
+    _write_output_workbook(workbook)
+    bindings = validate_bindings_document(deepcopy(BINDINGS_DOCUMENT))
+    targets = expand_data_range("Sheet1!F5:J5", workbook=workbook) + ["Sheet1!G5"]
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+
+    with CodeGenerator(graph) as gen:
+        code = gen.generate(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+            series_docstring_callback=callback_name,
+        )
+
+    ns: dict[str, object] = {}
+    exec(code, ns)
+    compute = cast(Callable[..., list[dict[str, object]]], ns["compute_borvelia_primary_balance"])
+    assert compute.__doc__ is not None
+    assert "Compute borvelia_primary_balance." in compute.__doc__
+    assert "Example:" in compute.__doc__
 
 
 def test_generate_modules_exports_output_compute(tmp_path: Path) -> None:

--- a/tests/unit/series_bindings/test_compute_codegen.py
+++ b/tests/unit/series_bindings/test_compute_codegen.py
@@ -19,6 +19,11 @@ from excel_grapher.series_bindings import (
     resolve_series_binding,
 )
 from excel_grapher.series_bindings.compute_codegen import emit_compute_function, emit_computes_block
+from excel_grapher.series_bindings.docstrings import (
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
 
@@ -166,3 +171,103 @@ def test_emit_computes_block_warns_when_output_has_no_graph_overlap(tmp_path: Pa
         lines = emit_computes_block(graph, wb_path, bindings)
 
     assert "def compute_scaled_output(" not in "\n".join(lines)
+
+
+def test_emit_compute_structured_docstring_callback(tmp_path: Path) -> None:
+    callback_name = "_test_compute_structured_docstring"
+    register_series_docstring_callback(
+        callback_name,
+        lambda ctx: SeriesFunctionDoc(
+            summary="Compute scaled output.",
+            purpose="Returns scaled output records.",
+            record_matching="One record per output cell.",
+            field_descriptions={
+                "LABEL": FieldDoc(description="Series label."),
+                "OBS_VALUE": FieldDoc(description="Computed value."),
+            },
+        ),
+    )
+    wb_path = tmp_path / "formula.xlsx"
+    _write_formula_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, ["Sheet1!C2"], load_values=True)
+    series = {
+        "id": "scaled_output",
+        "sheet": "Sheet1",
+        "data_range": "Sheet1!C2",
+        "layout": "scalar",
+        "output": {"compute": {"name": "compute_scaled_output"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+            "dimensions": [
+                {
+                    "concept": "LABEL",
+                    "role": "key",
+                    "scope": "series",
+                    "bind": {"kind": "constant", "value": "scaled"},
+                }
+            ],
+        },
+        "key": ["LABEL"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series, direction="output")
+    lines = [
+        "Record = dict[str, object]",
+        "Records = list[Record]",
+        "",
+        *emit_compute_function(
+            series,
+            resolved,
+            graph=graph,
+            workbook=wb_path,
+            bindings={
+                "schema_version": "1.2.0",
+                "workbook": "formula.xlsx",
+                "series": [series],
+                "concept_scheme": {},
+            },
+            series_docstring_callback=callback_name,
+        ),
+    ]
+
+    def resolver(address: str):
+        if address == "Sheet1!C2":
+            return lambda ctx: 10.0
+        return None
+
+    ns = _exec_compute(lines, resolver=resolver)
+    compute = cast(Callable[..., Records], ns["compute_scaled_output"])
+    assert compute.__doc__ is not None
+    assert "Compute scaled output." in compute.__doc__
+    assert "Example:" in compute.__doc__
+
+
+def test_emit_compute_callback_requires_codegen_context(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula.xlsx"
+    _write_formula_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, ["Sheet1!C2"], load_values=True)
+    series = {
+        "id": "scaled_output",
+        "sheet": "Sheet1",
+        "data_range": "Sheet1!C2",
+        "layout": "scalar",
+        "output": {"compute": {"name": "compute_scaled_output"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+            "dimensions": [
+                {
+                    "concept": "LABEL",
+                    "role": "key",
+                    "scope": "series",
+                    "bind": {"kind": "constant", "value": "scaled"},
+                }
+            ],
+        },
+        "key": ["LABEL"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series, direction="output")
+    with pytest.raises(ValueError, match="requires graph, workbook, and bindings"):
+        _ = emit_compute_function(
+            series,
+            resolved,
+            series_docstring_callback="series_notes",
+        )

--- a/tests/unit/series_bindings/test_docstrings.py
+++ b/tests/unit/series_bindings/test_docstrings.py
@@ -1,0 +1,366 @@
+"""Unit tests for series-binding docstring callbacks and contract derivation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import xlsxwriter
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings import (
+    expand_data_range,
+    load_series_bindings,
+    resolve_series_binding,
+)
+from excel_grapher.series_bindings.docstrings import (
+    FieldDoc,
+    SeriesBindingDocstringContext,
+    SeriesFunctionDoc,
+    derive_doc_contract,
+    emit_docstring_literal,
+    list_series_docstring_callbacks,
+    register_series_docstring_callback,
+    render_series_function_doc,
+    resolve_series_function_docstring,
+    run_series_docstring_callback,
+)
+from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
+
+
+def _bindings_stub() -> WorkbookSeriesBindings:
+    return {
+        "schema_version": "1.0.0",
+        "workbook": "unused.xlsx",
+        "series": [],
+        "concept_scheme": {},
+    }
+
+
+def _write_borvelia_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("A2", "Borvelia")
+    ws.write("A5", "Primary balance (% of GDP)")
+    for col, year in enumerate([1, 2, 3, 4, 5], start=5):
+        ws.write(0, col, year)
+        ws.write_number(4, col, float(year - 3))
+    wb.close()
+
+
+def test_list_series_docstring_callbacks_includes_builtins() -> None:
+    names = set(list_series_docstring_callbacks())
+    assert "series_notes" in names
+
+
+def test_register_series_docstring_callback_rejects_duplicate() -> None:
+    def _noop(ctx: SeriesBindingDocstringContext) -> SeriesFunctionDoc | None:
+        del ctx
+        return None
+
+    unique_name = "_test_duplicate_docstring_callback"
+    register_series_docstring_callback(unique_name, _noop)
+    with pytest.raises(ValueError, match="duplicate"):
+        register_series_docstring_callback(unique_name, _noop)
+
+
+def test_register_series_docstring_callback_allows_replace() -> None:
+    name = "_test_replace_docstring_callback"
+    register_series_docstring_callback(
+        name,
+        lambda ctx: SeriesFunctionDoc(
+            summary="first",
+            purpose="first",
+            record_matching="first",
+        ),
+    )
+    register_series_docstring_callback(
+        name,
+        lambda ctx: SeriesFunctionDoc(
+            summary="second",
+            purpose="second",
+            record_matching="second",
+        ),
+        replace=True,
+    )
+    rendered = resolve_series_function_docstring(
+        graph=DependencyGraph(),
+        workbook=Path("unused.xlsx"),
+        bindings=_bindings_stub(),
+        series={
+            "id": "demo",
+            "data_range": "Sheet1!A1",
+            "layout": "scalar",
+            "structure": {"measure": {"concept": "OBS_VALUE"}},
+            "key": [],
+        },
+        resolution={
+            "series_id": "demo",
+            "ok": True,
+            "requires_address": False,
+            "leaves": [
+                {
+                    "address": "S!A1",
+                    "coordinates": {},
+                    "key": {},
+                    "record": {"OBS_VALUE": 1.0},
+                }
+            ],
+            "issues": [],
+        },
+        function_kind="setter",
+        function_name="set_demo",
+        callback_name=name,
+    )
+    assert rendered is not None
+    assert rendered.startswith("second")
+
+
+def test_run_series_docstring_callback_unknown_name_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown series docstring callback"):
+        run_series_docstring_callback("not.registered.callback", _make_context())
+
+
+def _make_context() -> SeriesBindingDocstringContext:
+    return SeriesBindingDocstringContext(
+        graph=DependencyGraph(),
+        workbook=Path("unused.xlsx"),
+        bindings=_bindings_stub(),
+        series={"id": "demo"},
+        resolution={
+            "series_id": "demo",
+            "ok": True,
+            "requires_address": False,
+            "leaves": [],
+            "issues": [],
+        },
+        contract=derive_doc_contract(
+            {"id": "demo", "structure": {"measure": {"concept": "OBS_VALUE", "dtype": "float"}}},
+            function_kind="setter",
+            function_name="set_demo",
+            resolution={
+                "series_id": "demo",
+                "ok": True,
+                "requires_address": False,
+                "leaves": [],
+                "issues": [],
+            },
+            bindings=_bindings_stub(),
+        ),
+        function_kind="setter",
+        function_name="set_demo",
+    )
+
+
+def test_derive_doc_contract_required_and_optional_fields(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!F5:J5"),
+        load_values=True,
+    )
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+
+    contract = derive_doc_contract(
+        series,
+        function_kind="setter",
+        function_name="set_borvelia_primary_balance",
+        resolution=resolved,
+        bindings=bindings,
+    )
+
+    assert contract.series_id == "borvelia_primary_balance"
+    assert contract.function_name == "set_borvelia_primary_balance"
+    assert contract.function_kind == "setter"
+    assert contract.data_range == "Inputs!F5:J5"
+    assert contract.layout == "row_series"
+    assert contract.value_type == "float"
+    assert contract.required_fields == ("TIME_PERIOD", "OBS_VALUE")
+    assert contract.fields["TIME_PERIOD"].required is True
+    assert contract.fields["UNIT_MEASURE"].required is False
+    assert contract.fields["UNIT_MEASURE"].expected_value == "PC_GDP"
+    assert len(contract.example_records) >= 1
+    assert "TIME_PERIOD" in contract.example_records[0]
+    assert "OBS_VALUE" in contract.example_records[0]
+
+
+def test_derive_doc_contract_uses_none_for_unknown_dtype() -> None:
+    contract = derive_doc_contract(
+        {
+            "id": "demo",
+            "data_range": "Sheet1!A1",
+            "layout": "scalar",
+            "structure": {
+                "measure": {"concept": "OBS_VALUE"},
+                "dimensions": [{"concept": "TIME_PERIOD"}],
+            },
+            "key": ["TIME_PERIOD"],
+        },
+        function_kind="setter",
+        function_name="set_demo",
+        resolution={
+            "series_id": "demo",
+            "ok": True,
+            "requires_address": False,
+            "leaves": [
+                {
+                    "address": "Sheet1!A1",
+                    "coordinates": {},
+                    "key": {"TIME_PERIOD": 1},
+                    "record": {"TIME_PERIOD": 1, "OBS_VALUE": 2.0},
+                }
+            ],
+            "issues": [],
+        },
+        bindings={
+            "schema_version": "1.0.0",
+            "workbook": "demo.xlsx",
+            "series": [],
+            "concept_scheme": {},
+        },
+    )
+    assert contract.value_type is None
+    assert contract.fields["OBS_VALUE"].dtype is None
+    assert contract.fields["TIME_PERIOD"].dtype is None
+
+
+def test_render_series_function_doc_includes_sections() -> None:
+    contract = derive_doc_contract(
+        {
+            "id": "demo",
+            "data_range": "Sheet1!A1",
+            "layout": "scalar",
+            "structure": {
+                "measure": {"concept": "OBS_VALUE", "dtype": "float"},
+                "dimensions": [
+                    {
+                        "concept": "TIME_PERIOD",
+                        "include_in_record": True,
+                    }
+                ],
+            },
+            "key": ["TIME_PERIOD"],
+        },
+        function_kind="setter",
+        function_name="set_demo",
+        resolution={
+            "series_id": "demo",
+            "ok": True,
+            "requires_address": False,
+            "leaves": [
+                {
+                    "address": "Sheet1!A1",
+                    "coordinates": {},
+                    "key": {"TIME_PERIOD": 1},
+                    "record": {"TIME_PERIOD": 1, "OBS_VALUE": 2.0},
+                }
+            ],
+            "issues": [],
+        },
+        bindings={
+            "schema_version": "1.0.0",
+            "workbook": "demo.xlsx",
+            "series": [],
+            "concept_scheme": {},
+        },
+    )
+    doc = SeriesFunctionDoc(
+        summary="Set demo values.",
+        purpose="Updates the demo input series.",
+        record_matching="Records match by TIME_PERIOD.",
+        field_descriptions={
+            "TIME_PERIOD": FieldDoc(description="Reporting period."),
+            "OBS_VALUE": FieldDoc(description="Observed value."),
+        },
+    )
+    rendered = render_series_function_doc(doc, contract=contract, series={"id": "demo"})
+    assert "Set demo values." in rendered
+    assert "Required record fields:" in rendered
+    assert "TIME_PERIOD:" in rendered
+    assert "Source binding:" in rendered
+    assert "Example:" in rendered
+    assert "set_demo(ctx, [" in rendered
+
+
+def test_emit_docstring_literal_escapes_quotes_and_is_valid_python() -> None:
+    doc = 'Contains "quotes" and\nmultiple lines.'
+    lines = emit_docstring_literal(doc)
+    code = "def fn():\n" + "\n".join(lines) + "\n    pass"
+    exec(code, {})
+
+
+def test_resolve_series_function_docstring_default_uses_series_notes() -> None:
+    series: dict[str, Any] = {
+        "id": "demo",
+        "notes": "Custom notes for demo.",
+        "structure": {"measure": {"concept": "OBS_VALUE", "dtype": "float"}},
+        "key": [],
+    }
+    resolved = cast(
+        SeriesResolution,
+        {
+            "series_id": "demo",
+            "ok": True,
+            "requires_address": False,
+            "leaves": [{"address": "S!A1", "coordinates": {}, "key": {}, "record": {}}],
+            "issues": [],
+        },
+    )
+    doc = resolve_series_function_docstring(
+        graph=DependencyGraph(),
+        workbook=Path("unused.xlsx"),
+        bindings=_bindings_stub(),
+        series=series,
+        resolution=resolved,
+        function_kind="setter",
+        function_name="set_demo",
+        callback_name=None,
+    )
+    assert doc == "Custom notes for demo."
+
+
+def test_resolve_series_function_docstring_registered_callback(tmp_path: Path) -> None:
+    callback_name = "_test_structured_docstring_callback"
+    register_series_docstring_callback(
+        callback_name,
+        lambda ctx: SeriesFunctionDoc(
+            summary=f"Set {ctx.contract.series_id}.",
+            purpose="Purpose text.",
+            record_matching="Match by key.",
+            field_descriptions={
+                field: FieldDoc(description=f"Describe {field}.")
+                for field in ctx.contract.required_fields
+            },
+        ),
+    )
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!F5:J5"),
+        load_values=True,
+    )
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+
+    doc = resolve_series_function_docstring(
+        graph=graph,
+        workbook=wb_path,
+        bindings=bindings,
+        series=series,
+        resolution=resolved,
+        function_kind="setter",
+        function_name="set_borvelia_primary_balance",
+        callback_name=callback_name,
+    )
+    assert doc is not None
+    assert "Set borvelia_primary_balance." in doc
+    assert "Required record fields:" in doc

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -16,6 +16,11 @@ from excel_grapher.series_bindings import (
     load_series_bindings,
     resolve_series_binding,
 )
+from excel_grapher.series_bindings.docstrings import (
+    FieldDoc,
+    SeriesFunctionDoc,
+    register_series_docstring_callback,
+)
 from excel_grapher.series_bindings.setter_codegen import emit_setter_function, emit_setters_block
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
@@ -169,3 +174,91 @@ def test_emit_setters_block_skips_series_without_graph_leaf_overlap(tmp_path: Pa
         lines = emit_setters_block(graph, wb_path, bindings)
 
     assert "def set_borvelia_primary_balance(" not in "\n".join(lines)
+
+
+def test_emit_setter_structured_docstring_callback(tmp_path: Path) -> None:
+    callback_name = "_test_setter_structured_docstring"
+    register_series_docstring_callback(
+        callback_name,
+        lambda ctx: SeriesFunctionDoc(
+            summary="Set borvelia values.",
+            purpose="Updates borvelia primary balance inputs.",
+            record_matching="Match records by TIME_PERIOD.",
+            field_descriptions={
+                "TIME_PERIOD": FieldDoc(description="Reporting year."),
+                "OBS_VALUE": FieldDoc(description='Value with "quotes".'),
+            },
+        ),
+    )
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!F5:J5"),
+        load_values=True,
+    )
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(
+        series,
+        resolved,
+        graph=graph,
+        workbook=wb_path,
+        bindings=bindings,
+        series_docstring_callback=callback_name,
+    )
+    code = "\n".join(lines)
+    ns = _exec_setters(lines)
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_borvelia_primary_balance"],
+    )
+    assert setter.__doc__ is not None
+    assert "Set borvelia values." in setter.__doc__
+    assert 'Value with "quotes".' in setter.__doc__
+    exec(code, {"EvalContext": EvalContext, "coerce_inputs_dict": coerce_inputs_dict})
+
+
+def test_emit_setter_docstring_callback_none_omits_docstring(tmp_path: Path) -> None:
+    callback_name = "_test_setter_none_docstring"
+    register_series_docstring_callback(callback_name, lambda ctx: None)
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!F5:J5"),
+        load_values=True,
+    )
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(
+        series,
+        resolved,
+        graph=graph,
+        workbook=wb_path,
+        bindings=bindings,
+        series_docstring_callback=callback_name,
+    )
+    ns = _exec_setters(lines)
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_borvelia_primary_balance"],
+    )
+    assert setter.__doc__ is None
+
+
+def test_emit_setter_callback_requires_codegen_context(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    with pytest.raises(ValueError, match="requires graph, workbook, and bindings"):
+        _ = emit_setter_function(
+            series,
+            resolved,
+            series_docstring_callback="series_notes",
+        )


### PR DESCRIPTION
## Summary
- add a new series-binding docstring callback registry with structured callback context/contract and renderer support
- thread `series_docstring_callback` through `CodeGenerator.generate()`/`generate_modules()` and series binding emitters for generated `set_*` and output `compute_*` docs
- tighten behavior by requiring full context when a callback name is supplied, supporting callback replacement (`replace=True`), and documenting usage in README + micro-workbook docs

## Test plan
- [x] `uv run pytest tests/unit/series_bindings/test_docstrings.py tests/unit/series_bindings/test_setter_codegen.py tests/unit/series_bindings/test_compute_codegen.py tests/integration/user_flows/test_series_bindings_codegen.py tests/integration/user_flows/test_series_bindings_output_codegen.py -q`
- [x] `uv run ty check`
- [x] `uv run quarto render "examples/micro_workbooks/series_bindings.qmd"`

Made with [Cursor](https://cursor.com)