### PR TITLE
Publish to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 jobs:
   test:
@@ -13,6 +14,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            release:
+              - 'excel_grapher/**'
+              - 'pyproject.toml'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -21,6 +32,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: pyproject.toml
+
+      - name: Check version bump
+        if: github.event_name == 'pull_request' && steps.changes.outputs.release == 'true'
+        run: python scripts/check_version_bump.py --base origin/${{ github.base_ref }}
 
       - name: Install dependencies
         run: uv sync --all-extras --dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  release:
+    runs-on: ubuntu-latest
+    needs: ci
+    environment: PyPi
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Read package version
+        id: version
+        run: |
+          VERSION="$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml', 'rb').read())['project']['version'])")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if version already released
+        id: release
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse "$TAG^{}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; skipping release."
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build package
+        if: steps.release.outputs.released == 'true'
+        run: uv build
+
+      - name: Publish package distributions to PyPI
+        if: steps.release.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+      - name: Push release tag
+        if: steps.release.outputs.released == 'true'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git tag "${{ steps.release.outputs.tag }}"
+          git push origin "${{ steps.release.outputs.tag }}"
+
+      - name: Create GitHub release
+        if: steps.release.outputs.released == 'true'
+        run: |
+          gh release create "${{ steps.release.outputs.tag }}" \
+            --title "${{ steps.release.outputs.tag }}" \
+            --generate-notes \
+            dist/*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_install_hook_types: [pre-commit]
+default_install_hook_types: [pre-commit, pre-push]
 default_stages: [pre-commit]
 
 repos:
@@ -22,3 +22,10 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: version-bump-reminder
+        name: version bump reminder
+        entry: uv run python scripts/check_version_bump.py --pre-push --warn-only
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/scripts/check_version_bump.py
+++ b/scripts/check_version_bump.py
@@ -1,0 +1,337 @@
+"""Verify the PR version in pyproject.toml is greater than the base branch."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import TypeAlias
+
+VersionTuple: TypeAlias = tuple[int, int, int]
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)")
+_ZERO_SHA = "0" * 40
+_RELEASE_PATHS = ("excel_grapher", "pyproject.toml")
+_MAIN_REFS = ("origin/main", "main")
+
+
+def parse_version(version: str) -> VersionTuple:
+    """Parse a simple ``major.minor.patch`` version string.
+
+    Args:
+        version: Version text from ``pyproject.toml``.
+
+    Returns:
+        A ``(major, minor, patch)`` tuple.
+
+    Raises:
+        ValueError: If ``version`` is not a supported ``x.y.z`` value.
+    """
+    match = _VERSION_RE.match(version.strip())
+    if match is None:
+        raise ValueError(f"unsupported version: {version}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def version_from_pyproject(path: Path) -> VersionTuple:
+    """Read ``project.version`` from a ``pyproject.toml`` file.
+
+    Args:
+        path: Path to ``pyproject.toml``.
+
+    Returns:
+        Parsed project version.
+    """
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    return parse_version(str(data["project"]["version"]))
+
+
+def version_from_git_ref(
+    ref: str,
+    path: Path = Path("pyproject.toml"),
+    cwd: Path | None = None,
+) -> VersionTuple:
+    """Read ``project.version`` from ``pyproject.toml`` at a git ref.
+
+    Args:
+        ref: Git ref or commit, for example ``origin/main``.
+        path: Repository-relative path to ``pyproject.toml``.
+        cwd: Optional repository root for git commands.
+
+    Returns:
+        Parsed project version at ``ref``.
+
+    Raises:
+        SystemExit: If git cannot resolve ``ref`` or the file is missing.
+    """
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path.as_posix()}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        print(
+            f"failed to read {path} at {ref}: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    data = tomllib.loads(result.stdout)
+    return parse_version(str(data["project"]["version"]))
+
+
+def version_is_greater_than(head: VersionTuple, base: VersionTuple) -> bool:
+    """Return whether ``head`` is strictly greater than ``base``."""
+    return head > base
+
+
+def format_version(version: VersionTuple) -> str:
+    """Format a version tuple as ``major.minor.patch``."""
+    return ".".join(str(part) for part in version)
+
+
+def resolve_main_ref(cwd: Path) -> str | None:
+    """Return the first resolvable main-branch ref.
+
+    Args:
+        cwd: Repository root for git commands.
+
+    Returns:
+        A ref such as ``origin/main``, or ``None`` if none resolve.
+    """
+    for ref in _MAIN_REFS:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", ref],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+        if result.returncode == 0:
+            return ref
+    return None
+
+
+def push_diff_range(remote_sha: str, local_sha: str, cwd: Path) -> str:
+    """Build a git revision range for commits being pushed.
+
+    Args:
+        remote_sha: Remote tip before the push, or the all-zero OID for a new ref.
+        local_sha: Local tip being pushed.
+        cwd: Repository root for git commands.
+
+    Returns:
+        A revision range suitable for ``git diff`` / ``git log``.
+    """
+    if remote_sha == _ZERO_SHA:
+        main_ref = resolve_main_ref(cwd)
+        if main_ref is None:
+            return local_sha
+        merge_base = subprocess.run(
+            ["git", "merge-base", main_ref, local_sha],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+        )
+        if merge_base.returncode == 0 and merge_base.stdout.strip():
+            return f"{merge_base.stdout.strip()}..{local_sha}"
+        return local_sha
+    return f"{remote_sha}..{local_sha}"
+
+
+def push_includes_release_paths(remote_sha: str, local_sha: str, cwd: Path) -> bool:
+    """Return whether a push updates package source or ``pyproject.toml``.
+
+    Args:
+        remote_sha: Remote tip before the push, or the all-zero OID for a new ref.
+        local_sha: Local tip being pushed.
+        cwd: Repository root for git commands.
+
+    Returns:
+        ``True`` when the push range touches ``excel_grapher/`` or ``pyproject.toml``.
+    """
+    range_expr = push_diff_range(remote_sha, local_sha, cwd)
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            range_expr,
+            "--",
+            *_RELEASE_PATHS,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
+def read_pre_push_updates() -> list[tuple[str, str, str, str]]:
+    """Parse git pre-push stdin lines.
+
+    Returns:
+        Tuples of ``(local_ref, local_sha, remote_ref, remote_sha)``.
+    """
+    updates: list[tuple[str, str, str, str]] = []
+    for line in sys.stdin:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) != 4:
+            continue
+        local_ref, local_sha, remote_ref, remote_sha = parts
+        updates.append((local_ref, local_sha, remote_ref, remote_sha))
+    return updates
+
+
+def emit_version_bump_message(
+    *,
+    head_version: VersionTuple,
+    base_version: VersionTuple,
+    base_ref: str,
+    warn_only: bool,
+) -> None:
+    """Print a version-bump failure or reminder message.
+
+    Args:
+        head_version: Version on the branch being checked.
+        base_version: Version on the base ref.
+        base_ref: Git ref used for the base version.
+        warn_only: When ``True``, print a reminder to stdout instead of an error.
+    """
+    head_text = format_version(head_version)
+    base_text = format_version(base_version)
+    if warn_only:
+        print(
+            "version bump reminder: pushing changes under excel_grapher/ or "
+            "pyproject.toml, but pyproject.toml version "
+            f"({head_text}) is not greater than {base_ref} ({base_text}).\n"
+            "Bump the version before opening a PR — CI will reject equal versions."
+        )
+        return
+
+    print(
+        "pyproject.toml version must be greater than the base branch.\n"
+        f"  base ({base_ref}): {base_text}\n"
+        f"  head:               {head_text}",
+        file=sys.stderr,
+    )
+
+
+def run_pre_push(warn_only: bool, cwd: Path, pyproject: Path) -> None:
+    """Check pushed commits for a required version bump.
+
+    Args:
+        warn_only: Print a reminder and always exit successfully.
+        cwd: Repository root.
+        pyproject: Repository-relative path to ``pyproject.toml``.
+
+    Raises:
+        SystemExit: When ``warn_only`` is false and the version was not bumped.
+    """
+    updates = read_pre_push_updates()
+    if not updates:
+        return
+
+    qualifying = [
+        (local_sha, remote_sha)
+        for _, local_sha, _, remote_sha in updates
+        if push_includes_release_paths(remote_sha, local_sha, cwd)
+    ]
+    if not qualifying:
+        return
+
+    main_ref = resolve_main_ref(cwd)
+    if main_ref is None:
+        return
+
+    local_sha = qualifying[-1][0]
+    head_version = version_from_git_ref(local_sha, pyproject, cwd=cwd)
+    base_version = version_from_git_ref(main_ref, pyproject, cwd=cwd)
+
+    if version_is_greater_than(head_version, base_version):
+        return
+
+    emit_version_bump_message(
+        head_version=head_version,
+        base_version=base_version,
+        base_ref=main_ref,
+        warn_only=warn_only,
+    )
+    if not warn_only:
+        raise SystemExit(1)
+
+
+def main(argv: list[str] | None = None, cwd: Path | None = None) -> None:
+    """Compare versions for CI or git pre-push hooks.
+
+    Args:
+        argv: Optional CLI arguments. Defaults to ``sys.argv[1:]``.
+        cwd: Optional repository root. Defaults to the current directory.
+
+    Raises:
+        SystemExit: If the head version is not greater than the base version.
+    """
+    parser = argparse.ArgumentParser(
+        description="Require pyproject.toml version to be greater than a base git ref.",
+    )
+    parser.add_argument(
+        "--base",
+        help="Git ref for the base branch (for example origin/main).",
+    )
+    parser.add_argument(
+        "--pre-push",
+        action="store_true",
+        help="Read refs from git pre-push stdin instead of using the working tree.",
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Print a reminder instead of failing (for local pre-push hooks).",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Repository-relative path to pyproject.toml.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = cwd or Path.cwd()
+
+    if args.pre_push:
+        run_pre_push(warn_only=args.warn_only, cwd=repo_root, pyproject=args.pyproject)
+        return
+
+    if args.base is None:
+        parser.error("--base is required unless --pre-push is set")
+
+    pyproject_path = repo_root / args.pyproject
+    head_version = version_from_pyproject(pyproject_path)
+    base_version = version_from_git_ref(args.base, args.pyproject, cwd=repo_root)
+
+    if version_is_greater_than(head_version, base_version):
+        return
+
+    emit_version_bump_message(
+        head_version=head_version,
+        base_version=base_version,
+        base_ref=args.base,
+        warn_only=args.warn_only,
+    )
+    if not args.warn_only:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_check_version_bump.py
+++ b/tests/unit/scripts/test_check_version_bump.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.check_version_bump import (
+    main,
+    parse_version,
+    push_includes_release_paths,
+    run_pre_push,
+    version_from_pyproject,
+    version_is_greater_than,
+)
+
+
+def _write_pyproject(path: Path, version: str) -> None:
+    path.write_text(
+        f'[project]\nname = "excel-grapher"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def _init_git_repo(repo: Path, version: str, branch: str = "main") -> str:
+    _write_pyproject(repo / "pyproject.toml", version)
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "pyproject.toml"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "branch", "-M", branch], cwd=repo, check=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit_file(repo: Path, relative_path: str, content: str, message: str) -> str:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", relative_path], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_parse_version_parses_semver() -> None:
+    assert parse_version("0.1.0") == (0, 1, 0)
+    assert parse_version("1.2.3") == (1, 2, 3)
+
+
+def test_parse_version_rejects_invalid() -> None:
+    with pytest.raises(ValueError, match="unsupported version"):
+        parse_version("not-a-version")
+
+
+def test_version_from_pyproject_reads_project_version(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    _write_pyproject(pyproject, "0.2.1")
+
+    assert version_from_pyproject(pyproject) == (0, 2, 1)
+
+
+def test_version_is_greater_than() -> None:
+    assert version_is_greater_than((0, 2, 0), (0, 1, 9))
+    assert not version_is_greater_than((0, 1, 0), (0, 1, 0))
+    assert not version_is_greater_than((0, 1, 0), (0, 2, 0))
+
+
+def test_main_passes_when_head_version_is_greater(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, "0.1.0")
+    _write_pyproject(repo / "pyproject.toml", "0.2.0")
+
+    main(["--base", "main"], cwd=repo)
+
+
+def test_main_fails_when_head_version_is_equal(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, "0.1.0")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--base", "main"], cwd=repo)
+
+    assert exc_info.value.code == 1
+
+
+def test_main_fails_when_head_version_is_lower(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, "0.2.0")
+    _write_pyproject(repo / "pyproject.toml", "0.1.0")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--base", "main"], cwd=repo)
+
+    assert exc_info.value.code == 1
+
+
+def test_main_warn_only_does_not_fail_when_version_is_equal(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, "0.1.0")
+
+    main(["--base", "main", "--warn-only"], cwd=repo)
+
+
+def test_push_includes_release_paths_detects_excel_grapher_changes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    base_sha = _init_git_repo(repo, "0.1.0")
+    head_sha = _commit_file(
+        repo,
+        "excel_grapher/example.py",
+        "VALUE = 1\n",
+        "add module",
+    )
+
+    assert push_includes_release_paths(base_sha, head_sha, repo)
+    assert not push_includes_release_paths(head_sha, head_sha, repo)
+
+
+def test_run_pre_push_warn_only_prints_reminder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, "0.1.0")
+    head_sha = _commit_file(
+        repo,
+        "excel_grapher/example.py",
+        "VALUE = 2\n",
+        "change module",
+    )
+    zero_sha = "0" * 40
+    monkeypatch.setattr(
+        "scripts.check_version_bump.read_pre_push_updates",
+        lambda: [("refs/heads/feature", head_sha, "refs/heads/feature", zero_sha)],
+    )
+
+    run_pre_push(warn_only=True, cwd=repo, pyproject=Path("pyproject.toml"))
+
+
+def test_run_pre_push_skips_when_push_has_no_release_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, "0.1.0")
+    head_sha = _commit_file(repo, "README.md", "docs\n", "docs only")
+    zero_sha = "0" * 40
+    monkeypatch.setattr(
+        "scripts.check_version_bump.read_pre_push_updates",
+        lambda: [("refs/heads/feature", head_sha, "refs/heads/feature", zero_sha)],
+    )
+
+    run_pre_push(warn_only=True, cwd=repo, pyproject=Path("pyproject.toml"))


### PR DESCRIPTION
## Summary
- Add a `release` workflow that runs CI on merge to `main`, builds with `uv build`, publishes to PyPI via trusted publishing, then tags `v{version}` and creates a GitHub release (skips if the tag already exists).
- Enforce manual versioning in CI: PRs that touch `excel_grapher/**` or `pyproject.toml` must bump `project.version` above `main`.
- Add `scripts/check_version_bump.py` with tests, plus a non-blocking pre-push reminder in pre-commit.

Closes #241

## Test plan
- [ ] Confirm CI passes on this PR (version bump check should run because package files changed).
- [ ] Verify `pre-commit install --hook-type pre-push` prints a reminder when pushing package changes without a version bump.
- [ ] After merge, confirm PyPI trusted publishing and the `PyPi` environment are configured before the first release run.
- [ ] On merge with a new version, confirm workflow builds, publishes, tags, and creates a GitHub release; re-run on `main` without a version bump and confirm it skips cleanly.


Made with [Cursor](https://cursor.com)