### PR TITLE
Parse whole-column and whole-row Excel references (issue #257)

### DIFF
--- a/excel_grapher/core/formula_ast.py
+++ b/excel_grapher/core/formula_ast.py
@@ -345,7 +345,8 @@ def _parse_ref_after_sheet_bang(s: _Scanner, original: str, *, sheet_qualifier: 
     if s.peek() == "$":
         s.consume()
 
-    if s.peek() and s.peek().isdigit():
+    ch = s.peek()
+    if ch is not None and ch.isdigit():
         row_start = s.i
         row_str = s.take_while(lambda c: c.isdigit())
         s.skip_ws()

--- a/excel_grapher/core/formula_ast.py
+++ b/excel_grapher/core/formula_ast.py
@@ -47,6 +47,18 @@ class RangeNode:
 
 
 @dataclass(frozen=True, slots=True)
+class WholeColumnNode:
+    sheet: str
+    column: str
+
+
+@dataclass(frozen=True, slots=True)
+class WholeRowNode:
+    sheet: str
+    row: int
+
+
+@dataclass(frozen=True, slots=True)
 class FunctionCallNode:
     name: str
     args: list[AstNode]
@@ -79,6 +91,8 @@ AstNode: TypeAlias = (
     | ErrorNode
     | CellRefNode
     | RangeNode
+    | WholeColumnNode
+    | WholeRowNode
     | FunctionCallNode
     | BinaryOpNode
     | UnaryOpNode
@@ -275,14 +289,7 @@ def _parse_atom(s: _Scanner, original: str) -> AstNode:
         # If there's an exclamation next, ident is the sheet name.
         if s.peek() == "!":
             s.consume()
-            addr = _parse_cell_coord(s, original)
-            start = f"{ident}!{addr}"
-            s.skip_ws()
-            if s.peek() == ":":
-                s.consume()
-                end = _parse_range_end(s, original, default_sheet=ident)
-                return RangeNode(start=start, end=end)
-            return CellRefNode(start)
+            return _parse_ref_after_sheet_bang(s, original, sheet_qualifier=ident)
 
         # Bare A1 is not supported because inputs are normalized and sheet-qualified.
         raise FormulaParseError(
@@ -319,21 +326,64 @@ def _parse_quoted_sheet_ref(s: _Scanner, original: str) -> AstNode:
         raise FormulaParseError(original, f"Expected '!' after quoted sheet name '{sheet_name}'")
     s.consume()
 
-    # Parse cell coordinate
-    addr = _parse_cell_coord(s, original)
-    start = f"{sheet_name}!{addr}"
-
-    s.skip_ws()
-    if s.peek() == ":":
-        s.consume()
-        end = _parse_range_end(s, original, default_sheet=sheet_name)
-        return RangeNode(start=start, end=end)
-
-    return CellRefNode(start)
+    return _parse_ref_after_sheet_bang(s, original, sheet_qualifier=sheet_name)
 
 
 def _parse_ident(s: _Scanner) -> str:
     return s.take_while(lambda c: c.isalnum() or c in ("_", ".", " "))
+
+
+def _bare_sheet_name(sheet_qualifier: str) -> str:
+    if sheet_qualifier.startswith("'") and sheet_qualifier.endswith("'"):
+        return sheet_qualifier[1:-1].replace("''", "'")
+    return sheet_qualifier
+
+
+def _parse_ref_after_sheet_bang(s: _Scanner, original: str, *, sheet_qualifier: str) -> AstNode:
+    """Parse a reference after ``sheet!`` (cell, whole column/row, or A1 range)."""
+    s.skip_ws()
+    if s.peek() == "$":
+        s.consume()
+
+    if s.peek() and s.peek().isdigit():
+        row_start = s.i
+        row_str = s.take_while(lambda c: c.isdigit())
+        s.skip_ws()
+        if s.peek() == ":":
+            s.consume()
+            s.skip_ws()
+            if s.peek() == "$":
+                s.consume()
+            row2 = s.take_while(lambda c: c.isdigit())
+            if row2 == row_str:
+                return WholeRowNode(sheet=_bare_sheet_name(sheet_qualifier), row=int(row_str))
+        s.i = row_start
+
+    col_start = s.i
+    col = s.take_while(lambda c: c.isalpha())
+    if col:
+        s.skip_ws()
+        if s.peek() == ":":
+            s.consume()
+            s.skip_ws()
+            if s.peek() == "$":
+                s.consume()
+            col2 = s.take_while(lambda c: c.isalpha())
+            if col2.upper() == col.upper():
+                return WholeColumnNode(
+                    sheet=_bare_sheet_name(sheet_qualifier),
+                    column=col.upper(),
+                )
+        s.i = col_start
+
+    addr = _parse_cell_coord(s, original)
+    start = f"{sheet_qualifier}!{addr}"
+    s.skip_ws()
+    if s.peek() == ":":
+        s.consume()
+        end = _parse_range_end(s, original, default_sheet=sheet_qualifier)
+        return RangeNode(start=start, end=end)
+    return CellRefNode(start)
 
 
 def _parse_cell_coord(s: _Scanner, original: str) -> str:

--- a/excel_grapher/core/formula_normalization.py
+++ b/excel_grapher/core/formula_normalization.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass
 from typing import cast
 
-from excel_grapher.core.address_keys import format_cell_key
+from excel_grapher.core.address_keys import format_cell_key, quote_sheet_if_needed
 
 _FUNC_LIKE = frozenset({"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"})
 _STRING_LITERAL_RE = re.compile(r'"(?:[^"]|"")*"')
@@ -81,9 +81,130 @@ def _apply_named_range_replacements(
     return names_re.sub(replace_name, formula)
 
 
+def _format_whole_column_ref(sheet: str, column: str) -> str:
+    col = column.upper()
+    return f"{quote_sheet_if_needed(sheet)}!{col}:{col}"
+
+
+def _format_whole_row_ref(sheet: str, row: int) -> str:
+    return f"{quote_sheet_if_needed(sheet)}!{row}:{row}"
+
+
+def _normalize_whole_column_row_shorthand(formula: str, current_sheet: str) -> str:
+    """Strip ``$`` and sheet-qualify whole-column/row shorthand without expanding bounds."""
+    result = formula
+
+    def quoted_whole_col(m: re.Match[str]) -> str:
+        return _format_whole_column_ref(m.group("sheet"), m.group("col"))
+
+    result = re.sub(
+        r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
+        quoted_whole_col,
+        result,
+        flags=re.IGNORECASE,
+    )
+
+    def unquoted_whole_col(m: re.Match[str]) -> str:
+        return _format_whole_column_ref(m.group("sheet"), m.group("col"))
+
+    result = re.sub(
+        r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
+        unquoted_whole_col,
+        result,
+        flags=re.IGNORECASE,
+    )
+
+    def local_whole_col(m: re.Match[str]) -> str:
+        col = m.group("col")
+        if col in _FUNC_LIKE:
+            return m.group(0)
+        return _format_whole_column_ref(current_sheet, col)
+
+    result = re.sub(
+        r"(?<![!A-Za-z0-9_'])(?<!\$)\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b(?![A-Za-z0-9_])",
+        local_whole_col,
+        result,
+        flags=re.IGNORECASE,
+    )
+
+    def quoted_whole_row(m: re.Match[str]) -> str:
+        return _format_whole_row_ref(m.group("sheet"), int(m.group("row")))
+
+    result = re.sub(
+        r"'(?P<sheet>[^']+)'!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b",
+        quoted_whole_row,
+        result,
+    )
+
+    def unquoted_whole_row(m: re.Match[str]) -> str:
+        return _format_whole_row_ref(m.group("sheet"), int(m.group("row")))
+
+    result = re.sub(
+        r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b",
+        unquoted_whole_row,
+        result,
+    )
+
+    def local_whole_row(m: re.Match[str]) -> str:
+        return _format_whole_row_ref(current_sheet, int(m.group("row")))
+
+    result = re.sub(
+        r"(?<![!A-Za-z0-9_'])(?<!\$)(?P<row>\d+)\s*:\s*\$?(?P=row)\b(?![A-Za-z0-9_])",
+        local_whole_row,
+        result,
+    )
+
+    return result
+
+
+def expand_whole_column_row_for_parse(
+    formula: str,
+    bounds: dict[str, tuple[int, int]],
+) -> str:
+    """Expand whole-column/row shorthand to bounded A1 ranges for parse-only paths.
+
+    Used when a workbook is available outside graph build (e.g. defined-name OFFSET
+    resolution). Strips ``$`` markers before matching.
+    """
+    from excel_grapher.core.range_shorthand import (
+        whole_column_to_bounded_a1,
+        whole_row_to_bounded_a1,
+    )
+
+    s = formula.replace("$", "")
+    for sheet in bounds:
+        quoted = re.escape(quote_sheet_if_needed(sheet))
+        bare = re.escape(sheet)
+
+        def repl_col(m: re.Match[str], *, _sheet: str = sheet) -> str:
+            start, end = whole_column_to_bounded_a1(_sheet, m.group(1), bounds)
+            return f"{start}:{end}"
+
+        for prefix in (quoted, bare):
+            s = re.sub(
+                prefix + r"!\s*([A-Z]+)\s*:\s*\1\b",
+                repl_col,
+                s,
+                flags=re.IGNORECASE,
+            )
+
+        def repl_row(m: re.Match[str], *, _sheet: str = sheet) -> str:
+            row = int(m.group(1))
+            start, end = whole_row_to_bounded_a1(_sheet, row, bounds)
+            return f"{start}:{end}"
+
+        for prefix in (quoted, bare):
+            s = re.sub(
+                prefix + r"!\s*(\d+)\s*:\s*\1\b",
+                repl_row,
+                s,
+            )
+    return s
+
+
 def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
     """Strip $ markers, qualify ranges and cells, without defined-name substitution."""
-    result = formula
+    result = _normalize_whole_column_row_shorthand(formula, current_sheet)
 
     def replace_quoted_range(m: re.Match[str]) -> str:
         sheet = m.group("sheet")

--- a/excel_grapher/core/range_shorthand.py
+++ b/excel_grapher/core/range_shorthand.py
@@ -1,0 +1,102 @@
+"""Workbook-aware resolution for Excel whole-column and whole-row range shorthand.
+
+Excel allows ``C:C`` (entire column) and ``5:5`` (entire row) in formulas. We parse
+those forms syntactically and resolve them to bounded ``ExcelRange`` values using
+each sheet's **used range** from the workbook (``max_row``, ``max_col``), not
+Excel's full grid (1:1 048 576). Rectangular ranges that exceed ``max_range_cells``
+still collapse to corner endpoints (issue #56); whole-column/row shorthands always
+expand to every cell in the used-range extent so ``MATCH``/``INDEX`` on interior
+rows remain correct.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import fastpyxl.utils.cell
+from fastpyxl.utils.cell import column_index_from_string, get_column_letter
+
+from excel_grapher.core.address_keys import format_cell_key
+from excel_grapher.core.types import ExcelRange
+
+EXCEL_MAX_ROW = 1_048_576
+EXCEL_MAX_COL = 16_384
+
+SheetBounds = dict[str, tuple[int, int]]
+
+
+def sheet_used_extent(bounds: SheetBounds, sheet: str) -> tuple[int, int]:
+    """Return ``(max_row, max_col)`` for *sheet*, defaulting to Excel limits."""
+    return bounds.get(sheet, (EXCEL_MAX_ROW, EXCEL_MAX_COL))
+
+
+def resolve_whole_column(sheet: str, column: str, bounds: SheetBounds) -> ExcelRange:
+    """Map a whole-column shorthand to a bounded single-column ``ExcelRange``."""
+    col = column.upper()
+    col_idx = column_index_from_string(col)
+    max_r, _ = sheet_used_extent(bounds, sheet)
+    return ExcelRange(
+        sheet=sheet,
+        start_row=1,
+        start_col=col_idx,
+        end_row=max_r,
+        end_col=col_idx,
+    )
+
+
+def resolve_whole_row(sheet: str, row: int, bounds: SheetBounds) -> ExcelRange:
+    """Map a whole-row shorthand to a bounded single-row ``ExcelRange``."""
+    _, max_c = sheet_used_extent(bounds, sheet)
+    return ExcelRange(
+        sheet=sheet,
+        start_row=row,
+        start_col=1,
+        end_row=row,
+        end_col=max_c,
+    )
+
+
+def iter_whole_column_cells(
+    sheet: str, column: str, bounds: SheetBounds
+) -> Iterator[tuple[str, str]]:
+    """Yield ``(sheet, a1)`` for each cell in a workbook-bounded whole column."""
+    rng = resolve_whole_column(sheet, column, bounds)
+    col_letter = column.upper()
+    for row in range(rng.start_row, rng.end_row + 1):
+        yield sheet, f"{col_letter}{row}"
+
+
+def iter_whole_row_cells(sheet: str, row: int, bounds: SheetBounds) -> Iterator[tuple[str, str]]:
+    """Yield ``(sheet, a1)`` for each cell in a workbook-bounded whole row."""
+    rng = resolve_whole_row(sheet, row, bounds)
+    for col_idx in range(rng.start_col, rng.end_col + 1):
+        yield sheet, f"{fastpyxl.utils.cell.get_column_letter(col_idx)}{row}"
+
+
+def expand_whole_column_deps(sheet: str, column: str, bounds: SheetBounds) -> list[tuple[str, str]]:
+    """Expand a whole-column shorthand to all ``(sheet, a1)`` deps in the used range."""
+    return list(iter_whole_column_cells(sheet, column, bounds))
+
+
+def expand_whole_row_deps(sheet: str, row: int, bounds: SheetBounds) -> list[tuple[str, str]]:
+    """Expand a whole-row shorthand to all ``(sheet, a1)`` deps in the used range."""
+    return list(iter_whole_row_cells(sheet, row, bounds))
+
+
+def whole_column_to_bounded_a1(sheet: str, column: str, bounds: SheetBounds) -> tuple[str, str]:
+    """Return ``(start_ref, end_ref)`` sheet-qualified endpoints for a whole column."""
+    col = column.upper()
+    max_r, _ = sheet_used_extent(bounds, sheet)
+    return (
+        format_cell_key(sheet, col, 1),
+        format_cell_key(sheet, col, max_r),
+    )
+
+
+def whole_row_to_bounded_a1(sheet: str, row: int, bounds: SheetBounds) -> tuple[str, str]:
+    """Return ``(start_ref, end_ref)`` sheet-qualified endpoints for a whole row."""
+    _, max_c = sheet_used_extent(bounds, sheet)
+    return (
+        format_cell_key(sheet, get_column_letter(1), row),
+        format_cell_key(sheet, get_column_letter(max_c), row),
+    )

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -13,6 +13,11 @@ from excel_grapher.core.address_keys import (
     parse_address,
 )
 from excel_grapher.core.addressing import index_excel_range
+from excel_grapher.core.range_shorthand import (
+    SheetBounds,
+    resolve_whole_column,
+    resolve_whole_row,
+)
 from excel_grapher.grapher.blank_ranges import (
     address_in_blank_ranges,
     normalize_blank_range_specs,
@@ -52,6 +57,8 @@ from .parser import (
     RangeNode,
     StringNode,
     UnaryOpNode,
+    WholeColumnNode,
+    WholeRowNode,
     parse,
 )
 from .types import CellValue, ExcelRange, XlError
@@ -276,6 +283,10 @@ class FormulaEvaluator:
             return node.error
         if isinstance(node, CellRefNode):
             return self._evaluate_cell(node.address)
+        if isinstance(node, WholeColumnNode):
+            return self._resolve_whole_column(node.sheet, node.column)
+        if isinstance(node, WholeRowNode):
+            return self._resolve_whole_row(node.sheet, node.row)
         if isinstance(node, RangeNode):
             return _range_from_a1(node.start, node.end)
         if isinstance(node, FunctionCallNode):
@@ -330,6 +341,16 @@ class FormulaEvaluator:
 
     def _resolve_range(self, rng: ExcelRange) -> numpy.ndarray:
         return rng.resolve(self._evaluate_cell)
+
+    def _sheet_bounds(self) -> SheetBounds:
+        bounds = getattr(self.graph, "sheet_bounds", None)
+        return dict(bounds) if bounds else {}
+
+    def _resolve_whole_column(self, sheet: str, column: str) -> ExcelRange:
+        return resolve_whole_column(sheet, column, self._sheet_bounds())
+
+    def _resolve_whole_row(self, sheet: str, row: int) -> ExcelRange:
+        return resolve_whole_row(sheet, row, self._sheet_bounds())
 
     def _auto_resolve_single_cell(self, value: CellValue) -> CellValue:
         """If value is a 1x1 ExcelRange, resolve it to its single cell value."""
@@ -546,7 +567,11 @@ class FormulaEvaluator:
         if len(node.args) < 1:
             return XlError.VALUE
         array_node = node.args[0]
-        if isinstance(array_node, RangeNode):
+        if isinstance(array_node, WholeColumnNode):
+            base = self._resolve_whole_column(array_node.sheet, array_node.column)
+        elif isinstance(array_node, WholeRowNode):
+            base = self._resolve_whole_row(array_node.sheet, array_node.row)
+        elif isinstance(array_node, RangeNode):
             base = _range_from_a1(array_node.start, array_node.end)
         else:
             inner = self._range_from_ref_node(array_node)
@@ -572,6 +597,10 @@ class FormulaEvaluator:
         """Interpret an AST node as a reference (cell or range) without evaluating its value."""
         if isinstance(node, RangeNode):
             return _range_from_a1(node.start, node.end)
+        if isinstance(node, WholeColumnNode):
+            return self._resolve_whole_column(node.sheet, node.column)
+        if isinstance(node, WholeRowNode):
+            return self._resolve_whole_row(node.sheet, node.row)
 
         if isinstance(node, CellRefNode):
             sheet, coord = parse_address(node.address)

--- a/excel_grapher/evaluator/parser.py
+++ b/excel_grapher/evaluator/parser.py
@@ -7,6 +7,7 @@ from excel_grapher.core.formula_ast import (
     BinaryOpNode,
     BoolNode,
     CellRefNode,
+    EmptyArgNode,
     ErrorNode,
     FormulaParseError,
     FunctionCallNode,
@@ -14,7 +15,8 @@ from excel_grapher.core.formula_ast import (
     RangeNode,
     StringNode,
     UnaryOpNode,
-    EmptyArgNode,
+    WholeColumnNode,
+    WholeRowNode,
     parse as _core_parse,
 )
 
@@ -33,6 +35,8 @@ __all__ = [
     "StringNode",
     "UnaryOpNode",
     "EmptyArgNode",
+    "WholeColumnNode",
+    "WholeRowNode",
     "parse",
 ]
 

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -44,6 +44,7 @@ from .parser import (
     _find_function_calls_with_spans,
     _split_function_args,
     expand_range,
+    expand_range_ref,
     format_key,
     mask_spans,
     parse_cell_refs,
@@ -318,6 +319,7 @@ def create_dependency_graph(
             _wb_sha256 = hashlib.file_digest(_f, "sha256").hexdigest()
 
     graph = DependencyGraph(sheet_order=list(wb_formulas.sheetnames))
+    sheet_bounds: dict[str, tuple[int, int]] = {}
     for h in hooks or []:
         graph.register_hook(h)
 
@@ -348,7 +350,18 @@ def create_dependency_graph(
         if ws is None:
             ws = wb_formulas[sheet]
             _ws_f_cache[sheet] = ws
+            max_row = getattr(ws, "max_row", None) or 1
+            max_col = getattr(ws, "max_column", None) or 1
+            if max_row < 1:
+                max_row = 1
+            if max_col < 1:
+                max_col = 1
+            sheet_bounds[sheet] = (max_row, max_col)
         return ws
+
+    def _ensure_sheet_bounds(sheet: str) -> None:
+        if sheet not in sheet_bounds:
+            _get_ws_f(sheet)
 
     def _get_ws_v(sheet: str) -> Worksheet:
         # Only called when wb_values is not None.
@@ -385,13 +398,13 @@ def create_dependency_graph(
             out.add(format_key(sh, f"{ref.column}{ref.row}"))
         for start, end, _span in parse_range_refs_with_spans(normalized):
             sh = start.sheet if start.sheet is not None else sheet_of_cell
-            for dep_sheet, dep_a1 in expand_range(
-                sheet=sh,
-                start_col=start.column,
-                start_row=start.row,
-                end_col=end.column,
-                end_row=end.row,
+            _ensure_sheet_bounds(sh)
+            for dep_sheet, dep_a1 in expand_range_ref(
+                start=start,
+                end=end,
+                default_sheet=sh,
                 max_cells=max_range_cells,
+                sheet_bounds=sheet_bounds,
             ):
                 out.add(format_key(dep_sheet, dep_a1))
         return out
@@ -812,14 +825,14 @@ def create_dependency_graph(
                 for start, end, span in parse_range_refs_with_spans(masked):
                     spans.append(span)
                     sheet = start.sheet if start.sheet is not None else current_sheet
+                    _ensure_sheet_bounds(sheet)
                     deps.extend(
-                        expand_range(
-                            sheet=sheet,
-                            start_col=start.column,
-                            start_row=start.row,
-                            end_col=end.column,
-                            end_row=end.row,
+                        expand_range_ref(
+                            start=start,
+                            end=end,
+                            default_sheet=sheet,
                             max_cells=max_range_cells,
+                            sheet_bounds=sheet_bounds,
                         )
                     )
                 masked = mask_spans(masked, spans)
@@ -1210,6 +1223,7 @@ def create_dependency_graph(
 
     graph.named_ranges = dict(named_ranges)
     graph.named_range_ranges = dict(named_range_ranges)
+    graph.sheet_bounds = dict(sheet_bounds)
     return graph
 
 

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -49,10 +49,13 @@ from excel_grapher.core.formula_ast import (
     RangeNode,
     StringNode,
     UnaryOpNode,
+    WholeColumnNode,
+    WholeRowNode,
 )
 from excel_grapher.core.formula_ast import (
     parse as parse_ast,
 )
+from excel_grapher.core.range_shorthand import expand_whole_column_deps, expand_whole_row_deps
 from excel_grapher.core.types import ExcelRange, XlError
 
 from .parser import _find_function_calls_with_spans, expand_range, format_key
@@ -3276,7 +3279,12 @@ def _ast_address_to_ref_key(address: str) -> str:
     return format_key(sheet, f"{col_letter}{row}")
 
 
-def _collect_static_addresses_from_ast(node: AstNode, *, max_range_cells: int) -> set[str]:
+def _collect_static_addresses_from_ast(
+    node: AstNode,
+    *,
+    max_range_cells: int,
+    sheet_bounds: dict[str, tuple[int, int]] | None = None,
+) -> set[str]:
     """Collect static cell/range addresses while skipping dynamic-ref call subtrees.
 
     Range expansion uses the same `max_range_cells` policy as
@@ -3288,6 +3296,16 @@ def _collect_static_addresses_from_ast(node: AstNode, *, max_range_cells: int) -
     def visit(n: AstNode) -> None:
         if isinstance(n, CellRefNode):
             addrs.add(_ast_address_to_ref_key(n.address))
+            return
+        if isinstance(n, WholeColumnNode):
+            bounds = sheet_bounds or {}
+            for dep_sheet, dep_a1 in expand_whole_column_deps(n.sheet, n.column, bounds):
+                addrs.add(format_key(dep_sheet, dep_a1))
+            return
+        if isinstance(n, WholeRowNode):
+            bounds = sheet_bounds or {}
+            for dep_sheet, dep_a1 in expand_whole_row_deps(n.sheet, n.row, bounds):
+                addrs.add(format_key(dep_sheet, dep_a1))
             return
         if isinstance(n, RangeNode):
             try:

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -119,6 +119,7 @@ class DependencyGraph:
     _hooks: list[NodeHook] = field(default_factory=list)
     leaf_classification: dict[str, str] | None = None
     sheet_order: list[str] | None = None
+    sheet_bounds: dict[str, tuple[int, int]] | None = None
     named_ranges: dict[str, tuple[str, str]] | None = None
     named_range_ranges: dict[str, tuple[str, str, str]] | None = None
 

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -5,6 +5,7 @@ import re
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal as TypingLiteral
 
 import fastpyxl.utils.cell
 
@@ -17,6 +18,11 @@ from excel_grapher.core.formula_normalization import (
     build_named_range_replacement_state,
     normalize_excel_formula,
     normalize_excel_formula_with_name_state,
+)
+from excel_grapher.core.range_shorthand import (
+    SheetBounds,
+    expand_whole_column_deps,
+    expand_whole_row_deps,
 )
 
 from .guard import And, Compare, GuardExpr, Literal, Not, Or
@@ -36,6 +42,7 @@ class CellRef:
     row: int
     is_absolute_col: bool = False
     is_absolute_row: bool = False
+    range_kind: TypingLiteral["cell", "whole_column", "whole_row"] = "cell"
 
 
 _SHEET_CELL_RE = re.compile(
@@ -62,6 +69,25 @@ _RANGE_UNQUOTED_BOTH_ENDPOINTS_RE = re.compile(
 )
 _RANGE_LOCAL_RE = re.compile(
     r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])"
+)
+_RANGE_WHOLE_COL_QUOTED_RE = re.compile(
+    r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
+    re.IGNORECASE,
+)
+_RANGE_WHOLE_COL_UNQUOTED_RE = re.compile(
+    r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
+    re.IGNORECASE,
+)
+_RANGE_WHOLE_COL_LOCAL_RE = re.compile(
+    r"(?<![!A-Za-z0-9_'])(?<!\$)\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b(?![A-Za-z0-9_])",
+    re.IGNORECASE,
+)
+_RANGE_WHOLE_ROW_QUOTED_RE = re.compile(r"'(?P<sheet>[^']+)'!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b")
+_RANGE_WHOLE_ROW_UNQUOTED_RE = re.compile(
+    r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b"
+)
+_RANGE_WHOLE_ROW_LOCAL_RE = re.compile(
+    r"(?<![!A-Za-z0-9_'])(?<!\$)(?P<row>\d+)\s*:\s*\$?(?P=row)\b(?![A-Za-z0-9_])"
 )
 
 
@@ -116,6 +142,40 @@ def parse_range_refs(formula: str) -> list[tuple[CellRef, CellRef]]:
         return []
 
     out: list[tuple[CellRef, CellRef]] = []
+
+    for m in _RANGE_WHOLE_COL_QUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        col = m.group("col").upper()
+        ref = CellRef(sheet=sheet, column=col, row=0, range_kind="whole_column")
+        out.append((ref, ref))
+
+    for m in _RANGE_WHOLE_COL_UNQUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        col = m.group("col").upper()
+        ref = CellRef(sheet=sheet, column=col, row=0, range_kind="whole_column")
+        out.append((ref, ref))
+
+    for m in _RANGE_WHOLE_COL_LOCAL_RE.finditer(formula):
+        col = m.group("col").upper()
+        ref = CellRef(sheet=None, column=col, row=0, range_kind="whole_column")
+        out.append((ref, ref))
+
+    for m in _RANGE_WHOLE_ROW_QUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        row = int(m.group("row"))
+        ref = CellRef(sheet=sheet, column="", row=row, range_kind="whole_row")
+        out.append((ref, ref))
+
+    for m in _RANGE_WHOLE_ROW_UNQUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        row = int(m.group("row"))
+        ref = CellRef(sheet=sheet, column="", row=row, range_kind="whole_row")
+        out.append((ref, ref))
+
+    for m in _RANGE_WHOLE_ROW_LOCAL_RE.finditer(formula):
+        row = int(m.group("row"))
+        ref = CellRef(sheet=None, column="", row=row, range_kind="whole_row")
+        out.append((ref, ref))
 
     for m in _RANGE_QUOTED_BOTH_ENDPOINTS_RE.finditer(formula):
         sheet = m.group("sheet")
@@ -174,6 +234,40 @@ def parse_range_refs_with_spans(formula: str) -> list[tuple[CellRef, CellRef, tu
         return []
 
     out: list[tuple[CellRef, CellRef, tuple[int, int]]] = []
+
+    for m in _RANGE_WHOLE_COL_QUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        col = m.group("col").upper()
+        ref = CellRef(sheet=sheet, column=col, row=0, range_kind="whole_column")
+        out.append((ref, ref, m.span()))
+
+    for m in _RANGE_WHOLE_COL_UNQUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        col = m.group("col").upper()
+        ref = CellRef(sheet=sheet, column=col, row=0, range_kind="whole_column")
+        out.append((ref, ref, m.span()))
+
+    for m in _RANGE_WHOLE_COL_LOCAL_RE.finditer(formula):
+        col = m.group("col").upper()
+        ref = CellRef(sheet=None, column=col, row=0, range_kind="whole_column")
+        out.append((ref, ref, m.span()))
+
+    for m in _RANGE_WHOLE_ROW_QUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        row = int(m.group("row"))
+        ref = CellRef(sheet=sheet, column="", row=row, range_kind="whole_row")
+        out.append((ref, ref, m.span()))
+
+    for m in _RANGE_WHOLE_ROW_UNQUOTED_RE.finditer(formula):
+        sheet = m.group("sheet")
+        row = int(m.group("row"))
+        ref = CellRef(sheet=sheet, column="", row=row, range_kind="whole_row")
+        out.append((ref, ref, m.span()))
+
+    for m in _RANGE_WHOLE_ROW_LOCAL_RE.finditer(formula):
+        row = int(m.group("row"))
+        ref = CellRef(sheet=None, column="", row=row, range_kind="whole_row")
+        out.append((ref, ref, m.span()))
 
     for m in _RANGE_QUOTED_BOTH_ENDPOINTS_RE.finditer(formula):
         sheet = m.group("sheet")
@@ -250,6 +344,33 @@ def expand_range(
         for cc in range(clo, chi + 1):
             out.append((sheet, f"{fastpyxl.utils.cell.get_column_letter(cc)}{rr}"))
     return out
+
+
+def expand_range_ref(
+    *,
+    start: CellRef,
+    end: CellRef,
+    default_sheet: str,
+    max_cells: int,
+    sheet_bounds: SheetBounds | None = None,
+) -> list[tuple[str, str]]:
+    """Expand a parsed range reference, using workbook bounds for whole-column/row forms."""
+    sheet = start.sheet if start.sheet is not None else default_sheet
+    bounds = sheet_bounds or {}
+
+    if start.range_kind == "whole_column":
+        return expand_whole_column_deps(sheet, start.column, bounds)
+    if start.range_kind == "whole_row":
+        return expand_whole_row_deps(sheet, start.row, bounds)
+
+    return expand_range(
+        sheet=sheet,
+        start_col=start.column,
+        start_row=start.row,
+        end_col=end.column,
+        end_row=end.row,
+        max_cells=max_cells,
+    )
 
 
 def mask_spans(s: str, spans: list[tuple[int, int]]) -> str:

--- a/excel_grapher/grapher/resolver.py
+++ b/excel_grapher/grapher/resolver.py
@@ -25,6 +25,7 @@ from excel_grapher.core.formula_ast import (
 from excel_grapher.core.formula_ast import (
     parse as parse_formula_ast,
 )
+from excel_grapher.core.formula_normalization import expand_whole_column_row_for_parse
 from excel_grapher.core.types import CellValue, ExcelRange, XlError
 
 from .parser import CellRef
@@ -278,22 +279,8 @@ def _eval_indirect_formula_to_range(
 
 
 def _normalize_formula_for_parse(formula: str, bounds: dict[str, tuple[int, int]]) -> str:
-    """Strip $ and expand whole-column/whole-row refs so formula_ast can parse."""
-    s = formula.replace("$", "")
-    for sheet, (max_r, max_c) in bounds.items():
-        col_letter = get_column_letter(max_c)
-        s = re.sub(
-            re.escape(sheet) + r"!\s*([A-Z]+)\s*:\s*\1\b",
-            f"{sheet}!\\g<1>1:\\g<1>{max_r}",
-            s,
-            flags=re.IGNORECASE,
-        )
-        s = re.sub(
-            re.escape(sheet) + r"!\s*(\d+)\s*:\s*\1\b",
-            f"{sheet}!A\\g<1>:{col_letter}\\g<1>",
-            s,
-        )
-    return s
+    """Strip ``$`` and expand whole-column/whole-row refs so formula_ast can parse."""
+    return expand_whole_column_row_for_parse(formula, bounds)
 
 
 def _try_resolve_formula_defined_name(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "excel-grapher"
-version = "0.5.0"
+version = "0.5.1"
 description = "Build and analyze dependency graphs from Excel workbooks"
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/tests/unit/core/test_whole_column_row_refs.py
+++ b/tests/unit/core/test_whole_column_row_refs.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+from excel_grapher.core.formula_ast import (
+    CellRefNode,
+    FunctionCallNode,
+    WholeColumnNode,
+    WholeRowNode,
+    parse,
+)
+from excel_grapher.core.formula_normalization import (
+    expand_whole_column_row_for_parse,
+    normalize_excel_formula,
+)
+from excel_grapher.core.range_shorthand import (
+    EXCEL_MAX_ROW,
+    expand_whole_column_deps,
+    resolve_whole_column,
+    resolve_whole_row,
+)
+from excel_grapher.core.types import ExcelRange
+from excel_grapher.grapher.parser import parse_range_refs, parse_range_refs_with_spans
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "='QB - Stafford'!C:C",
+        "='QB - Stafford'!$C:$C",
+        "=Data!A:A",
+        "=Data!5:5",
+        "='My Sheet'!B:B",
+    ],
+)
+def test_parse_whole_column_or_row_shorthand(formula: str) -> None:
+    ast = parse(formula)
+    assert isinstance(ast, (WholeColumnNode, WholeRowNode))
+
+
+def test_parse_whole_column_ast_shape() -> None:
+    assert parse("=Data!C:C") == WholeColumnNode(sheet="Data", column="C")
+
+
+def test_parse_whole_row_ast_shape() -> None:
+    assert parse("=Data!5:5") == WholeRowNode(sheet="Data", row=5)
+
+
+def test_parse_index_match_whole_column_formula() -> None:
+    formula = (
+        "=INDEX(Data!C:C,"
+        "MATCH(INDEX(Stats!C1:G1,MATCH(MAX(Stats!C2:G2),Stats!C2:G2,0)),"
+        "Data!A:A,0))"
+    )
+    ast = parse(formula)
+    assert isinstance(ast, FunctionCallNode)
+    assert ast.name == "INDEX"
+    assert isinstance(ast.args[0], WholeColumnNode)
+
+
+def test_parse_whole_column_does_not_break_cell_ref() -> None:
+    assert parse("='QB - Stafford'!C1") == CellRefNode("'QB - Stafford'!C1")
+
+
+def test_resolve_whole_column_uses_workbook_bounds() -> None:
+    bounds = {"Data": (50, 10)}
+    rng = resolve_whole_column("Data", "C", bounds)
+    assert rng == ExcelRange("Data", 1, 3, 50, 3)
+
+
+def test_resolve_whole_column_quoted_sheet_name() -> None:
+    bounds = {"QB - Stafford": (30, 5)}
+    rng = resolve_whole_column("QB - Stafford", "A", bounds)
+    assert rng.end_row == 30
+
+
+def test_resolve_whole_row_uses_workbook_bounds() -> None:
+    bounds = {"Data": (50, 10)}
+    rng = resolve_whole_row("Data", 5, bounds)
+    assert rng.start_col == 1 and rng.end_col == 10 and rng.start_row == rng.end_row == 5
+
+
+def test_resolve_whole_column_defaults_to_excel_max_without_bounds() -> None:
+    rng = resolve_whole_column("Missing", "A", {})
+    assert rng.end_row == EXCEL_MAX_ROW
+
+
+def test_expand_whole_column_deps_enumerates_used_range() -> None:
+    bounds = {"Data": (3, 2)}
+    deps = expand_whole_column_deps("Data", "A", bounds)
+    assert deps == [("Data", "A1"), ("Data", "A2"), ("Data", "A3")]
+
+
+def test_normalize_preserves_whole_column_shorthand() -> None:
+    out = normalize_excel_formula("=MATCH(x,Data!$A:$A,0)", "Sheet1")
+    assert out == "=MATCH(x,Data!A:A,0)"
+
+
+def test_normalize_qualifies_local_whole_column() -> None:
+    out = normalize_excel_formula("=MATCH(x,A:A,0)", "Sheet1")
+    assert out == "=MATCH(x,Sheet1!A:A,0)"
+
+
+def test_expand_whole_column_row_for_parse_quoted_sheet() -> None:
+    bounds = {"QB - Stafford": (30, 5)}
+    formula = "=INDEX('QB - Stafford'!C:C,1)"
+    expanded = expand_whole_column_row_for_parse(formula, bounds)
+    assert "'QB - Stafford'!C1:'QB - Stafford'!C30" in expanded
+
+
+def test_parse_range_refs_whole_column_quoted() -> None:
+    refs = parse_range_refs("=INDEX('Data'!C:C,1)")
+    assert len(refs) == 1
+    start, end = refs[0]
+    assert start.sheet == "Data"
+    assert start.column == end.column == "C"
+    assert start.range_kind == "whole_column"
+
+
+def test_parse_range_refs_whole_row() -> None:
+    refs = parse_range_refs("=SUM('Data'!5:5)")
+    assert len(refs) == 1
+    start, end = refs[0]
+    assert start.sheet == "Data"
+    assert start.row == end.row == 5
+    assert start.range_kind == "whole_row"
+
+
+def test_parse_range_refs_with_spans_whole_column() -> None:
+    refs = parse_range_refs_with_spans("=MATCH(x,'Data'!A:A,0)")
+    assert len(refs) == 1
+    _, _, span = refs[0]
+    assert span == (9, 19)

--- a/tests/unit/evaluator/test_whole_column_refs.py
+++ b/tests/unit/evaluator/test_whole_column_refs.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import xlsxwriter
+
+from excel_grapher import FormulaEvaluator, create_dependency_graph
+
+
+def test_match_whole_column_finds_interior_value(tmp_path: Path) -> None:
+    excel_path = tmp_path / "index_match.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    data = wb.add_worksheet("Data")
+    sheet1 = wb.add_worksheet("Sheet1")
+    data.write_string(9, 0, "lookup")
+    data.write_string(9, 2, "result")
+    sheet1.write_formula(
+        0,
+        1,
+        '=INDEX(Data!C:C,MATCH("lookup",Data!A:A,0))',
+        None,
+        "result",
+    )
+    wb.close()
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!B1"],
+        load_values=True,
+        max_range_cells=2,
+        use_cached_dynamic_refs=True,
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate("Sheet1!B1") == "result"
+
+
+def test_match_whole_column_interior_row_25(tmp_path: Path) -> None:
+    excel_path = tmp_path / "match_row.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    data = wb.add_worksheet("Data")
+    sheet1 = wb.add_worksheet("Sheet1")
+    data.write_string(24, 0, "SEA")
+    sheet1.write_formula(0, 1, '=MATCH("SEA",Data!A:A,0)', None, 25)
+    wb.close()
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!B1"],
+        load_values=True,
+        max_range_cells=2,
+        use_cached_dynamic_refs=True,
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate("Sheet1!B1") == 25
+
+
+def test_index_match_cross_sheet_quoted_sheet_name(tmp_path: Path) -> None:
+    excel_path = tmp_path / "quoted_sheet.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    qb = wb.add_worksheet("QB - Stafford")
+    sheet1 = wb.add_worksheet("Sheet1")
+    qb.write_string(4, 0, "target")
+    qb.write_string(4, 2, "A SEA")
+    sheet1.write_formula(
+        0,
+        0,
+        "=INDEX('QB - Stafford'!C:C,MATCH(\"target\",'QB - Stafford'!A:A,0))",
+        None,
+        "A SEA",
+    )
+    wb.close()
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!A1"],
+        load_values=True,
+        max_range_cells=2,
+        use_cached_dynamic_refs=True,
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate("Sheet1!A1") == "A SEA"

--- a/tests/unit/grapher/test_normalized_formula_whole_column.py
+++ b/tests/unit/grapher/test_normalized_formula_whole_column.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import fastpyxl
+
+from excel_grapher import create_dependency_graph
+
+
+def test_normalized_formula_preserves_whole_column_shorthand(tmp_path: Path) -> None:
+    excel_path = tmp_path / "norm_whole_col.xlsx"
+    wb = fastpyxl.Workbook()
+    data = wb.create_sheet("Data")
+    sheet1 = wb.active
+    sheet1.title = "Sheet1"
+    sheet1["B1"].value = '=MATCH("x",Data!A:A,0)'
+    data["A1"].value = "x"
+    wb.save(excel_path)
+    wb.close()
+
+    graph = create_dependency_graph(excel_path, ["Sheet1!B1"], load_values=False)
+    node = graph.get_node("Sheet1!B1")
+    assert node is not None
+    assert node.normalized_formula == '=MATCH("x",Data!A:A,0)'

--- a/tests/unit/grapher/test_whole_column_range_deps.py
+++ b/tests/unit/grapher/test_whole_column_range_deps.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import xlsxwriter
+
+from excel_grapher import create_dependency_graph
+
+
+def _write_match_column_workbook(path: Path, *, interior_row: int, used_rows: int) -> None:
+    wb = xlsxwriter.Workbook(path)
+    data = wb.add_worksheet("Data")
+    sheet1 = wb.add_worksheet("Sheet1")
+    data.write_string(interior_row - 1, 0, "SEA")
+    sheet1.write_formula(0, 1, '=MATCH("SEA",Data!A:A,0)', None, 0)
+    wb.close()
+
+
+def test_whole_column_deps_include_interior_cell_not_corners_only(tmp_path: Path) -> None:
+    excel_path = tmp_path / "match_interior.xlsx"
+    _write_match_column_workbook(excel_path, interior_row=25, used_rows=50)
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!B1"],
+        load_values=True,
+        max_range_cells=2,
+    )
+    deps = graph.get_dependencies("Sheet1!B1")
+    assert "Data!A25" in deps
+    assert len([d for d in deps if d.startswith("Data!A")]) >= 3
+
+
+def test_whole_column_deps_bounded_to_used_range_not_excel_max(tmp_path: Path) -> None:
+    excel_path = tmp_path / "match_bounded.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    data = wb.add_worksheet("Data")
+    sheet1 = wb.add_worksheet("Sheet1")
+    for row in range(50):
+        data.write_string(row, 0, "x")
+    sheet1.write_formula(0, 1, '=MATCH("x",Data!A:A,0)', None, 1)
+    wb.close()
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!B1"],
+        load_values=True,
+        max_range_cells=2,
+    )
+    deps = graph.get_dependencies("Sheet1!B1")
+    assert "Data!A50" in deps
+    assert "Data!A1048576" not in deps
+
+
+def test_rectangular_range_still_uses_corner_fallback_issue_56(tmp_path: Path) -> None:
+    excel_path = tmp_path / "rect_corner_cap.xlsx"
+    wb = xlsxwriter.Workbook(excel_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number(0, 0, 1)
+    ws.write_number(0, 2, 1)
+    ws.write_formula(0, 3, "=SUM(Sheet1!A1:C1)", None, 2)
+    wb.close()
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!D1"],
+        load_values=False,
+        max_range_cells=2,
+    )
+    deps = graph.get_dependencies("Sheet1!D1")
+    assert "Sheet1!A1" in deps
+    assert "Sheet1!C1" in deps
+    assert "Sheet1!B1" not in deps

--- a/user_guide/01-dependency-graphs.qmd
+++ b/user_guide/01-dependency-graphs.qmd
@@ -11,6 +11,7 @@ guide-section: "Core workflow"
 - **Values are optional**: `load_values=True` loads cached Excel results (second workbook load); otherwise formula nodes have `value=None`.
 - **Extensible metadata**: each `Node` has a `metadata: dict[str, Any]` that hooks can mutate.
 - **Range expansion**: ranges like `A1:A10` are expanded to individual cell dependencies (bounded by `max_range_cells`).
+- **Whole-column/row shorthand**: Excel forms like `Data!A:A` and `Data!5:5` parse as syntactic shorthands and resolve to each sheet's **used range** (workbook dimensions), not Excel's full grid. These shorthands expand to every row/column in that extent even when `max_range_cells` would otherwise keep only rectangular corner endpoints.
 - **Normalized formulas**: each formula node has a `normalized_formula` field with sheet-qualified refs, resolved named ranges, and stripped `$` markers — ready for transpilation.
 
 ### Quick start: building a graph

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,7 @@ wheels = [
 
 [[package]]
 name = "excel-grapher"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastpyxl" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements workbook-aware parsing and resolution for Excel whole-column and whole-row range shorthand (`C:C`, `A:A`, `5:5`), fixing parse-time failures that blocked `INDEX`/`MATCH` formulas and aggregate-stats export paths.

## Design choice

Whole-column/row shorthands are parsed syntactically and resolved using each sheet's **used range** (from workbook dimensions), not Excel's full 1,048,576-row grid. This is documented in `user_guide/01-dependency-graphs.qmd`.

Rectangular ranges still honor `max_range_cells` corner-endpoint fallback (issue #56). Whole-column/row shorthands **bypass** that fallback so interior cells remain in the dependency graph and evaluator closure.

## Changes

- **AST parser** (`formula_ast.py`): `WholeColumnNode`, `WholeRowNode`
- **Bounds helpers** (`range_shorthand.py`): resolve/expand using workbook used range
- **Normalization** (`formula_normalization.py`): strip `$`, sheet-qualify shorthand; shared `expand_whole_column_row_for_parse` for defined-name OFFSET paths
- **Grapher regex** (`parser.py`): `parse_range_refs*` + `expand_range_ref`
- **Graph builder**: lazy `sheet_bounds` on worksheet cache; full-column deps
- **Evaluator**: resolve shorthand via `graph.sheet_bounds`
- **27 new unit tests** covering parse, deps (corner regression), evaluator INDEX/MATCH

## Test plan

- [x] `uv run pytest tests/unit/core/test_whole_column_row_refs.py`
- [x] `uv run pytest tests/unit/grapher/test_whole_column_range_deps.py`
- [x] `uv run pytest tests/unit/evaluator/test_whole_column_refs.py`
- [x] Full suite: 1180 passed

Closes #257
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bab4bad-8e52-4558-9d30-63718a091cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bab4bad-8e52-4558-9d30-63718a091cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

