### PR TITLE
Reduce generated API duplication by extracting shared setter helper

### DIFF
--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -53,6 +53,7 @@ from excel_grapher.series_bindings.schema import (
 )
 from excel_grapher.series_bindings.setter_codegen import (
     emit_setter_function,
+    emit_setter_helpers,
     emit_setters_block,
     generate_setters_module,
 )
@@ -123,6 +124,7 @@ __all__ = [
     "emit_computes_block",
     "emit_series_bindings_block",
     "emit_setter_function",
+    "emit_setter_helpers",
     "emit_setters_block",
     "generate_computes_module",
     "has_input_direction",

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -79,6 +79,64 @@ def _allowed_record_fields(
     return {f for f in fields if f}
 
 
+def emit_setter_helpers() -> list[str]:
+    """Emit shared private helpers used by generated ``set_*`` functions."""
+    return [
+        "def _coerce_records(records, measure_field, *, allow_scalar=False) -> Records:",
+        "    if not allow_scalar:",
+        "        return records",
+        "    if not isinstance(records, list):",
+        "        if isinstance(records, dict):",
+        "            return [records]",
+        "        return [{measure_field: records}]",
+        "    return records",
+        "",
+        "def _apply_series_records(",
+        "    ctx,",
+        "    records,",
+        "    *,",
+        "    key_fields,",
+        "    allowed_fields,",
+        "    measure_field,",
+        "    leaf_index,",
+        "    strict,",
+        "    fn_name,",
+        "    allow_address=False,",
+        "    requires_address=False,",
+        ") -> None:",
+        "    updates: dict[str, object] = {}",
+        "    for index, record in enumerate(records):",
+        "        if strict:",
+        "            unknown = set(record) - allowed_fields",
+        "            if unknown:",
+        '                raise ValueError(f"record[{index}]: unknown fields {sorted(unknown)!r}")',
+        "        if measure_field not in record:",
+        '            raise ValueError(f"record[{index}]: missing required field {measure_field!r}")',
+        "        address = None",
+        "        if allow_address or requires_address:",
+        '            address = record.get("address") or record.get("cell_address")',
+        "        if requires_address and address is None:",
+        "            raise ValueError(",
+        '                f"record[{index}]: address required for {fn_name} (duplicate keys in binding)"',
+        "            )",
+        "        if address is None:",
+        "            if not requires_address:",
+        "                missing = [field for field in key_fields if field not in record]",
+        "                if missing:",
+        '                    raise ValueError(f"record[{index}]: missing key fields {missing!r}")',
+        "                key_tuple = tuple((field, record[field]) for field in key_fields)",
+        "                address = leaf_index.get(key_tuple)",
+        "                if address is None:",
+        "                    raise ValueError(",
+        '                        f"record[{index}]: no leaf matches key {dict(key_tuple)!r}"',
+        "                    )",
+        "        updates[address] = record[measure_field]",
+        "    if updates:",
+        "        ctx.set_inputs(coerce_inputs_dict(updates))",
+        "",
+    ]
+
+
 def emit_setter_function(
     series: dict[str, Any],
     resolved: SeriesResolution,
@@ -154,58 +212,24 @@ def emit_setter_function(
         )
     if doc is not None:
         lines.extend(emit_docstring_literal(doc))
-    lines.append(f"    key_fields = {tuple(key_fields)!r}")
-    lines.append(f"    allow_address = {allow_address!r}")
-    lines.append(f"    requires_address = {requires_address!r}")
-    lines.append(f"    measure_field = {measure_concept!r}")
-    lines.append(f"    allowed_fields = {set(allowed)!r}")
+    leaf_index_arg = "{}" if requires_address else index_name
     if scalar_shorthand:
-        lines.append("    if not isinstance(records, list):")
-        lines.append("        if isinstance(records, dict):")
-        lines.append("            records = [records]")
-        lines.append("        else:")
-        lines.append("            records = [{measure_field: records}]")
-    lines.append("    updates: dict[str, object] = {}")
-    lines.append("    for index, record in enumerate(records):")
-    lines.append("        if strict:")
-    lines.append("            unknown = set(record) - allowed_fields")
-    lines.append("            if unknown:")
-    lines.append(
-        '                raise ValueError(f"record[{index}]: unknown fields {sorted(unknown)!r}")'
-    )
-    lines.append("        if measure_field not in record:")
-    lines.append(
-        '            raise ValueError(f"record[{index}]: missing required field {measure_field!r}")'
-    )
-    lines.append("        address = None")
-    lines.append("        if allow_address or requires_address:")
-    lines.append('            address = record.get("address") or record.get("cell_address")')
-    lines.append("        if requires_address and address is None:")
-    lines.append(
-        "            raise ValueError("
-        f'f"record[{{index}}]: address required for {fn_name} (duplicate keys in binding)"'
-        ")"
-    )
-    lines.append("        if address is None:")
-    if requires_address:
-        lines.append("            pass  # address required; key lookup disabled")
+        lines.append("    _apply_series_records(")
+        lines.append("        ctx,")
+        lines.append(f"        _coerce_records(records, {measure_concept!r}, allow_scalar=True),")
     else:
-        lines.append("            missing = [field for field in key_fields if field not in record]")
-        lines.append("            if missing:")
-        lines.append(
-            '                raise ValueError(f"record[{index}]: missing key fields {missing!r}")'
-        )
-        lines.append(
-            "            key_tuple = tuple((field, record[field]) for field in key_fields)"
-        )
-        lines.append(f"            address = {index_name}.get(key_tuple)")
-        lines.append("            if address is None:")
-        lines.append(
-            '                raise ValueError(f"record[{index}]: no leaf matches key {dict(key_tuple)!r}")'
-        )
-    lines.append("        updates[address] = record[measure_field]")
-    lines.append("    if updates:")
-    lines.append("        ctx.set_inputs(coerce_inputs_dict(updates))")
+        lines.append("    _apply_series_records(")
+        lines.append("        ctx,")
+        lines.append("        records,")
+    lines.append(f"        key_fields={tuple(key_fields)!r},")
+    lines.append(f"        allowed_fields={set(allowed)!r},")
+    lines.append(f"        measure_field={measure_concept!r},")
+    lines.append(f"        leaf_index={leaf_index_arg},")
+    lines.append("        strict=strict,")
+    lines.append(f"        fn_name={fn_name!r},")
+    lines.append(f"        allow_address={allow_address!r},")
+    lines.append(f"        requires_address={requires_address!r},")
+    lines.append("    )")
     lines.append("")
     return lines
 
@@ -231,6 +255,7 @@ def emit_setters_block(
                 "",
             ]
         )
+    lines.extend(emit_setter_helpers())
     by_id = {
         s["id"]: s
         for s in bindings.get("series", [])

--- a/tests/unit/series_bindings/test_keyless_scalar.py
+++ b/tests/unit/series_bindings/test_keyless_scalar.py
@@ -15,7 +15,11 @@ from excel_grapher.series_bindings import (
     resolve_series_binding,
     validate_bindings_document,
 )
-from excel_grapher.series_bindings.setter_codegen import emit_setter_function, emit_setters_block
+from excel_grapher.series_bindings.setter_codegen import (
+    emit_setter_function,
+    emit_setter_helpers,
+    emit_setters_block,
+)
 
 KEYLESS_SCALAR_BINDING: dict[str, Any] = {
     "schema_version": "1.2.0",
@@ -60,7 +64,7 @@ def _exec_setters(lines: list[str]) -> dict[str, object]:
         "EvalContext": EvalContext,
         "coerce_inputs_dict": coerce_inputs_dict,
     }
-    exec("\n".join(lines), namespace)
+    exec("\n".join(emit_setter_helpers() + lines), namespace)
     return namespace
 
 

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -21,7 +21,11 @@ from excel_grapher.series_bindings.docstrings import (
     SeriesFunctionDoc,
     register_series_docstring_callback,
 )
-from excel_grapher.series_bindings.setter_codegen import emit_setter_function, emit_setters_block
+from excel_grapher.series_bindings.setter_codegen import (
+    emit_setter_function,
+    emit_setter_helpers,
+    emit_setters_block,
+)
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
 
@@ -48,7 +52,7 @@ def _exec_setters(
     }
     if extra:
         namespace.update(extra)
-    exec("\n".join(lines), namespace)
+    exec("\n".join(emit_setter_helpers() + lines), namespace)
     return namespace
 
 
@@ -155,6 +159,19 @@ def test_emit_setter_allow_address(tmp_path: Path) -> None:
     assert ctx.inputs["Sheet1!D2"] == 99.0
 
 
+def test_emit_setters_block_emits_helpers_once(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    code = "\n".join(emit_setters_block(graph, wb_path, bindings))
+
+    assert code.count("def _apply_series_records(") == 1
+    assert code.count("def _coerce_records(") == 1
+    assert "_apply_series_records(" in code
+    assert "def set_borvelia_primary_balance(" in code
+
+
 def test_emit_setters_block_all_series(tmp_path: Path) -> None:
     wb_path = tmp_path / "lic_inputs.xlsx"
     _write_borvelia_workbook(wb_path)
@@ -208,7 +225,6 @@ def test_emit_setter_structured_docstring_callback(tmp_path: Path) -> None:
         bindings=bindings,
         series_docstring_callback=callback_name,
     )
-    code = "\n".join(lines)
     ns = _exec_setters(lines)
     setter = cast(
         Callable[[EvalContext, list[dict[str, object]]], None],
@@ -217,7 +233,10 @@ def test_emit_setter_structured_docstring_callback(tmp_path: Path) -> None:
     assert setter.__doc__ is not None
     assert "Set borvelia values." in setter.__doc__
     assert 'Value with "quotes".' in setter.__doc__
-    exec(code, {"EvalContext": EvalContext, "coerce_inputs_dict": coerce_inputs_dict})
+    exec(
+        "\n".join(emit_setter_helpers() + lines),
+        {"EvalContext": EvalContext, "coerce_inputs_dict": coerce_inputs_dict},
+    )
 
 
 def test_emit_setter_google_docstring_renderer(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Extract `_coerce_records` and `_apply_series_records` helpers into generated setter modules so validation and key-to-address resolution live in one place.
- Refactor `emit_setter_function` to emit declarative `set_*` wrappers that delegate to the shared helpers.
- Add a test asserting helpers are emitted once per generated block.

Closes #217

## Test plan
- [x] `uv run pytest tests/unit/series_bindings/test_setter_codegen.py tests/unit/series_bindings/test_keyless_scalar.py tests/integration/user_flows/test_series_bindings_codegen.py tests/integration/user_flows/test_series_bindings_output_codegen.py`


Made with [Cursor](https://cursor.com)