### PR TITLE
Implement Excel VALUE function in FormulaEvaluator (#258)

### DIFF
--- a/excel_grapher/runtime/text.py
+++ b/excel_grapher/runtime/text.py
@@ -167,4 +167,7 @@ def xl_lower(text: CellValue) -> str | XlError:
 
 def xl_value(text: CellValue) -> float | XlError:
     """Convert locale-formatted text to a number (Excel VALUE)."""
-    return xl_numbervalue(text)
+    parsed = xl_numbervalue(text)
+    if parsed is XlError.VALUE and isinstance(text, str):
+        return to_number(text)
+    return parsed

--- a/excel_grapher/runtime/text.py
+++ b/excel_grapher/runtime/text.py
@@ -166,5 +166,5 @@ def xl_lower(text: CellValue) -> str | XlError:
 
 
 def xl_value(text: CellValue) -> float | XlError:
-    """Convert text to a number (Excel ``VALUE``)."""
-    return to_number(text)
+    """Convert locale-formatted text to a number (Excel VALUE)."""
+    return xl_numbervalue(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "excel-grapher"
-version = "0.6.1"
+version = "0.6.2"
 description = "Build and analyze dependency graphs from Excel workbooks"
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/tests/integration/evaluator/test_value_parity.py
+++ b/tests/integration/evaluator/test_value_parity.py
@@ -1,0 +1,60 @@
+"""VALUE: evaluator and generated export runtime agree on synthetic graphs (integration).
+
+Guards numeric parsing parity through `assert_codegen_matches_evaluator` for small
+dependency graphs.
+"""
+
+from excel_grapher import DependencyGraph, Node, XlError
+from excel_grapher.core.address_keys import parse_address
+from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
+
+
+def _make_node(address: str, formula: str | None, value: object) -> Node:
+    """Helper to create a Node from a sheet-qualified address."""
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=formula,
+        value=value,
+        is_leaf=formula is None,
+    )
+
+
+def _make_graph(*nodes: Node) -> DependencyGraph:
+    """Helper to create a DependencyGraph from nodes."""
+    graph = DependencyGraph()
+    for node in nodes:
+        graph.add_node(node)
+    return graph
+
+
+def test_value_parity_with_lic_dsf_style_key() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", '=VALUE("6522014")', None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!A1"])
+    assert result.generated_results["S!A1"] == 6522014.0
+
+
+def test_value_parity_with_currency() -> None:
+    graph = _make_graph(
+        _make_node("S!B1", '=VALUE("$1,234.56")', None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!B1"])
+    assert result.generated_results["S!B1"] == 1234.56
+
+
+def test_value_parity_with_invalid_text() -> None:
+    graph = _make_graph(
+        _make_node("S!C1", '=VALUE("abc")', None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!C1"])
+    assert result.generated_results["S!C1"] == XlError.VALUE

--- a/tests/integration/evaluator/test_value_parity.py
+++ b/tests/integration/evaluator/test_value_parity.py
@@ -4,8 +4,13 @@ Guards numeric parsing parity through `assert_codegen_matches_evaluator` for sma
 dependency graphs.
 """
 
+from datetime import datetime
+
+import pytest
+
 from excel_grapher import DependencyGraph, Node, XlError
 from excel_grapher.core.address_keys import parse_address
+from excel_grapher.core.coercions import datetime_to_excel_serial
 from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
 
 
@@ -58,3 +63,13 @@ def test_value_parity_with_invalid_text() -> None:
 
     result = assert_codegen_matches_evaluator(graph, ["S!C1"])
     assert result.generated_results["S!C1"] == XlError.VALUE
+
+
+def test_value_parity_with_iso_date_string() -> None:
+    graph = _make_graph(
+        _make_node("S!D1", '=VALUE("2018-03-15")', None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!D1"])
+    expected = datetime_to_excel_serial(datetime(2018, 3, 15))
+    assert result.generated_results["S!D1"] == pytest.approx(expected)

--- a/tests/unit/evaluator/test_functions.py
+++ b/tests/unit/evaluator/test_functions.py
@@ -439,6 +439,28 @@ def test_text() -> None:
         assert result["S!A2"] == "25%"
 
 
+def test_value() -> None:
+    """Test VALUE function."""
+    graph = _make_graph(
+        _make_node("S!A1", '=VALUE("42")', None),
+        _make_node("S!A2", '=VALUE("12.5")', None),
+        _make_node("S!A3", '=VALUE("6522014")', None),
+        _make_node("S!A4", '=VALUE("$1,234.56")', None),
+        _make_node("S!A5", '=VALUE("abc")', None),
+        _make_node("S!A6", "=VALUE(#REF!)", None),
+        _make_node("S!A7", '=VALUE("")', None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        result = ev.evaluate(["S!A1", "S!A2", "S!A3", "S!A4", "S!A5", "S!A6", "S!A7"])
+        assert result["S!A1"] == 42.0
+        assert result["S!A2"] == 12.5
+        assert result["S!A3"] == 6522014.0
+        assert result["S!A4"] == 1234.56
+        assert result["S!A5"] == XlError.VALUE
+        assert result["S!A6"] == XlError.REF
+        assert result["S!A7"] == 0.0
+
+
 # --- Additional lookup function tests ---
 
 

--- a/tests/unit/evaluator/test_functions.py
+++ b/tests/unit/evaluator/test_functions.py
@@ -1,11 +1,13 @@
 """Tests for Excel function implementations."""
 
+from datetime import datetime
 from typing import cast
 
 import pytest
 
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core.address_keys import parse_address
+from excel_grapher.core.coercions import datetime_to_excel_serial
 from excel_grapher.evaluator.evaluator import FormulaEvaluator
 from excel_grapher.evaluator.types import XlError
 
@@ -441,6 +443,7 @@ def test_text() -> None:
 
 def test_value() -> None:
     """Test VALUE function."""
+    expected_date_serial = datetime_to_excel_serial(datetime(2018, 3, 15))
     graph = _make_graph(
         _make_node("S!A1", '=VALUE("42")', None),
         _make_node("S!A2", '=VALUE("12.5")', None),
@@ -449,9 +452,10 @@ def test_value() -> None:
         _make_node("S!A5", '=VALUE("abc")', None),
         _make_node("S!A6", "=VALUE(#REF!)", None),
         _make_node("S!A7", '=VALUE("")', None),
+        _make_node("S!A8", '=VALUE("2018-03-15")', None),
     )
     with FormulaEvaluator(graph) as ev:
-        result = ev.evaluate(["S!A1", "S!A2", "S!A3", "S!A4", "S!A5", "S!A6", "S!A7"])
+        result = ev.evaluate(["S!A1", "S!A2", "S!A3", "S!A4", "S!A5", "S!A6", "S!A7", "S!A8"])
         assert result["S!A1"] == 42.0
         assert result["S!A2"] == 12.5
         assert result["S!A3"] == 6522014.0
@@ -459,6 +463,7 @@ def test_value() -> None:
         assert result["S!A5"] == XlError.VALUE
         assert result["S!A6"] == XlError.REF
         assert result["S!A7"] == 0.0
+        assert result["S!A8"] == pytest.approx(expected_date_serial)
 
 
 # --- Additional lookup function tests ---

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,7 @@ wheels = [
 
 [[package]]
 name = "excel-grapher"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastpyxl" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the Excel `VALUE()` text function to use full locale-aware number parsing (via `xl_numbervalue`) while preserving existing ISO date/datetime coercion from `to_number`. This unblocks LIC-DSF evaluation where `VALUE` converts concatenated prefix+label strings to numeric FAD data keys, and avoids drifting from existing date-string behavior on main.

Closes #258.

## Changes

- **`excel_grapher/runtime/text.py`** — `xl_value(text)` now tries `xl_numbervalue(text)` first, then falls back to `to_number(text)` for string inputs that `xl_numbervalue` cannot parse (preserves ISO date parsing)
- **`tests/unit/evaluator/test_functions.py`** — unit tests (integer, decimal, LIC-DSF key, currency, invalid text, error propagation, empty string, ISO date string)
- **`tests/integration/evaluator/test_value_parity.py`** — codegen parity tests via `assert_codegen_matches_evaluator`, including ISO date-string parity
- **`pyproject.toml` / `uv.lock`** — version bump to **0.6.2** (main is 0.6.1)

Rebased onto `origin/main`. Evaluator registration for `VALUE` was already present on main; this PR fixes runtime semantics and adds coverage.

## Verification

```
uv run pytest tests/unit/evaluator/test_functions.py::test_value tests/integration/evaluator/test_value_parity.py -v
uv run pytest   # 1366 passed
uv run python scripts/check_version_bump.py --base origin/main
uv run pre-commit run --all-files
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b26391cf-0de4-48c6-91e3-664da1cd1e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b26391cf-0de4-48c6-91e3-664da1cd1e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

