### PR TITLE
Standardize extension point customization UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Detailed documentation lives in the [User Guide](https://teal-insights.github.io
 | Series bindings | [Read guide](https://teal-insights.github.io/excel-grapher/user-guide/series-bindings.html) |
 | Code export | [Read guide](https://teal-insights.github.io/excel-grapher/user-guide/export.html) |
 | Parity testing | [Read guide](https://teal-insights.github.io/excel-grapher/user-guide/parity-testing.html) |
-| Roadmap | [Read guide](https://teal-insights.github.io/excel-grapher/user-guide/roadmap.html) |
+| Contributing | [Read guide](https://teal-insights.github.io/excel-grapher/user-guide/contributing.html) |
 
 ### Examples
 

--- a/excel_grapher/exporter/__init__.py
+++ b/excel_grapher/exporter/__init__.py
@@ -25,6 +25,7 @@ from excel_grapher.series_bindings.docstrings import (
     list_series_docstring_callbacks,
     register_series_docstring_callback,
     resolve_series_docstring_callback,
+    unregister_series_docstring_callback,
 )
 
 from .codegen import CodeGenerator
@@ -39,8 +40,12 @@ from .web_viz_layout import (
     LAYOUT_MULTIPARTITE,
     LAYOUT_SPRING,
     LAYOUT_STRATIFIED_MULTIPARTITE,
+    WebVizLayoutPlugin,
+    WebVizLayoutSpec,
     list_web_viz_layouts,
     register_web_viz_layout,
+    resolve_web_viz_layout,
+    unregister_web_viz_layout,
 )
 
 __all__ = [
@@ -67,10 +72,15 @@ __all__ = [
     "LAYOUT_MULTIPARTITE",
     "LAYOUT_GRAPHVIZ_DOT",
     "LAYOUT_GRAPHVIZ_SFDP",
+    "WebVizLayoutPlugin",
+    "WebVizLayoutSpec",
     "list_web_viz_layouts",
     "register_web_viz_layout",
+    "resolve_web_viz_layout",
+    "unregister_web_viz_layout",
     "list_series_docstring_callbacks",
     "register_series_docstring_callback",
     "resolve_series_docstring_callback",
+    "unregister_series_docstring_callback",
     "resolve_series_docstring_renderer",
 ]

--- a/excel_grapher/exporter/__init__.py
+++ b/excel_grapher/exporter/__init__.py
@@ -17,11 +17,14 @@ from excel_grapher.series_bindings.docstring_renderers import (
 )
 from excel_grapher.series_bindings.docstrings import (
     FieldDoc,
+    SeriesBindingDocstringCallback,
+    SeriesBindingDocstringCallbackSpec,
     SeriesBindingDocstringContext,
     SeriesBindingDocstringContract,
     SeriesFunctionDoc,
     list_series_docstring_callbacks,
     register_series_docstring_callback,
+    resolve_series_docstring_callback,
 )
 
 from .codegen import CodeGenerator
@@ -53,6 +56,8 @@ __all__ = [
     "SeriesDocstringRenderer",
     "SeriesDocstringRendererName",
     "SeriesDocstringRendererSpec",
+    "SeriesBindingDocstringCallback",
+    "SeriesBindingDocstringCallbackSpec",
     "SeriesBindingDocstringContext",
     "SeriesBindingDocstringContract",
     "SeriesFunctionDoc",
@@ -66,5 +71,6 @@ __all__ = [
     "register_web_viz_layout",
     "list_series_docstring_callbacks",
     "register_series_docstring_callback",
+    "resolve_series_docstring_callback",
     "resolve_series_docstring_renderer",
 ]

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -50,6 +50,7 @@ __all__ = ["CodeGenerator", "GenerationParts", "GraphLike", "GraphNode"]
 if TYPE_CHECKING:
     from excel_grapher.grapher import DependencyGraph  # noqa: F401
     from excel_grapher.series_bindings.docstring_renderers import SeriesDocstringRendererSpec
+    from excel_grapher.series_bindings.docstrings import SeriesBindingDocstringCallbackSpec
     from excel_grapher.series_bindings.types import InputSeries, WorkbookSeriesBindings
 
 
@@ -338,7 +339,7 @@ class CodeGenerator:
         workbook: Path | str,
         *,
         export_addresses: Iterable[str],
-        series_docstring_callback: str | None = None,
+        series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
         docstring_renderer: SeriesDocstringRendererSpec = "google",
     ) -> list[str]:
         from excel_grapher.series_bindings.bindings_codegen import emit_series_bindings_block
@@ -1681,7 +1682,7 @@ class CodeGenerator:
         blank_ranges: Sequence[str] | None = None,
         series_bindings: WorkbookSeriesBindings | None = None,
         bindings_workbook: Path | str | None = None,
-        series_docstring_callback: str | None = None,
+        series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
         docstring_renderer: SeriesDocstringRendererSpec = "google",
     ) -> str:
         """Generate standalone Python code for target cells.
@@ -1808,7 +1809,7 @@ class CodeGenerator:
         blank_ranges: Sequence[str] | None = None,
         series_bindings: WorkbookSeriesBindings | None = None,
         bindings_workbook: Path | str | None = None,
-        series_docstring_callback: str | None = None,
+        series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
         docstring_renderer: SeriesDocstringRendererSpec = "google",
     ) -> dict[str, str]:
         """Generate a multi-module Python package for target cells.

--- a/excel_grapher/exporter/lightweight_viz.py
+++ b/excel_grapher/exporter/lightweight_viz.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import heapq
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from excel_grapher.exporter.web_viz_layout import WebVizLayoutSpec
 
 import fastpyxl.utils.cell
 
@@ -505,7 +508,7 @@ def to_web_viz_payload(
     max_local_edges: int | None = None,
     include_guarded_edges: bool = True,
     include_guarded_edges_for_partition: bool = False,
-    layout: str = "stratified_multipartite",
+    layout: WebVizLayoutSpec = "stratified_multipartite",
     layout_config: dict[str, Any] | None = None,
     include_formula_on_nodes: bool = True,
     max_formula_length: int | None = 120,
@@ -515,8 +518,8 @@ def to_web_viz_payload(
 ) -> WebVizPayload:
     """Build a web-visualization payload from a NetworkX DiGraph.
 
-    Layout is selected by `layout` (registered web layout plugin id). The default
-    `stratified_multipartite` uses SCC-condensation longest-path rank on the vertical axis and
+    Layout is selected by `layout` (registered web layout plugin id or a direct
+    `WebVizLayoutPlugin` callable). The default `stratified_multipartite` uses SCC-condensation longest-path rank on the vertical axis and
     Louvain community ordering on the horizontal axis when `include_module_overlay` is true.
     Other built-in ids include `spring`, `forceatlas2`, `multipartite` (NetworkX
     `multipartite_layout`), `graphviz_dot`, and `graphviz_sfdp`.

--- a/excel_grapher/exporter/web_viz_layout.py
+++ b/excel_grapher/exporter/web_viz_layout.py
@@ -61,8 +61,10 @@ class WebVizLayoutPlugin(Protocol):
 _plugins: dict[str, WebVizLayoutPlugin] = {}
 
 
-def register_web_viz_layout(layout_id: str, plugin: WebVizLayoutPlugin) -> None:
-    if layout_id in _plugins:
+def register_web_viz_layout(
+    layout_id: str, plugin: WebVizLayoutPlugin, *, replace: bool = False
+) -> None:
+    if layout_id in _plugins and not replace:
         raise ValueError(f"duplicate web viz layout_id: {layout_id!r}")
     _plugins[layout_id] = plugin
 

--- a/excel_grapher/exporter/web_viz_layout.py
+++ b/excel_grapher/exporter/web_viz_layout.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.grapher.lightweight_viz import VizLimits
@@ -58,6 +58,8 @@ class WebVizLayoutPlugin(Protocol):
     ) -> WebVizLayoutResult: ...
 
 
+WebVizLayoutSpec: TypeAlias = str | WebVizLayoutPlugin
+
 _plugins: dict[str, WebVizLayoutPlugin] = {}
 
 
@@ -73,15 +75,28 @@ def list_web_viz_layouts() -> tuple[str, ...]:
     return tuple(sorted(_plugins))
 
 
+def resolve_web_viz_layout(layout: WebVizLayoutSpec) -> WebVizLayoutPlugin:
+    """Look up a registered layout ID or return a direct layout plugin."""
+    if isinstance(layout, str):
+        if layout not in _plugins:
+            raise ValueError(
+                f"Unknown web viz layout: {layout!r}. Known: {', '.join(sorted(_plugins))}"
+            )
+        return _plugins[layout]
+    return layout
+
+
 def run_web_viz_layout(
-    ctx: WebVizLayoutContext, layout_id: str, layout_config: dict[str, Any] | None
+    ctx: WebVizLayoutContext, layout: WebVizLayoutSpec, layout_config: dict[str, Any] | None
 ) -> WebVizLayoutResult:
-    if layout_id not in _plugins:
-        raise ValueError(
-            f"Unknown web viz layout: {layout_id!r}. Known: {', '.join(sorted(_plugins))}"
-        )
+    """Execute a registered layout ID or direct layout plugin."""
     cfg = dict(layout_config or {})
-    return _plugins[layout_id](ctx, cfg)
+    return resolve_web_viz_layout(layout)(ctx, cfg)
+
+
+def unregister_web_viz_layout(layout_id: str) -> None:
+    """Remove a registered layout plugin (for tests and notebook cleanup)."""
+    _plugins.pop(layout_id, None)
 
 
 def _positions_stratified_scc_louvain(
@@ -250,8 +265,12 @@ __all__ = [
     "LAYOUT_GRAPHVIZ_DOT",
     "LAYOUT_GRAPHVIZ_SFDP",
     "WebVizLayoutContext",
+    "WebVizLayoutPlugin",
     "WebVizLayoutResult",
+    "WebVizLayoutSpec",
     "list_web_viz_layouts",
     "register_web_viz_layout",
+    "resolve_web_viz_layout",
     "run_web_viz_layout",
+    "unregister_web_viz_layout",
 ]

--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -22,11 +22,14 @@ from excel_grapher.series_bindings.docstring_renderers import (
 )
 from excel_grapher.series_bindings.docstrings import (
     FieldDoc,
+    SeriesBindingDocstringCallback,
+    SeriesBindingDocstringCallbackSpec,
     SeriesBindingDocstringContext,
     SeriesBindingDocstringContract,
     SeriesFunctionDoc,
     list_series_docstring_callbacks,
     register_series_docstring_callback,
+    resolve_series_docstring_callback,
 )
 from excel_grapher.series_bindings.input_series import derive_input_series
 from excel_grapher.series_bindings.load import (
@@ -103,6 +106,8 @@ __all__ = [
     "SeriesDocstringRenderer",
     "SeriesDocstringRendererName",
     "SeriesDocstringRendererSpec",
+    "SeriesBindingDocstringCallback",
+    "SeriesBindingDocstringCallbackSpec",
     "SeriesBindingDocstringContext",
     "SeriesBindingDocstringContract",
     "SeriesFunctionDoc",
@@ -141,6 +146,7 @@ __all__ = [
     "merge_series_binding_documents",
     "parse_bindings_file",
     "register_series_docstring_callback",
+    "resolve_series_docstring_callback",
     "resolve_series_binding",
     "resolve_series_bindings",
     "resolve_series_docstring_renderer",

--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -30,6 +30,7 @@ from excel_grapher.series_bindings.docstrings import (
     list_series_docstring_callbacks,
     register_series_docstring_callback,
     resolve_series_docstring_callback,
+    unregister_series_docstring_callback,
 )
 from excel_grapher.series_bindings.input_series import derive_input_series
 from excel_grapher.series_bindings.load import (
@@ -147,6 +148,7 @@ __all__ = [
     "parse_bindings_file",
     "register_series_docstring_callback",
     "resolve_series_docstring_callback",
+    "unregister_series_docstring_callback",
     "resolve_series_binding",
     "resolve_series_bindings",
     "resolve_series_docstring_renderer",

--- a/excel_grapher/series_bindings/bindings_codegen.py
+++ b/excel_grapher/series_bindings/bindings_codegen.py
@@ -14,6 +14,7 @@ from excel_grapher.series_bindings.types import WorkbookSeriesBindings
 
 if TYPE_CHECKING:
     from excel_grapher.series_bindings.docstring_renderers import SeriesDocstringRendererSpec
+    from excel_grapher.series_bindings.docstrings import SeriesBindingDocstringCallbackSpec
 
 
 def emit_series_bindings_block(
@@ -22,7 +23,7 @@ def emit_series_bindings_block(
     bindings: WorkbookSeriesBindings,
     *,
     export_addresses: Iterable[str] | None = None,
-    series_docstring_callback: str | None = None,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> list[str]:
     """Emit setter and/or output compute functions for a binding manifest."""

--- a/excel_grapher/series_bindings/compute_codegen.py
+++ b/excel_grapher/series_bindings/compute_codegen.py
@@ -24,6 +24,7 @@ from excel_grapher.series_bindings.types import (
 
 if TYPE_CHECKING:
     from excel_grapher.series_bindings.docstring_renderers import SeriesDocstringRendererSpec
+    from excel_grapher.series_bindings.docstrings import SeriesBindingDocstringCallbackSpec
 
 
 def _py_literal(value: object) -> str:
@@ -57,7 +58,7 @@ def emit_compute_function(
     graph: DependencyGraph | None = None,
     workbook: Path | str | None = None,
     bindings: WorkbookSeriesBindings | None = None,
-    series_docstring_callback: str | None = None,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> list[str]:
     """Emit Python source lines for one series binding output compute function."""
@@ -138,7 +139,7 @@ def emit_computes_block(
     *,
     export_addresses: Iterable[str] | None = None,
     include_type_aliases: bool = True,
-    series_docstring_callback: str | None = None,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> list[str]:
     """Emit all series output compute functions for a validated binding manifest."""

--- a/excel_grapher/series_bindings/compute_codegen.py
+++ b/excel_grapher/series_bindings/compute_codegen.py
@@ -99,7 +99,7 @@ def emit_compute_function(
             resolution=resolved,
             function_kind="compute",
             function_name=fn_name,
-            callback_name=series_docstring_callback,
+            callback_spec=series_docstring_callback,
             docstring_renderer=docstring_renderer,
         )
     else:

--- a/excel_grapher/series_bindings/docstrings.py
+++ b/excel_grapher/series_bindings/docstrings.py
@@ -6,7 +6,7 @@ import textwrap
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
@@ -69,6 +69,8 @@ class SeriesBindingDocstringCallback(Protocol):
     def __call__(self, ctx: SeriesBindingDocstringContext) -> SeriesFunctionDoc | None: ...
 
 
+SeriesBindingDocstringCallbackSpec: TypeAlias = str | SeriesBindingDocstringCallback
+
 _callbacks: dict[str, SeriesBindingDocstringCallback] = {}
 
 
@@ -95,6 +97,18 @@ def run_series_docstring_callback(
         known = ", ".join(sorted(_callbacks))
         raise ValueError(f"Unknown series docstring callback: {name!r}. Known: {known}")
     return _callbacks[name](ctx)
+
+
+def resolve_series_docstring_callback(
+    callback: SeriesBindingDocstringCallbackSpec,
+    ctx: SeriesBindingDocstringContext,
+) -> SeriesFunctionDoc | None:
+    """Run a registered callback name or direct callback object."""
+    if isinstance(callback, str):
+        return run_series_docstring_callback(callback, ctx)
+    if not callable(callback):
+        raise TypeError("series docstring callback must be a registered name or callable")
+    return callback(ctx)
 
 
 def _unique(values: list[str]) -> list[str]:
@@ -261,7 +275,7 @@ def resolve_series_function_docstring(
     resolution: SeriesResolution,
     function_kind: SeriesFunctionKind,
     function_name: str,
-    callback_name: str | None,
+    callback_name: SeriesBindingDocstringCallbackSpec | None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> str | None:
     if callback_name is None:
@@ -292,7 +306,7 @@ def resolve_series_function_docstring(
         function_kind=function_kind,
         function_name=function_name,
     )
-    structured = run_series_docstring_callback(callback_name, ctx)
+    structured = resolve_series_docstring_callback(callback_name, ctx)
     if structured is None:
         return None
     renderer = resolve_series_docstring_renderer(docstring_renderer)
@@ -309,6 +323,7 @@ __all__ = [
     "FieldContract",
     "FieldDoc",
     "SeriesBindingDocstringCallback",
+    "SeriesBindingDocstringCallbackSpec",
     "SeriesBindingDocstringContext",
     "SeriesBindingDocstringContract",
     "SeriesFunctionDoc",
@@ -317,6 +332,7 @@ __all__ = [
     "emit_docstring_literal",
     "list_series_docstring_callbacks",
     "register_series_docstring_callback",
+    "resolve_series_docstring_callback",
     "resolve_series_function_docstring",
     "run_series_docstring_callback",
 ]

--- a/excel_grapher/series_bindings/docstrings.py
+++ b/excel_grapher/series_bindings/docstrings.py
@@ -89,26 +89,29 @@ def list_series_docstring_callbacks() -> tuple[str, ...]:
     return tuple(sorted(_callbacks))
 
 
+def resolve_series_docstring_callback(
+    callback: SeriesBindingDocstringCallbackSpec,
+) -> SeriesBindingDocstringCallback:
+    """Look up a registered callback name or return a direct callback object."""
+    if isinstance(callback, str):
+        if callback not in _callbacks:
+            known = ", ".join(sorted(_callbacks))
+            raise ValueError(f"Unknown series docstring callback: {callback!r}. Known: {known}")
+        return _callbacks[callback]
+    return callback
+
+
 def run_series_docstring_callback(
     name: str,
     ctx: SeriesBindingDocstringContext,
 ) -> SeriesFunctionDoc | None:
-    if name not in _callbacks:
-        known = ", ".join(sorted(_callbacks))
-        raise ValueError(f"Unknown series docstring callback: {name!r}. Known: {known}")
-    return _callbacks[name](ctx)
+    """Execute a registered series docstring callback by name."""
+    return resolve_series_docstring_callback(name)(ctx)
 
 
-def resolve_series_docstring_callback(
-    callback: SeriesBindingDocstringCallbackSpec,
-    ctx: SeriesBindingDocstringContext,
-) -> SeriesFunctionDoc | None:
-    """Run a registered callback name or direct callback object."""
-    if isinstance(callback, str):
-        return run_series_docstring_callback(callback, ctx)
-    if not callable(callback):
-        raise TypeError("series docstring callback must be a registered name or callable")
-    return callback(ctx)
+def unregister_series_docstring_callback(name: str) -> None:
+    """Remove a registered callback (for tests and notebook cleanup)."""
+    _callbacks.pop(name, None)
 
 
 def _unique(values: list[str]) -> list[str]:
@@ -275,10 +278,10 @@ def resolve_series_function_docstring(
     resolution: SeriesResolution,
     function_kind: SeriesFunctionKind,
     function_name: str,
-    callback_name: SeriesBindingDocstringCallbackSpec | None,
+    callback_spec: SeriesBindingDocstringCallbackSpec | None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> str | None:
-    if callback_name is None:
+    if callback_spec is None:
         return _default_docstring(
             series,
             function_kind=function_kind,
@@ -306,7 +309,7 @@ def resolve_series_function_docstring(
         function_kind=function_kind,
         function_name=function_name,
     )
-    structured = resolve_series_docstring_callback(callback_name, ctx)
+    structured = resolve_series_docstring_callback(callback_spec)(ctx)
     if structured is None:
         return None
     renderer = resolve_series_docstring_renderer(docstring_renderer)
@@ -335,4 +338,5 @@ __all__ = [
     "resolve_series_docstring_callback",
     "resolve_series_function_docstring",
     "run_series_docstring_callback",
+    "unregister_series_docstring_callback",
 ]

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -24,6 +24,7 @@ from excel_grapher.series_bindings.types import (
 
 if TYPE_CHECKING:
     from excel_grapher.series_bindings.docstring_renderers import SeriesDocstringRendererSpec
+    from excel_grapher.series_bindings.docstrings import SeriesBindingDocstringCallbackSpec
 
 
 def _py_literal(value: object) -> str:
@@ -153,7 +154,7 @@ def emit_setter_function(
     graph: DependencyGraph | None = None,
     workbook: Path | str | None = None,
     bindings: WorkbookSeriesBindings | None = None,
-    series_docstring_callback: str | None = None,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> list[str]:
     """Emit Python source lines for one series binding setter."""
@@ -250,7 +251,7 @@ def emit_setters_block(
     *,
     export_addresses: Iterable[str] | None = None,
     include_type_aliases: bool = True,
-    series_docstring_callback: str | None = None,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> list[str]:
     """Emit all series setter functions for a validated binding manifest."""

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -211,7 +211,7 @@ def emit_setter_function(
             resolution=resolved,
             function_kind="setter",
             function_name=fn_name,
-            callback_name=series_docstring_callback,
+            callback_spec=series_docstring_callback,
             docstring_renderer=docstring_renderer,
         )
     else:

--- a/tests/integration/exporter/test_web_viz_api.py
+++ b/tests/integration/exporter/test_web_viz_api.py
@@ -18,6 +18,7 @@ from excel_grapher.exporter.web_viz_layout import (
     WebVizLayoutResult,
     list_web_viz_layouts,
     register_web_viz_layout,
+    unregister_web_viz_layout,
 )
 from excel_grapher.grapher.lightweight_viz import lightweight_viz_flat
 
@@ -84,14 +85,34 @@ def test_register_web_viz_layout_allows_replace() -> None:
             viewer_hints={},
         )
 
-    register_web_viz_layout(layout_id, first)
-    with pytest.raises(ValueError, match="duplicate"):
+    try:
         register_web_viz_layout(layout_id, first)
-    register_web_viz_layout(layout_id, second, replace=True)
+        with pytest.raises(ValueError, match="duplicate"):
+            register_web_viz_layout(layout_id, first)
+        register_web_viz_layout(layout_id, second, replace=True)
 
-    payload = to_web_viz_payload(_build_two_component_digraph(), layout=layout_id)
+        payload = to_web_viz_payload(_build_two_component_digraph(), layout=layout_id)
+        assert payload.annotations is not None
+        assert payload.annotations["custom_layout"] == "second"
+    finally:
+        unregister_web_viz_layout(layout_id)
+
+
+def test_to_web_viz_payload_accepts_direct_layout_plugin() -> None:
+    def custom_layout(
+        ctx: WebVizLayoutContext, layout_config: dict[str, object]
+    ) -> WebVizLayoutResult:
+        del layout_config
+        return WebVizLayoutResult(
+            positions={key: (0.5, 0.5) for key in ctx.keys},
+            module_analysis=None,
+            annotations={"custom_layout": "direct"},
+            viewer_hints={},
+        )
+
+    payload = to_web_viz_payload(_build_two_component_digraph(), layout=custom_layout)
     assert payload.annotations is not None
-    assert payload.annotations["custom_layout"] == "second"
+    assert payload.annotations["custom_layout"] == "direct"
 
 
 def test_to_web_viz_payload_unknown_layout_raises() -> None:

--- a/tests/integration/exporter/test_web_viz_api.py
+++ b/tests/integration/exporter/test_web_viz_api.py
@@ -14,7 +14,10 @@ from excel_grapher import write_web_viz_html
 from excel_grapher.exporter import to_web_viz_payload
 from excel_grapher.exporter.web_viz_layout import (
     LAYOUT_STRATIFIED_MULTIPARTITE,
+    WebVizLayoutContext,
+    WebVizLayoutResult,
     list_web_viz_layouts,
+    register_web_viz_layout,
 )
 from excel_grapher.grapher.lightweight_viz import lightweight_viz_flat
 
@@ -58,6 +61,37 @@ def test_to_web_viz_layout_registry_includes_builtins() -> None:
     assert "stratified_multipartite" in ids
     assert "spring" in ids
     assert "multipartite" in ids
+
+
+def test_register_web_viz_layout_allows_replace() -> None:
+    layout_id = "_test_replace_layout"
+
+    def first(ctx: WebVizLayoutContext, layout_config: dict[str, object]) -> WebVizLayoutResult:
+        del layout_config
+        return WebVizLayoutResult(
+            positions={key: (0.0, 0.0) for key in ctx.keys},
+            module_analysis=None,
+            annotations={"custom_layout": "first"},
+            viewer_hints={},
+        )
+
+    def second(ctx: WebVizLayoutContext, layout_config: dict[str, object]) -> WebVizLayoutResult:
+        del layout_config
+        return WebVizLayoutResult(
+            positions={key: (1.0, 1.0) for key in ctx.keys},
+            module_analysis=None,
+            annotations={"custom_layout": "second"},
+            viewer_hints={},
+        )
+
+    register_web_viz_layout(layout_id, first)
+    with pytest.raises(ValueError, match="duplicate"):
+        register_web_viz_layout(layout_id, first)
+    register_web_viz_layout(layout_id, second, replace=True)
+
+    payload = to_web_viz_payload(_build_two_component_digraph(), layout=layout_id)
+    assert payload.annotations is not None
+    assert payload.annotations["custom_layout"] == "second"
 
 
 def test_to_web_viz_payload_unknown_layout_raises() -> None:

--- a/tests/integration/user_flows/test_series_bindings_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_codegen.py
@@ -145,6 +145,42 @@ def test_generate_applies_series_docstring_callback() -> None:
     assert "Required record fields:" in setter.__doc__
 
 
+def test_generate_accepts_direct_series_docstring_callback() -> None:
+    bindings = validate_bindings_document(deepcopy(BINDINGS_DOCUMENT))
+    targets: list[str] = []
+    for series in bindings["series"]:
+        targets.extend(expand_data_range(series["data_range"], workbook=WORKBOOK))
+    graph = create_dependency_graph(WORKBOOK, targets, load_values=True)
+
+    def callback(ctx: Any) -> SeriesFunctionDoc:
+        return SeriesFunctionDoc(
+            summary=f"Set {ctx.contract.series_id} directly.",
+            purpose="Integration test direct callback purpose.",
+            record_matching="Match by TIME_PERIOD.",
+            field_descriptions={
+                "TIME_PERIOD": FieldDoc(description="Reporting year."),
+                "OBS_VALUE": FieldDoc(description="Observed value."),
+            },
+        )
+
+    with CodeGenerator(graph) as gen:
+        code = gen.generate(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=WORKBOOK,
+            series_docstring_callback=callback,
+        )
+
+    ns: dict[str, object] = {}
+    exec(code, ns)
+    setter = cast(
+        Callable[[Any, list[dict[str, object]]], None],
+        ns["set_borvelia_primary_balance"],
+    )
+    assert setter.__doc__ is not None
+    assert "Set borvelia_primary_balance directly." in setter.__doc__
+
+
 def test_generate_applies_google_docstring_renderer() -> None:
     callback_name = "_test_integration_setter_google_docstring"
     register_series_docstring_callback(

--- a/tests/unit/series_bindings/test_docstrings.py
+++ b/tests/unit/series_bindings/test_docstrings.py
@@ -32,8 +32,10 @@ from excel_grapher.series_bindings.docstrings import (
     emit_docstring_literal,
     list_series_docstring_callbacks,
     register_series_docstring_callback,
+    resolve_series_docstring_callback,
     resolve_series_function_docstring,
     run_series_docstring_callback,
+    unregister_series_docstring_callback,
 )
 from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
 
@@ -122,10 +124,41 @@ def test_register_series_docstring_callback_allows_replace() -> None:
         },
         function_kind="setter",
         function_name="set_demo",
-        callback_name=name,
+        callback_spec=name,
     )
     assert rendered is not None
     assert rendered.startswith("second")
+
+
+def test_resolve_series_docstring_callback_returns_direct_callable() -> None:
+    def direct(ctx: SeriesBindingDocstringContext) -> SeriesFunctionDoc:
+        del ctx
+        return SeriesFunctionDoc(
+            summary="direct",
+            purpose="direct",
+            record_matching="direct",
+        )
+
+    resolved = resolve_series_docstring_callback(direct)
+    assert resolved is direct
+
+
+def test_resolve_series_docstring_callback_unknown_name_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown series docstring callback"):
+        resolve_series_docstring_callback("not.registered.callback")
+
+
+def test_unregister_series_docstring_callback_removes_registration() -> None:
+    name = "_test_unregister_docstring_callback"
+
+    def _noop(ctx: SeriesBindingDocstringContext) -> None:
+        del ctx
+        return None
+
+    register_series_docstring_callback(name, _noop)
+    assert name in list_series_docstring_callbacks()
+    unregister_series_docstring_callback(name)
+    assert name not in list_series_docstring_callbacks()
 
 
 def test_run_series_docstring_callback_unknown_name_raises() -> None:
@@ -407,7 +440,7 @@ def test_resolve_series_function_docstring_default_uses_series_notes() -> None:
         resolution=resolved,
         function_kind="setter",
         function_name="set_demo",
-        callback_name=None,
+        callback_spec=None,
     )
     assert doc == "Custom notes for demo."
 
@@ -445,7 +478,7 @@ def test_resolve_series_function_docstring_registered_callback(tmp_path: Path) -
         resolution=resolved,
         function_kind="setter",
         function_name="set_borvelia_primary_balance",
-        callback_name=callback_name,
+        callback_spec=callback_name,
     )
     assert doc is not None
     assert "Set borvelia_primary_balance." in doc
@@ -485,7 +518,7 @@ def test_resolve_series_function_docstring_applies_renderer(tmp_path: Path) -> N
         resolution=resolved,
         function_kind="setter",
         function_name="set_borvelia_primary_balance",
-        callback_name=callback_name,
+        callback_spec=callback_name,
         docstring_renderer="google",
     )
     assert doc is not None

--- a/user_guide/06-export.qmd
+++ b/user_guide/06-export.qmd
@@ -50,8 +50,8 @@ code = CodeGenerator(graph).generate(
 ## Series docstring callbacks
 
 When exporting series bindings, you can attach structured docstrings to generated `set_*` and
-series output `compute_*` functions by registering a callback and passing its name to
-`generate(..., series_docstring_callback=...)` or `generate_modules(..., series_docstring_callback=...)`:
+series output `compute_*` functions by passing a callback directly or by registering a reusable
+callback name for project-wide use:
 
 ```python
 from excel_grapher.exporter import (
@@ -85,7 +85,7 @@ code = CodeGenerator(graph).generate(
     targets,
     series_bindings=bindings,
     bindings_workbook=workbook_path,
-    series_docstring_callback="my_docs",
+    series_docstring_callback="my_docs",  # or my_series_docstring
     docstring_renderer=compact_google_renderer,  # or "plain" | "rst" | "google" | "numpy"
 )
 ```
@@ -98,7 +98,7 @@ Callback contract highlights:
 - The callback is invoked once per generated series API function (`set_*` and series output `compute_*`).
 - Use `ctx.function_kind` (`"setter"` or `"compute"`) and `ctx.function_name` to branch wording per function.
 - `ctx.contract` contains deterministic binding facts for that specific function (required fields, field dtypes, examples, layout, and data range).
-- Docstring callbacks are selected by name (`series_docstring_callback="..."`), not passed as direct callables to `generate`.
+- Docstring callbacks may be direct callables or registered names (`series_docstring_callback="..."`).
 - Docstring renderers can be built-in names (`"plain"`, `"rst"`, `"google"`, `"numpy"`), renderer objects implementing `SeriesDocstringRenderer`, or simple callables `(contract, doc, *, series=None) -> str`.
 - If callback rendering is requested, codegen requires full series context (`series_bindings` + `bindings_workbook`).
 

--- a/user_guide/06-export.qmd
+++ b/user_guide/06-export.qmd
@@ -74,7 +74,7 @@ def my_series_docstring(ctx):
         },
     )
 
-register_series_docstring_callback("my_docs", my_series_docstring, replace=True)
+register_series_docstring_callback("my_docs", my_series_docstring)
 
 
 def compact_google_renderer(contract, doc, *, series=None):

--- a/user_guide/08-contributing.qmd
+++ b/user_guide/08-contributing.qmd
@@ -1,0 +1,100 @@
+---
+title: "Contributing"
+guide-section: "Development"
+---
+
+## Development environment setup
+
+Clone the repository:
+
+```bash
+git clone https://github.com/Teal-Insights/excel-grapher.git
+cd excel-grapher
+```
+
+Install `uv` if you don't have it already:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Install the dependencies:
+
+```bash
+uv sync
+```
+
+Install pre-commit hooks:
+
+```bash
+uv run pre-commit install
+```
+
+To render the documentation, install Quarto if you don't have it already:
+
+```bash
+curl -LsSf https://quarto.org/install.sh | sh
+```
+
+## Extension-point conventions
+
+A key goal of `excel-grapher` is to make it easy to extend the library with new functionality. We achieve this by exposing a rich set of extension points that allow users to customize library behaviors, especially during graph extraction, visualization, and code generation.
+
+Prefer explicit, typed extension points over ad hoc keyword flags when users need to customize behavior. The core API should make simple Python usage direct, while still supporting named plugins when a choice needs to be stored in configuration, selected from a CLI, or reused across a project.
+
+### Direct customization first
+
+For local Python usage, accept direct objects or callables when they are easy to type and configure:
+
+```python
+code = CodeGenerator(graph).generate(
+    targets,
+    series_bindings=bindings,
+    bindings_workbook=workbook_path,
+    series_docstring_callback=my_callback,
+)
+```
+
+Use a `Protocol` for non-trivial callables so contributors know the expected context and return type.
+
+### Named plugins for reusable choices
+
+Use registries when an extension should be selectable by a stable string name. Registry-backed APIs should expose:
+
+- `register_*`
+- `list_*`
+- `resolve_*` for lookup without execution
+- `run_*` only when the helper executes the plugin immediately
+
+Duplicate registration should fail by default and support `replace=False` as an explicit opt-in parameter when replacement is useful in tests, notebooks, or project bootstrap code.
+
+```python
+register_series_docstring_callback("project_docs", my_callback, replace=True)
+
+code = CodeGenerator(graph).generate(
+    targets,
+    series_bindings=bindings,
+    bindings_workbook=workbook_path,
+    series_docstring_callback="project_docs",
+)
+```
+
+### Built-ins and specs
+
+When an API accepts more than one customization form, define a `*Spec` type alias. Built-ins should usually be available both as importable Python objects/classes and as stable string IDs if they are useful in config-driven workflows.
+
+Examples in the current API:
+
+- `SeriesDocstringRendererSpec`: built-in renderer name, renderer object, or callable.
+- `SeriesBindingDocstringCallbackSpec`: registered callback name or direct callback.
+- Web visualization layouts: registered layout IDs resolved by the layout registry.
+
+### Scope guidelines
+
+Use direct callables only for local instrumentation hooks that are not reusable plugin choices, such as graph build hooks. Use named registries for behavior that users may want to list, document, select from config, or share across workflows.
+
+Upcoming export projection transforms should follow the same pattern: direct transform objects/callables for normal Python usage, plus optional registered names for built-ins and reusable project transforms.
+
+## Roadmap
+
+- [Live workflow graph](/workflow/)

--- a/user_guide/08-contributing.qmd
+++ b/user_guide/08-contributing.qmd
@@ -42,6 +42,15 @@ A key goal of `excel-grapher` is to make it easy to extend the library with new 
 
 Prefer explicit, typed extension points over ad hoc keyword flags when users need to customize behavior. The core API should make simple Python usage direct, while still supporting named plugins when a choice needs to be stored in configuration, selected from a CLI, or reused across a project.
 
+### Current patterns in the codebase
+
+| Extension point | Customization forms | Registry helpers | Notes |
+| --- | --- | --- | --- |
+| Graph build hooks (`NodeHook`) | Direct callables only | None | Passed to `create_dependency_graph(..., hooks=...)` or `DependencyGraph.register_hook`. Local instrumentation only. |
+| Series docstring callbacks | `SeriesBindingDocstringCallbackSpec` | `register_*`, `list_*`, `resolve_*`, `run_*`, `unregister_*` | Direct callback or registered name for codegen. |
+| Series docstring renderers | `SeriesDocstringRendererSpec` | `resolve_*` only | Built-in names plus renderer objects or callables. |
+| Web visualization layouts | `WebVizLayoutSpec` | `register_*`, `list_*`, `resolve_*`, `run_*`, `unregister_*` | Layout ID string or direct `WebVizLayoutPlugin` callable. |
+
 ### Direct customization first
 
 For local Python usage, accept direct objects or callables when they are easy to type and configure:
@@ -53,6 +62,8 @@ code = CodeGenerator(graph).generate(
     bindings_workbook=workbook_path,
     series_docstring_callback=my_callback,
 )
+
+payload = to_web_viz_payload(graph, layout=my_layout_plugin)
 ```
 
 Use a `Protocol` for non-trivial callables so contributors know the expected context and return type.
@@ -65,11 +76,12 @@ Use registries when an extension should be selectable by a stable string name. R
 - `list_*`
 - `resolve_*` for lookup without execution
 - `run_*` only when the helper executes the plugin immediately
+- `unregister_*` for test and notebook cleanup (optional but recommended)
 
-Duplicate registration should fail by default and support `replace=False` as an explicit opt-in parameter when replacement is useful in tests, notebooks, or project bootstrap code.
+Duplicate registration should fail by default. Support `replace=True` as an explicit opt-in when replacement is useful in tests, notebooks, or project bootstrap code:
 
 ```python
-register_series_docstring_callback("project_docs", my_callback, replace=True)
+register_series_docstring_callback("project_docs", my_callback)
 
 code = CodeGenerator(graph).generate(
     targets,
@@ -77,6 +89,10 @@ code = CodeGenerator(graph).generate(
     bindings_workbook=workbook_path,
     series_docstring_callback="project_docs",
 )
+
+# In tests or notebooks, re-register or clean up:
+register_series_docstring_callback("project_docs", updated_callback, replace=True)
+unregister_series_docstring_callback("project_docs")
 ```
 
 ### Built-ins and specs
@@ -87,14 +103,37 @@ Examples in the current API:
 
 - `SeriesDocstringRendererSpec`: built-in renderer name, renderer object, or callable.
 - `SeriesBindingDocstringCallbackSpec`: registered callback name or direct callback.
-- Web visualization layouts: registered layout IDs resolved by the layout registry.
+- `WebVizLayoutSpec`: registered layout ID or direct `WebVizLayoutPlugin`.
 
 ### Scope guidelines
 
-Use direct callables only for local instrumentation hooks that are not reusable plugin choices, such as graph build hooks. Use named registries for behavior that users may want to list, document, select from config, or share across workflows.
+Use direct callables only for local instrumentation hooks that are not reusable plugin choices, such as `NodeHook` graph build hooks. Use named registries for behavior that users may want to list, document, select from config, or share across workflows.
 
-Upcoming export projection transforms should follow the same pattern: direct transform objects/callables for normal Python usage, plus optional registered names for built-ins and reusable project transforms.
+### Export projection transforms (planned)
+
+The upcoming `ExportTransform` / projection-transform API should follow the same pattern:
+
+- Define an `ExportTransform` protocol and an `ExportTransformSpec` alias (`str | ExportTransform`).
+- Accept direct transform objects/callables in Python APIs (`CodeGenerator.generate(..., transform=...)`).
+- Expose built-in transforms (e.g. `IdentityTransitReducer`) as importable classes and stable string IDs.
+- Provide `register_export_transform`, `list_export_transforms`, `resolve_export_transform`, and `run_export_transform` when config/CLI selection is needed.
+- Use `replace=True` and `unregister_export_transform` for the same test/bootstrap semantics as other registries.
+
+### Alignment status
+
+Changes aligned in this release:
+
+- Series docstring callbacks accept direct callables or registered names via `SeriesBindingDocstringCallbackSpec`.
+- Web viz layouts accept direct plugins via `WebVizLayoutSpec`; `register_web_viz_layout` supports `replace=True`.
+- Registry cleanup helpers (`unregister_*`) for docstring callbacks and web viz layouts.
+
+Deferred (no change needed yet):
+
+- Graph build hooks remain direct-only; a registry would add no value for one-off instrumentation.
+- Series docstring renderers stay lookup-only (no global registration); built-ins are fixed and custom renderers are passed inline.
 
 ## Roadmap
 
+- Continue expanding **three-way parity** coverage: evaluator ↔ export runtime, evaluator ↔ Excel (cache and live automation where available), especially for representation-sensitive areas such as `OFFSET`, `INDIRECT`, `LOOKUP`, `MATCH`, and `INDEX`.
+- Refine the dynamic-reference configuration API and constraints tooling (e.g., validation helpers) as more real-world models and templates are integrated.
 - [Live workflow graph](/workflow/)

--- a/user_guide/08-roadmap.qmd
+++ b/user_guide/08-roadmap.qmd
@@ -1,8 +1,0 @@
----
-title: "Roadmap"
-guide-section: "Export & quality"
----
-
-- Continue expanding **three-way parity** coverage: evaluator ↔ export runtime, evaluator ↔ Excel (cache and live automation where available), especially for representation-sensitive areas such as `OFFSET`, `INDIRECT`, `LOOKUP`, `MATCH`, and `INDEX`.
-- Refine the dynamic-reference configuration API and constraints tooling (e.g., validation helpers) as more real-world models and templates are integrated.
-- [Live workflow graph](/workflow/)


### PR DESCRIPTION
## Summary
- Document extension-point customization conventions in the contributing guide.
- Allow series docstring callbacks to be passed directly or by registered name.
- Add opt-in replacement support to web viz layout registration.

## Test plan
- `uv run pytest tests/unit/series_bindings/test_docstrings.py tests/unit/series_bindings/test_setter_codegen.py tests/unit/series_bindings/test_compute_codegen.py tests/integration/user_flows/test_series_bindings_codegen.py tests/integration/user_flows/test_series_bindings_output_codegen.py tests/integration/exporter/test_web_viz_api.py`
- Pre-commit hooks on commit: `ruff check`, `ruff format --check`, `ty check`


Made with [Cursor](https://cursor.com)