### PR TITLE
Make codegen sequencing deterministic (closes #219)

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Iterable, Mapping, Sequence, Set
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
 
@@ -15,6 +15,7 @@ from excel_grapher.core.address_keys import (
 from excel_grapher.core.address_keys import (
     parse_address,
     quote_sheet_if_needed,
+    sort_node_keys,
 )
 from excel_grapher.evaluator.errors import MissingNormalizedFormulaError
 from excel_grapher.evaluator.name_utils import (
@@ -2128,6 +2129,16 @@ class CodeGenerator:
             out = "_" + out
         return out.lower()
 
+    def _workbook_sort_addresses(self, addresses: Iterable[str]) -> list[str]:
+        """Return addresses sorted by workbook sheet order, then row, then column."""
+        materialized = [normalize_address(addr) for addr in addresses]
+        if not materialized:
+            return []
+        sheet_order = getattr(self.graph, "sheet_order", None)
+        if sheet_order:
+            return sort_node_keys(materialized, sheet_order=sheet_order)
+        return sorted(materialized)
+
     def _generate_parts(
         self,
         targets: list[str],
@@ -2164,21 +2175,28 @@ class CodeGenerator:
         cell_code_lines: list[str] = []
         used_xl_functions: set[str] = set()
         formula_cells: set[str] = set()
+        formula_emit_order: list[str] = []
 
-        for address in all_cells:
+        def _track_cell(address: str) -> None:
             if address in self._emitted:
-                continue
+                return
             self._emitted.add(address)
             node = self.graph.get_node(address)
             if node is not None and node.formula is not None:
-                formula_cells.add(normalize_address(address))
-                cell_code_lines.append(self._emit_cell(address))
-                cell_code_lines.append("")
-                cell_code_lines.append("")
-
+                normalized = normalize_address(address)
+                formula_emit_order.append(normalized)
+                self._temp_var_counter = 0
                 ast = self._get_or_parse_ast(address)
                 assert ast is not None
-                used_xl_functions.update(self._extract_xl_functions(ast))
+                prev_cell = self._formula_cell_address
+                self._formula_cell_address = normalized
+                try:
+                    self._emit_ast(ast)
+                finally:
+                    self._formula_cell_address = prev_cell
+
+        for address in all_cells:
+            _track_cell(address)
 
         # If dynamic OFFSET was used, ensure the runtime implementation is embedded.
         #
@@ -2199,20 +2217,18 @@ class CodeGenerator:
                         if parse_address(normalize_address(addr))[0] in self._offset_runtime_sheets
                     ]
                 for address in all_graph_cells:
-                    if address in self._emitted:
-                        continue
-                    self._emitted.add(address)
+                    _track_cell(address)
                     all_cells.append(address)
-                    node = self.graph.get_node(address)
-                    if node is not None and node.formula is not None:
-                        formula_cells.add(normalize_address(address))
-                        cell_code_lines.append(self._emit_cell(address))
-                        cell_code_lines.append("")
-                        cell_code_lines.append("")
 
-                        ast = self._get_or_parse_ast(address)
-                        assert ast is not None
-                        used_xl_functions.update(self._extract_xl_functions(ast))
+        for address in self._workbook_sort_addresses(formula_emit_order):
+            formula_cells.add(address)
+            cell_code_lines.append(self._emit_cell(address))
+            cell_code_lines.append("")
+            cell_code_lines.append("")
+
+            ast = self._get_or_parse_ast(address)
+            assert ast is not None
+            used_xl_functions.update(self._extract_xl_functions(ast))
 
         # Always include per-call evaluation scaffolding.
         # XlError is commonly referenced by generated code (error literals, IF/IFERROR, and
@@ -2254,7 +2270,7 @@ class CodeGenerator:
             "inputs_block_lines": inputs_block_lines,
             "constants_block_lines": constants_block_lines,
             "cell_code_lines": cell_code_lines,
-            "formula_cells": sorted(formula_cells),
+            "formula_cells": self._workbook_sort_addresses(formula_cells),
             "all_cells": all_cells,
             "needs_offset_table": self._needs_offset_runtime,
             "targets": normalized_targets,
@@ -2329,7 +2345,7 @@ class CodeGenerator:
                     continue
                 seen.add(a)
                 out.append(a)
-            for addr in sorted(closure):
+            for addr in self._workbook_sort_addresses(closure):
                 if addr not in seen:
                     out.append(addr)
             return out

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -6,7 +6,7 @@ import re
 import time
 import warnings
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 import fastpyxl
@@ -14,6 +14,7 @@ import fastpyxl.utils.cell
 from fastpyxl.worksheet.formula import ArrayFormula
 from fastpyxl.worksheet.worksheet import Worksheet
 
+from excel_grapher.core.address_keys import sort_node_keys
 from excel_grapher.core.cell_types import CellType, leaves_missing_cell_type_constraints
 
 from .blank_ranges import (
@@ -79,6 +80,29 @@ def _parse_address_to_sheet_a1(addr: str) -> tuple[str, str]:
         return sheet, a1
     sheet, a1 = addr.split("!", 1)
     return sheet, a1
+
+
+def _workbook_sorted_sheet_a1_pairs(
+    pairs: Iterable[tuple[str, str]], *, sheet_order: list[str]
+) -> list[tuple[str, str]]:
+    """Return ``(sheet, a1)`` pairs in workbook sheet/row/column order."""
+    materialized = list(pairs)
+    if not materialized:
+        return []
+    sorted_keys = sort_node_keys(
+        [format_key(sh, a1) for sh, a1 in materialized],
+        sheet_order=sheet_order,
+    )
+    return [_parse_address_to_sheet_a1(key) for key in sorted_keys]
+
+
+def _sorted_guard_deps(
+    dep_map: Mapping[tuple[str, str], GuardExpr | None], *, sheet_order: list[str]
+) -> list[tuple[str, str, GuardExpr | None]]:
+    return [
+        (sh, a1, dep_map[(sh, a1)])
+        for sh, a1 in _workbook_sorted_sheet_a1_pairs(dep_map.keys(), sheet_order=sheet_order)
+    ]
 
 
 def _expand_targets_to_roots(
@@ -436,6 +460,8 @@ def create_dependency_graph(
     def _extract_deps_with_guards_inner(
         formula: str, current_sheet: str, current_a1: str
     ) -> list[tuple[str, str, GuardExpr | None]]:
+        sheet_order = list(wb_formulas.sheetnames)
+
         def extract_expr_deps(expr: str) -> list[tuple[str, str]]:
             """
             Extract dependencies from an expression fragment (no leading '=').
@@ -775,7 +801,10 @@ def create_dependency_graph(
                                 indirect_targets,
                                 index_targets,
                             )
-                        for addr in offset_targets | indirect_targets | index_targets:
+                        for addr in sort_node_keys(
+                            offset_targets | indirect_targets | index_targets,
+                            sheet_order=sheet_order,
+                        ):
                             sh, a1 = _parse_address_to_sheet_a1(addr)
                             deps.append((sh, a1))
             masked = mask_spans(masked, dyn_spans)
@@ -838,7 +867,7 @@ def create_dependency_graph(
                     continue
                 seen.add(d)
                 out.append(d)
-            return out
+            return _workbook_sorted_sheet_a1_pairs(out, sheet_order=sheet_order)
 
         # 1) IF(cond, then, else)
         if_parts = split_top_level_if(formula)
@@ -848,7 +877,7 @@ def create_dependency_graph(
                 cond_s, current_sheet=current_sheet, named_ranges=named_ranges
             )
 
-            unconditional = set(extract_expr_deps(cond_s))
+            unconditional = extract_expr_deps(cond_s)
             out: dict[tuple[str, str], GuardExpr | None] = {
                 (sh, a1): None for (sh, a1) in unconditional
             }
@@ -870,7 +899,7 @@ def create_dependency_graph(
                         continue
                     out[key] = else_guard
 
-            return [(sh, a1, g) for (sh, a1), g in out.items()]
+            return _sorted_guard_deps(out, sheet_order=sheet_order)
 
         # 2) IFS(cond1, value1, cond2, value2, ..., [default])
         ifs_args = split_top_level_ifs(formula)
@@ -889,12 +918,20 @@ def create_dependency_graph(
                     conditions.append(pairs[i])
                     values.append(pairs[i + 1])
 
-            unconditional: set[tuple[str, str]] = set()
+            unconditional_pairs: list[tuple[str, str]] = []
+            seen_unconditional: set[tuple[str, str]] = set()
             for c in conditions:
-                unconditional |= set(extract_expr_deps(c))
+                for sh, a1 in extract_expr_deps(c):
+                    if (sh, a1) in seen_unconditional:
+                        continue
+                    seen_unconditional.add((sh, a1))
+                    unconditional_pairs.append((sh, a1))
 
             out: dict[tuple[str, str], GuardExpr | None] = {
-                (sh, a1): None for (sh, a1) in unconditional
+                (sh, a1): None
+                for sh, a1 in _workbook_sorted_sheet_a1_pairs(
+                    unconditional_pairs, sheet_order=sheet_order
+                )
             }
 
             prev_negations: list[GuardExpr] = []
@@ -932,7 +969,7 @@ def create_dependency_graph(
                         continue
                     out[key] = default_guard
 
-            return [(sh, a1, g) for (sh, a1), g in out.items()]
+            return _sorted_guard_deps(out, sheet_order=sheet_order)
 
         # 3) CHOOSE(index, value1, value2, ...)
         choose_args = split_top_level_choose(formula)
@@ -943,7 +980,7 @@ def create_dependency_graph(
             index_expr = parse_guard_expr(
                 index_s, current_sheet=current_sheet, named_ranges=named_ranges
             )
-            unconditional = set(extract_expr_deps(index_s))
+            unconditional = extract_expr_deps(index_s)
             out: dict[tuple[str, str], GuardExpr | None] = {
                 (sh, a1): None for (sh, a1) in unconditional
             }
@@ -958,7 +995,7 @@ def create_dependency_graph(
                         continue
                     out[key] = guard
 
-            return [(sh, a1, g) for (sh, a1), g in out.items()]
+            return _sorted_guard_deps(out, sheet_order=sheet_order)
 
         # 4) SWITCH(expr, value1, result1, ..., [default])
         switch_args = split_top_level_switch(formula)
@@ -967,7 +1004,7 @@ def create_dependency_graph(
             expr_ge = parse_guard_expr(
                 expr_s, current_sheet=current_sheet, named_ranges=named_ranges
             )
-            unconditional = set(extract_expr_deps(expr_s))
+            unconditional = extract_expr_deps(expr_s)
             out: dict[tuple[str, str], GuardExpr | None] = {
                 (sh, a1): None for (sh, a1) in unconditional
             }
@@ -1016,7 +1053,7 @@ def create_dependency_graph(
                         continue
                     out[key] = default_guard2
 
-            return [(sh, a1, g) for (sh, a1), g in out.items()]
+            return _sorted_guard_deps(out, sheet_order=sheet_order)
 
         return [(sh, a1, None) for (sh, a1) in extract_expr_deps(formula)]
 
@@ -1448,7 +1485,10 @@ def list_dynamic_ref_constraint_candidates(
                             current_row=_current_row,
                             current_col=_current_col,
                         )
-                        for addr in offset_targets | indirect_targets | index_targets:
+                        for addr in sort_node_keys(
+                            offset_targets | indirect_targets | index_targets,
+                            sheet_order=list(wb_formulas.sheetnames),
+                        ):
                             sh, a1 = _parse_address_to_sheet_a1(addr)
                             queue.append((sh, a1, depth + 1))
                     except DynamicRefError:

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -340,6 +340,15 @@ class DependencyGraph:
             example_may_cycle_path=example_may,
         )
 
+    def _workbook_sorted_keys(self, keys: Iterable[NodeKey]) -> list[NodeKey]:
+        """Return ``keys`` sorted by workbook sheet order, then row, then column."""
+        materialized = list(keys)
+        if not materialized:
+            return []
+        if self.sheet_order:
+            return sort_node_keys(materialized, sheet_order=self.sheet_order)
+        return sorted(materialized)
+
     def evaluation_order(
         self, *, strict: bool = True, iterate_enabled: bool | None = None
     ) -> list[NodeKey]:
@@ -405,7 +414,7 @@ class DependencyGraph:
             if n in temp:
                 raise CycleError(f"Cycle detected involving {n}", [n], is_must_cycle=True)
             temp.add(n)
-            for dep in adjacency.get(n, set()):
+            for dep in self._workbook_sorted_keys(adjacency.get(n, set())):
                 if dep in exclude:
                     continue
                 if dep in self._nodes and dep not in exclude:
@@ -414,7 +423,7 @@ class DependencyGraph:
             perm.add(n)
             order.append(n)
 
-        for key in list(self._nodes.keys()):
+        for key in self._workbook_sorted_keys(self._nodes.keys()):
             if key in exclude:
                 continue
             if key not in perm:

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -77,6 +77,12 @@ def _allowed_record_fields(
     if allow_address or requires_address:
         fields.update({"address", "cell_address"})
     return {f for f in fields if f}
+
+
+def _allowed_fields_literal(allowed: Sequence[str]) -> str:
+    """Emit a deterministic frozenset literal for generated setter calls."""
+    inner = ", ".join(repr(field) for field in allowed)
+    return f"frozenset({{{inner}}})"
 
 
 def emit_setter_helpers() -> list[str]:
@@ -222,7 +228,7 @@ def emit_setter_function(
         lines.append("        ctx,")
         lines.append("        records,")
     lines.append(f"        key_fields={tuple(key_fields)!r},")
-    lines.append(f"        allowed_fields={set(allowed)!r},")
+    lines.append(f"        allowed_fields={_allowed_fields_literal(allowed)},")
     lines.append(f"        measure_field={measure_concept!r},")
     lines.append(f"        leaf_index={leaf_index_arg},")
     lines.append("        strict=strict,")

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -336,6 +336,45 @@ def _make_graph(*nodes: Node) -> DependencyGraph:
     return graph
 
 
+def _build_codegen_diamond_graph(*, reverse_insertion: bool) -> DependencyGraph:
+    nodes = [
+        _make_node("Sheet1!A1", None, 1.0),
+        _make_node("Sheet1!B1", "=Sheet1!A1+1", None),
+        _make_node("Sheet1!C1", "=Sheet1!A1*2", None),
+        _make_node("Sheet1!D1", "=Sheet1!B1+Sheet1!C1", None),
+    ]
+    if reverse_insertion:
+        nodes = list(reversed(nodes))
+
+    graph = DependencyGraph(sheet_order=["Sheet1"])
+    for node in nodes:
+        graph.add_node(node)
+    graph.add_edge("Sheet1!B1", "Sheet1!A1")
+    graph.add_edge("Sheet1!C1", "Sheet1!A1")
+    graph.add_edge("Sheet1!D1", "Sheet1!B1")
+    graph.add_edge("Sheet1!D1", "Sheet1!C1")
+    return graph
+
+
+class TestDeterministicCodegenOrdering:
+    def test_generate_modules_emits_formula_functions_in_workbook_order(self) -> None:
+        graph = _build_codegen_diamond_graph(reverse_insertion=True)
+        files = CodeGenerator(graph).generate_modules(["Sheet1!D1"])
+        internals = files["internals.py"]
+
+        positions = [internals.index(f"def cell_sheet1_{col}1(") for col in ("b", "c", "d")]
+        assert positions == sorted(positions)
+
+    def test_generate_modules_formula_order_is_independent_of_node_insertion_order(self) -> None:
+        forward = CodeGenerator(
+            _build_codegen_diamond_graph(reverse_insertion=False)
+        ).generate_modules(["Sheet1!D1"])
+        reverse = CodeGenerator(
+            _build_codegen_diamond_graph(reverse_insertion=True)
+        ).generate_modules(["Sheet1!D1"])
+        assert forward["internals.py"] == reverse["internals.py"]
+
+
 class TestEmitCell:
     """Tests for _emit_cell method."""
 

--- a/tests/unit/grapher/test_graph_api.py
+++ b/tests/unit/grapher/test_graph_api.py
@@ -192,6 +192,45 @@ def test_keys_order_workbook_uses_sheet_order_then_row_then_column() -> None:
     assert g.keys(order="workbook") == ["Later!A2", "Earlier!A1", "Earlier!B2"]
 
 
+def _build_diamond_graph(*, reverse_insertion: bool) -> DependencyGraph:
+    """Diamond: A1 leaf; B1 and C1 depend on A1; D1 depends on B1 and C1."""
+    nodes = [
+        _leaf("Sheet1", "A", 1, value=1),
+        _formula("Sheet1", "B", 1, "=Sheet1!A1+1"),
+        _formula("Sheet1", "C", 1, "=Sheet1!A1*2"),
+        _formula("Sheet1", "D", 1, "=Sheet1!B1+Sheet1!C1"),
+    ]
+    if reverse_insertion:
+        nodes = list(reversed(nodes))
+
+    graph = DependencyGraph(sheet_order=["Sheet1"])
+    for node in nodes:
+        graph.add_node(node)
+    graph.add_edge("Sheet1!B1", "Sheet1!A1")
+    graph.add_edge("Sheet1!C1", "Sheet1!A1")
+    graph.add_edge("Sheet1!D1", "Sheet1!B1")
+    graph.add_edge("Sheet1!D1", "Sheet1!C1")
+    return graph
+
+
+def test_evaluation_order_breaks_ties_by_workbook_order() -> None:
+    graph = _build_diamond_graph(reverse_insertion=True)
+
+    order = graph.evaluation_order()
+
+    assert order.index("Sheet1!A1") < order.index("Sheet1!B1")
+    assert order.index("Sheet1!A1") < order.index("Sheet1!C1")
+    assert order.index("Sheet1!B1") < order.index("Sheet1!C1")
+    assert order.index("Sheet1!C1") < order.index("Sheet1!D1")
+
+
+def test_evaluation_order_is_independent_of_node_insertion_order() -> None:
+    graph_forward = _build_diamond_graph(reverse_insertion=False)
+    graph_reverse = _build_diamond_graph(reverse_insertion=True)
+
+    assert graph_forward.evaluation_order() == graph_reverse.evaluation_order()
+
+
 # -------------------------------------------------------------------
 # get_edge_attrs / get_edge_guard: typed container + normalization
 # -------------------------------------------------------------------

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -115,6 +115,65 @@ def test_emit_setter_missing_measure_raises(tmp_path: Path) -> None:
         setter(ctx, [{"TIME_PERIOD": 3}])
 
 
+def test_emit_setter_allowed_fields_literal_is_alphabetically_sorted(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(series, resolved)
+    allowed_line = next(line for line in lines if line.strip().startswith("allowed_fields="))
+    assert (
+        allowed_line == "        allowed_fields=frozenset("
+        "{'INDICATOR', 'OBS_VALUE', 'REF_AREA', 'TIME_PERIOD', 'UNIT_MEASURE'}),"
+    )
+
+
+def test_emit_setter_allowed_fields_literal_includes_address_fields_in_order(
+    tmp_path: Path,
+) -> None:
+    wb_path = tmp_path / "dup.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number("C1", 1)
+    ws.write_number("D1", 1)
+    ws.write_number("C2", 10)
+    ws.write_number("D2", 20)
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Sheet1!C2", "Sheet1!D2"], load_values=True)
+    series = {
+        "id": "dup_headers",
+        "sheet": "Sheet1",
+        "data_range": "Sheet1!C2:D2",
+        "layout": "row_series",
+        "setter": {"name": "set_dup_headers", "allow_address": True, "strict": False},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                }
+            ],
+        },
+        "key": ["TIME_PERIOD"],
+        "validation": {"require_unique_key": True},
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(series, resolved)
+    allowed_line = next(line for line in lines if line.strip().startswith("allowed_fields="))
+    assert allowed_line == (
+        "        allowed_fields=frozenset({'OBS_VALUE', 'TIME_PERIOD', 'address', 'cell_address'}),"
+    )
+
+
 def test_emit_setter_allow_address(tmp_path: Path) -> None:
     wb_path = tmp_path / "dup.xlsx"
     wb = xlsxwriter.Workbook(wb_path)


### PR DESCRIPTION
## Summary
- Emit `allowed_fields` as alphabetically ordered `frozenset` literals so generated setter calls are stable across runs.
- Break ties in `evaluation_order`, dependency extraction, and formula emission using workbook sheet order (`sort_node_keys`), eliminating hash-seed noise while preserving dependency-first semantics.
- Add regression tests for graph evaluation order and generated `internals.py` function ordering.

## Test plan
- [x] `uv run pytest tests/unit/series_bindings/test_setter_codegen.py`
- [x] `uv run pytest tests/unit/grapher/test_graph_api.py::test_evaluation_order_breaks_ties_by_workbook_order tests/unit/grapher/test_graph_api.py::test_evaluation_order_is_independent_of_node_insertion_order`
- [x] `uv run pytest tests/unit/exporter/test_codegen.py::TestDeterministicCodegenOrdering`
- [x] `uv run pytest tests/unit/grapher/ tests/unit/exporter/ tests/integration/grapher/ tests/integration/exporter/`


Made with [Cursor](https://cursor.com)