### PR TITLE
Support keyless scalar series bindings

### DIFF
--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -456,6 +456,18 @@ def resolve_series_binding(
             else:
                 seen_keys[key_tuple] = address
 
+    layout = series.get("layout")
+    if layout == "scalar" and not key_concepts and len(leaves) > 1:
+        issues.append(
+            make_issue(
+                "error",
+                "keyless_scalar_ambiguous",
+                "Keyless scalar binding must resolve to exactly one leaf; "
+                f"got {len(leaves)} leaves in data_range",
+                series_id=series_id,
+            )
+        )
+
     ok = not any(i["level"] == "error" for i in issues)
     return {
         "series_id": series_id,

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -381,7 +381,6 @@
             "measure": { "$ref": "#/$defs/Measure" },
             "dimensions": {
               "type": "array",
-              "minItems": 1,
               "items": { "$ref": "#/$defs/Dimension" }
             },
             "attributes": {
@@ -393,10 +392,9 @@
         },
         "key": {
           "type": "array",
-          "minItems": 1,
           "items": { "$ref": "#/$defs/ConceptId" },
           "uniqueItems": true,
-          "description": "Concept ids required on each incoming record for matching (MVP row_series: typically [TIME_PERIOD] when country and indicator are series-scoped)."
+          "description": "Concept ids required on each incoming record for matching (MVP row_series: typically [TIME_PERIOD] when country and indicator are series-scoped). Scalar layout may use an empty key when the binding resolves to a single cell."
         },
         "series_context": {
           "type": "object",
@@ -417,9 +415,37 @@
       },
       "allOf": [
         { "$ref": "#/$defs/SeriesBindingDirectionRules" },
+        { "$ref": "#/$defs/SeriesBindingLayoutKeyRules" },
         { "$ref": "#/$defs/SeriesBindingMvpRules" },
         { "$ref": "#/$defs/SeriesBindingMatrixRules" }
       ]
+    },
+    "SeriesBindingLayoutKeyRules": {
+      "description": "Non-scalar layouts require at least one key and dimension; scalar may use empty key and dimensions.",
+      "if": {
+        "properties": { "layout": { "const": "scalar" } },
+        "required": ["layout"]
+      },
+      "then": {
+        "properties": {
+          "key": { "minItems": 0 },
+          "structure": {
+            "properties": {
+              "dimensions": { "minItems": 0 }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "key": { "minItems": 1 },
+          "structure": {
+            "properties": {
+              "dimensions": { "minItems": 1 }
+            }
+          }
+        }
+      }
     },
     "SeriesBindingDirectionRules": {
       "description": "Each series must declare at least one of input or output (legacy top-level setter counts as input).",

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -47,6 +47,18 @@ def _measure_concept(series: dict[str, Any]) -> str:
     return str(measure.get("concept") or "OBS_VALUE")
 
 
+def _accepts_scalar_shorthand(
+    series: dict[str, Any],
+    resolved: SeriesResolution,
+) -> bool:
+    """True when the setter may accept a bare measure value instead of record(s)."""
+    if series.get("layout") != "scalar":
+        return False
+    if series.get("key"):
+        return False
+    return len(resolved["leaves"]) == 1
+
+
 def _allowed_record_fields(
     series: dict[str, Any],
     *,
@@ -108,9 +120,13 @@ def emit_setter_function(
             lines.append(f"    {key_tuple_src}: {repr(leaf['address'])},")
         lines.append("}")
         lines.append("")
+    scalar_shorthand = _accepts_scalar_shorthand(series, resolved)
     lines.append(f"def {fn_name}(")
     lines.append("    ctx: EvalContext,")
-    lines.append("    records: Records,")
+    if scalar_shorthand:
+        lines.append("    records: Records | Record | object,")
+    else:
+        lines.append("    records: Records,")
     lines.append("    *,")
     lines.append(f"    strict: bool = {strict!r},")
     lines.append(") -> None:")
@@ -143,6 +159,12 @@ def emit_setter_function(
     lines.append(f"    requires_address = {requires_address!r}")
     lines.append(f"    measure_field = {measure_concept!r}")
     lines.append(f"    allowed_fields = {set(allowed)!r}")
+    if scalar_shorthand:
+        lines.append("    if not isinstance(records, list):")
+        lines.append("        if isinstance(records, dict):")
+        lines.append("            records = [records]")
+        lines.append("        else:")
+        lines.append("            records = [{measure_field: records}]")
     lines.append("    updates: dict[str, object] = {}")
     lines.append("    for index, record in enumerate(records):")
     lines.append("        if strict:")

--- a/schemas/series_binding.schema.json
+++ b/schemas/series_binding.schema.json
@@ -381,7 +381,6 @@
             "measure": { "$ref": "#/$defs/Measure" },
             "dimensions": {
               "type": "array",
-              "minItems": 1,
               "items": { "$ref": "#/$defs/Dimension" }
             },
             "attributes": {
@@ -393,10 +392,9 @@
         },
         "key": {
           "type": "array",
-          "minItems": 1,
           "items": { "$ref": "#/$defs/ConceptId" },
           "uniqueItems": true,
-          "description": "Concept ids required on each incoming record for matching (MVP row_series: typically [TIME_PERIOD] when country and indicator are series-scoped)."
+          "description": "Concept ids required on each incoming record for matching (MVP row_series: typically [TIME_PERIOD] when country and indicator are series-scoped). Scalar layout may use an empty key when the binding resolves to a single cell."
         },
         "series_context": {
           "type": "object",
@@ -417,9 +415,37 @@
       },
       "allOf": [
         { "$ref": "#/$defs/SeriesBindingDirectionRules" },
+        { "$ref": "#/$defs/SeriesBindingLayoutKeyRules" },
         { "$ref": "#/$defs/SeriesBindingMvpRules" },
         { "$ref": "#/$defs/SeriesBindingMatrixRules" }
       ]
+    },
+    "SeriesBindingLayoutKeyRules": {
+      "description": "Non-scalar layouts require at least one key and dimension; scalar may use empty key and dimensions.",
+      "if": {
+        "properties": { "layout": { "const": "scalar" } },
+        "required": ["layout"]
+      },
+      "then": {
+        "properties": {
+          "key": { "minItems": 0 },
+          "structure": {
+            "properties": {
+              "dimensions": { "minItems": 0 }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "key": { "minItems": 1 },
+          "structure": {
+            "properties": {
+              "dimensions": { "minItems": 1 }
+            }
+          }
+        }
+      }
     },
     "SeriesBindingDirectionRules": {
       "description": "Each series must declare at least one of input or output (legacy top-level setter counts as input).",

--- a/tests/unit/series_bindings/test_keyless_scalar.py
+++ b/tests/unit/series_bindings/test_keyless_scalar.py
@@ -1,0 +1,155 @@
+"""Tests for keyless scalar series bindings (issue #215)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import xlsxwriter
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.runtime.cache import EvalContext, coerce_inputs_dict
+from excel_grapher.series_bindings import (
+    expand_data_range,
+    resolve_series_binding,
+    validate_bindings_document,
+)
+from excel_grapher.series_bindings.setter_codegen import emit_setter_function
+
+KEYLESS_SCALAR_BINDING: dict[str, Any] = {
+    "schema_version": "1.2.0",
+    "series": [
+        {
+            "id": "country_name",
+            "sheet": "Inputs",
+            "data_range": "Inputs!B5",
+            "layout": "scalar",
+            "input": {
+                "setter": {
+                    "name": "set_country_name",
+                    "record_contract": "records",
+                    "strict": True,
+                }
+            },
+            "structure": {
+                "measure": {
+                    "concept": "OBS_VALUE",
+                    "dtype": "string",
+                    "bind": {"kind": "data_cell", "read": "string"},
+                },
+                "dimensions": [],
+                "attributes": [
+                    {
+                        "concept": "PARAMETER",
+                        "role": "attribute",
+                        "value": "country_name",
+                        "include_in_record": False,
+                    }
+                ],
+            },
+            "key": [],
+            "series_context": {"PARAMETER": "country_name"},
+        }
+    ],
+}
+
+
+def _exec_setters(lines: list[str]) -> dict[str, object]:
+    namespace: dict[str, object] = {
+        "EvalContext": EvalContext,
+        "coerce_inputs_dict": coerce_inputs_dict,
+    }
+    exec("\n".join(lines), namespace)
+    return namespace
+
+
+def test_keyless_scalar_binding_passes_schema() -> None:
+    bindings = validate_bindings_document(KEYLESS_SCALAR_BINDING)
+    series = bindings["series"][0]
+    assert series["key"] == []
+    assert series["structure"]["dimensions"] == []
+
+
+def test_keyless_scalar_resolves_single_leaf(tmp_path: Path) -> None:
+    wb_path = tmp_path / "inputs.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("B5", "Litellia")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Inputs!B5"], load_values=True)
+    series = cast(dict[str, Any], KEYLESS_SCALAR_BINDING["series"][0])
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True
+    assert resolved["requires_address"] is False
+    assert len(resolved["leaves"]) == 1
+    assert resolved["leaves"][0]["key"] == {}
+    assert resolved["leaves"][0]["record"]["OBS_VALUE"] == "Litellia"
+
+
+def test_keyless_scalar_multi_leaf_fails_resolution(tmp_path: Path) -> None:
+    wb_path = tmp_path / "multi.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("B5", "A")
+    ws.write("C5", "B")
+    wb.close()
+
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!B5:C5"),
+        load_values=True,
+    )
+    series: dict[str, Any] = {
+        **cast(dict[str, Any], KEYLESS_SCALAR_BINDING["series"][0]),
+        "data_range": "Inputs!B5:C5",
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is False
+    codes = {issue["code"] for issue in resolved["issues"]}
+    assert "keyless_scalar_ambiguous" in codes
+
+
+def test_keyless_scalar_setter_accepts_shorthand_value(tmp_path: Path) -> None:
+    wb_path = tmp_path / "inputs.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("B5", "Litellia")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Inputs!B5"], load_values=True)
+    series = cast(dict[str, Any], KEYLESS_SCALAR_BINDING["series"][0])
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(series, resolved)
+    ns = _exec_setters(lines)
+    setter = cast(
+        Callable[[EvalContext, object], None],
+        ns["set_country_name"],
+    )
+
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    setter(ctx, "Newland")
+    assert ctx.inputs["Inputs!B5"] == "Newland"
+
+
+def test_keyless_scalar_setter_accepts_record_without_keys(tmp_path: Path) -> None:
+    wb_path = tmp_path / "inputs.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("B5", "Litellia")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Inputs!B5"], load_values=True)
+    series = cast(dict[str, Any], KEYLESS_SCALAR_BINDING["series"][0])
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(series, resolved)
+    ns = _exec_setters(lines)
+    setter = cast(
+        Callable[[EvalContext, object], None],
+        ns["set_country_name"],
+    )
+
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    setter(ctx, [{"OBS_VALUE": "Newland"}])
+    assert ctx.inputs["Inputs!B5"] == "Newland"

--- a/tests/unit/series_bindings/test_schema.py
+++ b/tests/unit/series_bindings/test_schema.py
@@ -92,6 +92,35 @@ def test_schema_accepts_1_1_0_matrix_fixture() -> None:
     assert bindings["series"][0]["structure"]["dimensions"][0]["bind"]["kind"] == "row_hierarchy"
 
 
+def test_row_series_rejects_empty_key() -> None:
+    doc = {
+        "schema_version": "1.0.0",
+        "series": [
+            {
+                "id": "empty_key_row",
+                "sheet": "S",
+                "data_range": "S!B2:C2",
+                "layout": "row_series",
+                "setter": {"name": "set_empty_key_row"},
+                "structure": {
+                    "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+                    "dimensions": [
+                        {
+                            "concept": "TIME_PERIOD",
+                            "role": "key",
+                            "scope": "cell",
+                            "bind": {"kind": "column_header", "header_row": 1},
+                        }
+                    ],
+                },
+                "key": [],
+            }
+        ],
+    }
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
 def test_row_series_requires_cell_scoped_dimension() -> None:
     doc = {
         "schema_version": "1.0.0",


### PR DESCRIPTION
## Summary

- Allow `key: []` and empty `structure.dimensions` for `layout: scalar` in the series binding schema.
- Reject keyless scalar bindings that resolve to more than one leaf (`keyless_scalar_ambiguous`).
- Generate scalar setters that accept bare measure values (normalized to `OBS_VALUE` records) or keyless record shapes.

Closes #215.

## Test plan

- [x] `uv run pytest tests/unit/series_bindings/test_keyless_scalar.py`
- [x] `uv run pytest tests/unit/series_bindings/`
- [x] `uv run pytest tests/integration/user_flows/test_series_bindings*.py`


Made with [Cursor](https://cursor.com)