### PR TITLE
Fix defined name support in series bindings schema

### DIFF
--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -30,6 +30,7 @@
   "$defs": {
     "A1Range": {
       "type": "string",
+      "pattern": "!",
       "description": "Sheet-qualified range using project target conventions: Inputs!F5:J5, Inputs!F5:Inputs!J5, 'My Sheet'!A1:'My Sheet'!B2. Parsed via expand_targets_to_roots (not a single regex)."
     },
     "DefinedName": {

--- a/schemas/series_binding.schema.json
+++ b/schemas/series_binding.schema.json
@@ -30,6 +30,7 @@
   "$defs": {
     "A1Range": {
       "type": "string",
+      "pattern": "!",
       "description": "Sheet-qualified range using project target conventions: Inputs!F5:J5, Inputs!F5:Inputs!J5, 'My Sheet'!A1:'My Sheet'!B2. Parsed via expand_targets_to_roots (not a single regex)."
     },
     "DefinedName": {

--- a/tests/unit/series_bindings/test_schema.py
+++ b/tests/unit/series_bindings/test_schema.py
@@ -85,6 +85,29 @@ def test_schema_rejects_bad_setter_name() -> None:
         validate_bindings_document(doc)
 
 
+def test_schema_accepts_bare_defined_name_data_range() -> None:
+    doc = {
+        "schema_version": "1.0.0",
+        "series": [
+            {
+                "id": "defined_name_target",
+                "sheet": "Inputs",
+                "data_range": "growth_baseline",
+                "layout": "scalar",
+                "setter": {"name": "set_defined_name_target"},
+                "structure": {
+                    "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+                    "dimensions": [],
+                },
+                "key": [],
+            }
+        ],
+    }
+
+    bindings = validate_bindings_document(doc)
+    assert bindings["series"][0]["data_range"] == "growth_baseline"
+
+
 def test_schema_accepts_1_1_0_matrix_fixture() -> None:
     bindings = load_series_bindings(FIXTURES / "matrix_country_block_1_1_0.yaml")
     assert bindings["schema_version"] == "1.1.0"


### PR DESCRIPTION
## Summary

- Require sheet qualification for `A1Range` via a minimal `!` discriminator so bare defined names no longer match both `A1Range` and `DefinedName` under `oneOf`.
- Add a regression test confirming `data_range: growth_baseline` passes schema validation.
- Update both schema copies (`excel_grapher/series_bindings/series_binding.schema.json` and `schemas/series_binding.schema.json`).

Fixes #203.

## Test plan

- [x] `uv run pytest tests/unit/series_bindings/test_schema.py`


Made with [Cursor](https://cursor.com)