### PR TITLE
Fix OptimalCompression formula corruption after identity transit (issue #277)

### DIFF
--- a/excel_grapher/grapher/compression.py
+++ b/excel_grapher/grapher/compression.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from excel_grapher.core.formula_ast import (
@@ -119,6 +119,101 @@ def _find_literal_spans(s: str, needle: str) -> list[tuple[int, int]]:
         out.append((j, j + len(needle)))
         i = j + len(needle)
     return out
+
+
+class CompressionProvenanceRequiredError(RuntimeError):
+    """Compression cannot run safely without captured dependency provenance."""
+
+
+def refresh_direct_sites(
+    provenance: EdgeProvenance,
+    *,
+    old_formula: str | None,
+    new_formula: str | None,
+    old_normalized: str | None,
+    new_normalized: str | None,
+    precedent_key: NodeKey,
+) -> EdgeProvenance:
+    """Re-locate direct-ref spans after a dependent formula rewrite."""
+    sites_n: list[tuple[int, int]] = []
+    if new_normalized:
+        sites_n = _find_literal_spans(new_normalized, precedent_key)
+
+    sites_f: list[tuple[int, int]] = []
+    if new_formula:
+        if provenance.direct_sites_formula and old_formula:
+            for a, b in provenance.direct_sites_formula:
+                if 0 <= a <= b <= len(old_formula):
+                    needle = old_formula[a:b]
+                    if needle:
+                        sites_f.extend(_find_literal_spans(new_formula, needle))
+        else:
+            sites_f = _find_literal_spans(new_formula, precedent_key)
+
+    return replace(
+        provenance,
+        direct_sites_formula=tuple(sites_f),
+        direct_sites_normalized=tuple(sites_n),
+    )
+
+
+def _structural_inline_candidate(
+    graph: DependencyGraph,
+    transit_key: NodeKey,
+) -> NodeKey | None:
+    """Return the sole dependent when `transit_key` is structurally inlinable."""
+    if is_identity_transit(graph, transit_key) is not None:
+        return None
+    t_node = graph.get_node(transit_key)
+    if t_node is None or t_node.is_leaf or t_node.formula is None:
+        return None
+    dependents = graph.get_dependents(transit_key)
+    if len(dependents) != 1:
+        return None
+    dependent = next(iter(dependents))
+    if graph._is_dependency_reachable(transit_key, dependent):
+        return None
+    if graph.get_edge_guard(dependent, transit_key) is not None:
+        return None
+    if not node_body_substitutable(graph, transit_key):
+        return None
+    if not dependent_context_substitutable(graph, dependent, replacing=transit_key):
+        return None
+    prov = graph.get_edge_attrs(dependent, transit_key).provenance
+    if prov is not None:
+        if len(prov.direct_sites_normalized) != 1:
+            return None
+        dep_node = graph.get_node(dependent)
+        if dep_node is None:
+            return None
+        if dep_node.formula is not None and len(prov.direct_sites_formula) != 1:
+            return None
+    return dependent
+
+
+def require_compression_provenance(graph: DependencyGraph) -> None:
+    """Raise when compression candidates exist but edge provenance is missing."""
+    missing: list[tuple[str, str]] = []
+    for transit_key in graph:
+        replacement = is_identity_transit(graph, transit_key)
+        if replacement is not None:
+            for dependent in graph.get_dependents(transit_key):
+                if graph.get_edge_attrs(dependent, transit_key).provenance is None:
+                    missing.append((dependent, transit_key))
+            continue
+        dependent = _structural_inline_candidate(graph, transit_key)
+        if (
+            dependent is not None
+            and graph.get_edge_attrs(dependent, transit_key).provenance is None
+        ):
+            missing.append((dependent, transit_key))
+    if missing:
+        dependent, transit = missing[0]
+        raise CompressionProvenanceRequiredError(
+            "Dependency provenance is required for compression but is missing on edge "
+            f"{dependent} -> {transit}. Build the graph with "
+            "capture_dependency_provenance=True."
+        )
 
 
 def compression_safe_provenance(prov: EdgeProvenance | None) -> bool:

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 from excel_grapher.core.address_keys import normalize_key, sort_node_keys
 
-from .dependency_provenance import EdgeProvenance, merge_edge_provenance
+from .dependency_provenance import DependencyCause, EdgeProvenance, merge_edge_provenance
 from .guard import And, CellRef, Compare, GuardConstraints, GuardExpr, Not, Or, or_guard
 from .node import Node, NodeKey, NodeView, node_to_view
 
@@ -555,9 +555,11 @@ class DependencyGraph:
             clear_identity_singleton_ref_cache,
             compression_safe_provenance,
             is_identity_transit,
+            require_compression_provenance,
             snapshot_transit_node,
         )
 
+        require_compression_provenance(self)
         clear_identity_singleton_ref_cache()
         try:
             heap: list[NodeKey] = list(self._nodes.keys())
@@ -624,6 +626,7 @@ class DependencyGraph:
             dependent_context_substitutable,
             is_identity_transit,
             node_body_substitutable,
+            require_compression_provenance,
             snapshot_transit_node,
         )
 
@@ -633,6 +636,7 @@ class DependencyGraph:
             inline_preserve = frozenset(normalize_key(key) for key in preserve)
         forwarding_protected: set[NodeKey] = set()
 
+        require_compression_provenance(self)
         clear_identity_singleton_ref_cache()
         try:
             heap: list[NodeKey] = list(self._nodes.keys())
@@ -781,6 +785,7 @@ class DependencyGraph:
         from .compression import (
             FormulaRewrite,
             direct_provenance_for_key_in_strings,
+            refresh_direct_sites,
             replace_substrings_at_spans,
         )
 
@@ -830,6 +835,25 @@ class DependencyGraph:
             new_prov = direct_provenance_for_key_in_strings(new_formula, new_norm, r_key)
             self.add_edge(d_key, r_key, guard=guard, provenance=new_prov)
 
+            for dep in list(self._edges.get(d_key, set())):
+                if dep == r_key:
+                    continue
+                dep_extra = self._edge_extra.get((d_key, dep), {})
+                old_dep_prov = dep_extra.get("provenance")
+                if not isinstance(old_dep_prov, EdgeProvenance):
+                    continue
+                if DependencyCause.direct_ref not in old_dep_prov.causes:
+                    continue
+                dep_extra["provenance"] = refresh_direct_sites(
+                    old_dep_prov,
+                    old_formula=before_formula,
+                    new_formula=new_formula,
+                    old_normalized=before_normalized,
+                    new_normalized=new_norm,
+                    precedent_key=dep,
+                )
+                self._edge_extra[(d_key, dep)] = dep_extra
+
         for dep in list(self._edges.get(t_key, set())):
             self._remove_edge(t_key, dep)
         self._nodes.pop(t_key, None)
@@ -862,6 +886,7 @@ class DependencyGraph:
         from .compression import (
             FormulaRewrite,
             direct_provenance_for_key_in_strings,
+            refresh_direct_sites,
             substitute_body_at_spans,
         )
 
@@ -909,6 +934,11 @@ class DependencyGraph:
         t_deps = set(self._edges.get(t_key, set()))
         d_dep_guards = {dep: self._guards.get((d_key, dep)) for dep in d_other_deps}
         t_dep_guards = {dep: self._guards.get((t_key, dep)) for dep in t_deps}
+        old_dependent_provenance: dict[NodeKey, EdgeProvenance] = {}
+        for dep in d_other_deps:
+            prov = self.get_edge_attrs(d_key, dep).provenance
+            if isinstance(prov, EdgeProvenance):
+                old_dependent_provenance[dep] = prov
 
         d_node.formula = new_formula
         d_node.normalized_formula = new_norm
@@ -916,11 +946,26 @@ class DependencyGraph:
         for dep in list(self._edges.get(d_key, set())):
             self._remove_edge(d_key, dep)
 
+        inherited_deps = t_deps - d_other_deps
         for dep in d_other_deps | t_deps:
             guard = d_dep_guards.get(dep)
             if guard is None:
                 guard = t_dep_guards.get(dep)
-            new_prov = direct_provenance_for_key_in_strings(new_formula, new_norm, dep)
+            if dep in inherited_deps:
+                new_prov = direct_provenance_for_key_in_strings(new_formula, new_norm, dep)
+            else:
+                old_prov = old_dependent_provenance.get(dep)
+                if old_prov is not None:
+                    new_prov = refresh_direct_sites(
+                        old_prov,
+                        old_formula=before_formula,
+                        new_formula=new_formula,
+                        old_normalized=before_normalized,
+                        new_normalized=new_norm,
+                        precedent_key=dep,
+                    )
+                else:
+                    new_prov = direct_provenance_for_key_in_strings(new_formula, new_norm, dep)
             self.add_edge(d_key, dep, guard=guard, provenance=new_prov)
 
         for dep in list(self._edges.get(t_key, set())):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "excel-grapher"
-version = "0.6.2"
+version = "0.6.3"
 description = "Build and analyze dependency graphs from Excel workbooks"
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/tests/unit/grapher/test_graph_compression.py
+++ b/tests/unit/grapher/test_graph_compression.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import xlsxwriter
 
 from excel_grapher import create_dependency_graph
 from excel_grapher.core.cell_types import CellKind, EnumDomain
+from excel_grapher.grapher.compression import CompressionProvenanceRequiredError
 from excel_grapher.grapher.dependency_provenance import DependencyCause, EdgeProvenance
 from excel_grapher.grapher.dynamic_refs import DynamicRefConfig, DynamicRefLimits
 from excel_grapher.grapher.node import Node
@@ -157,6 +159,26 @@ def test_compress_chain_manual_graph() -> None:
     assert graph.get_dependencies("Sheet1!A1") == {"Sheet1!D1"}
 
 
+def test_identity_transit_raises_when_provenance_missing(tmp_path: Path) -> None:
+    path = tmp_path / "no_prov.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    ws_inputs = wb.add_worksheet("Inputs")
+    ws_engine = wb.add_worksheet("Engine")
+    ws_inputs.write_number(5, 1, 100)
+    ws_engine.write_formula(19, 1, "=Inputs!B6", None, 100)
+    ws_engine.write_formula(19, 2, "=B20*2", None, 200)
+    wb.close()
+
+    graph = create_dependency_graph(
+        path,
+        ["Engine!C20"],
+        load_values=False,
+        capture_dependency_provenance=False,
+    )
+    with pytest.raises(CompressionProvenanceRequiredError, match="provenance"):
+        graph.compress_identity_transits()
+
+
 def test_static_range_blocks_compression(tmp_path: Path) -> None:
     path = tmp_path / "rng.xlsx"
     wb = xlsxwriter.Workbook(path)
@@ -256,7 +278,7 @@ def test_guarded_transit_not_compressed() -> None:
     assert graph.compress_identity_transits() == []
 
 
-def test_provenance_absent_skips_compression() -> None:
+def test_provenance_absent_raises_for_identity_transit() -> None:
     from excel_grapher.grapher.graph import DependencyGraph
 
     graph = DependencyGraph()
@@ -268,7 +290,8 @@ def test_provenance_absent_skips_compression() -> None:
     graph.add_edge("Sheet1!B1", "Sheet1!C1")
     graph.add_edge("Sheet1!A1", "Sheet1!B1")
 
-    assert graph.compress_identity_transits() == []
+    with pytest.raises(CompressionProvenanceRequiredError, match="provenance"):
+        graph.compress_identity_transits()
 
 
 def test_indirect_enum_blocks_when_direct_same_cell(tmp_path: Path) -> None:

--- a/tests/unit/grapher/test_graph_optimal_compression.py
+++ b/tests/unit/grapher/test_graph_optimal_compression.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Annotated, Literal
 
+import fastpyxl
 import pytest
 import xlsxwriter
 
 from excel_grapher import create_dependency_graph
-from excel_grapher.core.cell_types import CellKind, EnumDomain
-from excel_grapher.grapher.compression import OptimalCompressionRecord
+from excel_grapher.core.cell_types import Between, CellKind, EnumDomain, RealBetween
+from excel_grapher.evaluator.parser import parse
+from excel_grapher.grapher.compression import (
+    CompressionProvenanceRequiredError,
+    OptimalCompressionRecord,
+)
 from excel_grapher.grapher.dependency_provenance import DependencyCause, EdgeProvenance
 from excel_grapher.grapher.dynamic_refs import DynamicRefConfig, DynamicRefLimits
 from excel_grapher.grapher.graph import DependencyGraph
@@ -65,6 +71,190 @@ def _direct_edge(
             direct_sites_normalized=((i_n, i_n + len(ref)),),
         ),
     )
+
+
+def _local_ref_edge(
+    graph: DependencyGraph,
+    dependent: str,
+    precedent: str,
+    *,
+    formula_ref: str,
+    normalized_ref: str | None = None,
+) -> None:
+    dr = DependencyCause.direct_ref
+    dep_node = graph.get_node(dependent)
+    assert dep_node is not None
+    f = dep_node.formula
+    n = dep_node.normalized_formula
+    assert f is not None and n is not None
+    ref_n = normalized_ref if normalized_ref is not None else precedent
+    i_f = f.index(formula_ref)
+    i_n = n.index(ref_n)
+    graph.add_edge(
+        dependent,
+        precedent,
+        provenance=EdgeProvenance(
+            causes=frozenset({dr}),
+            direct_sites_formula=((i_f, i_f + len(formula_ref)),),
+            direct_sites_normalized=((i_n, i_n + len(ref_n)),),
+        ),
+    )
+
+
+def _build_issue_277_workbook(path: Path) -> None:
+    wb = fastpyxl.Workbook()
+    ws_inputs = wb.active
+    ws_inputs.title = "Inputs"
+    ws_engine = wb.create_sheet("Engine")
+
+    cells = {
+        ("Inputs", "B6"): 100,
+        ("Inputs", "B21"): 1,
+        ("Inputs", "B22"): 1,
+        ("Inputs", "C16"): 2.0,
+        ("Inputs", "C17"): 3.0,
+        ("Inputs", "C18"): -1.0,
+        ("Engine", "B9"): 0.5,
+        ("Engine", "C5"): 1,
+        ("Engine", "B20"): "=Inputs!B6",
+        ("Engine", "C10"): "=IF(C5>=Inputs!$B$21,1,0)",
+        ("Engine", "C14"): "=Inputs!C16+CHOOSE(Inputs!$B$22,$B$9,0,0)*C10",
+        ("Engine", "C15"): "=Inputs!C17+CHOOSE(Inputs!$B$22,0,$B$9,0)*C10",
+        ("Engine", "C16"): "=Inputs!C18+CHOOSE(Inputs!$B$22,0,0,$B$9)*C10",
+        ("Engine", "C20"): "=B20*(1+C15/100)/(1+C14/100)-C16",
+    }
+    for (sheet, addr), value in cells.items():
+        worksheet = ws_inputs if sheet == "Inputs" else ws_engine
+        worksheet[addr] = value
+    wb.save(path)
+
+
+def test_compress_identity_transit_refreshes_sibling_edge_spans() -> None:
+    graph = DependencyGraph()
+    b20 = _make_node("Engine!B20", "=Inputs!B6", "=Inputs!B6")
+    c14 = _make_node(
+        "Engine!C14",
+        "=Inputs!C16+CHOOSE(Inputs!$B$22,$B$9,0,0)*C10",
+        "=Inputs!C16+CHOOSE(Inputs!$B$22,Engine!$B$9,0,0)*Engine!C10",
+    )
+    c15 = _make_node("Engine!C15", "=Inputs!C17", "=Inputs!C17")
+    c16 = _make_node("Engine!C16", "=Inputs!C18", "=Inputs!C18")
+    c20 = _make_node(
+        "Engine!C20",
+        "=B20*(1+C15/100)/(1+C14/100)-C16",
+        "=Engine!B20*(1+Engine!C15/100)/(1+Engine!C14/100)-Engine!C16",
+    )
+    for n in (b20, c14, c15, c16, c20):
+        graph.add_node(n)
+    graph.add_edge(
+        "Engine!B20",
+        "Inputs!B6",
+        provenance=EdgeProvenance(causes=frozenset({DependencyCause.direct_ref})),
+    )
+    _local_ref_edge(graph, "Engine!C20", "Engine!B20", formula_ref="B20")
+    _local_ref_edge(graph, "Engine!C20", "Engine!C14", formula_ref="C14")
+    _local_ref_edge(graph, "Engine!C20", "Engine!C15", formula_ref="C15")
+    _local_ref_edge(graph, "Engine!C20", "Engine!C16", formula_ref="C16")
+
+    graph._compress_one_transit("Engine!B20", "Inputs!B6")
+
+    prov = graph.get_edge_attrs("Engine!C20", "Engine!C14").provenance
+    assert prov is not None
+    node = graph.get_node("Engine!C20")
+    assert node is not None
+    formula = node.formula
+    normalized = node.normalized_formula
+    assert formula is not None and normalized is not None
+    assert formula[prov.direct_sites_formula[0][0] : prov.direct_sites_formula[0][1]] == "C14"
+    assert (
+        normalized[prov.direct_sites_normalized[0][0] : prov.direct_sites_normalized[0][1]]
+        == "Engine!C14"
+    )
+
+
+def test_optimal_inline_local_ref_after_identity_transit(tmp_path: Path) -> None:
+    path = tmp_path / "issue_277.xlsx"
+    _build_issue_277_workbook(path)
+
+    constraints = {
+        "Engine!C5": Literal[1],
+        "Inputs!B21": Annotated[int, Between(1, 5)],
+        "Inputs!B22": Literal[1, 2, 3],
+        "Inputs!C16": Annotated[float, RealBetween(-10.0, 15.0)],
+        "Inputs!C17": Annotated[float, RealBetween(0.0, 20.0)],
+        "Inputs!C18": Annotated[float, RealBetween(-15.0, 15.0)],
+    }
+    config = DynamicRefConfig.from_constraints(constraints, {})
+    graph = create_dependency_graph(
+        path,
+        ["Engine!C20"],
+        load_values=True,
+        dynamic_refs=config,
+        capture_dependency_provenance=True,
+    )
+
+    projected = graph.copy()
+    removed = projected.compress_optimal()
+    assert "Engine!B20" in removed
+    assert "Engine!C14" in removed
+
+    node = projected.get_node("Engine!C20")
+    assert node is not None
+    formula = node.normalized_formula
+    assert formula is not None
+    parse(formula.strip())
+    assert "/100" in formula
+    assert "(Inputs!C16+CHOOSE" in formula
+
+
+def test_optimal_raises_when_provenance_missing(tmp_path: Path) -> None:
+    path = tmp_path / "no_prov.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    ws_inputs = wb.add_worksheet("Inputs")
+    ws_engine = wb.add_worksheet("Engine")
+    ws_inputs.write_number(5, 1, 100)
+    ws_engine.write_formula(19, 1, "=Inputs!B6", None, 100)
+    ws_engine.write_formula(19, 2, "=B20*2", None, 200)
+    wb.close()
+
+    graph = create_dependency_graph(
+        path,
+        ["Engine!C20"],
+        load_values=False,
+        capture_dependency_provenance=False,
+    )
+    with pytest.raises(CompressionProvenanceRequiredError, match="provenance"):
+        graph.compress_optimal()
+
+
+def test_optimal_no_raise_when_nothing_compressible(tmp_path: Path) -> None:
+    path = tmp_path / "leaf.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number(0, 0, 1)
+    wb.close()
+
+    graph = create_dependency_graph(
+        path,
+        ["Sheet1!A1"],
+        load_values=False,
+        capture_dependency_provenance=False,
+    )
+    assert graph.compress_optimal() == []
+
+
+def test_optimal_manual_graph_with_explicit_provenance_still_works() -> None:
+    graph = DependencyGraph()
+    d = _make_node("Sheet1!D1", None, None, is_leaf=True)
+    b = _make_node("Sheet1!B1", "=Sheet1!D1*2", "=Sheet1!D1*2")
+    a = _make_node("Sheet1!A1", "=Sheet1!B1+1", "=Sheet1!B1+1")
+    for n in (d, b, a):
+        graph.add_node(n)
+    _direct_edge(graph, "Sheet1!B1", "Sheet1!D1")
+    _direct_edge(graph, "Sheet1!A1", "Sheet1!B1")
+
+    removed = graph.compress_optimal()
+    assert "Sheet1!B1" in removed
 
 
 def test_optimal_inline_single_call_site() -> None:

--- a/tests/unit/grapher/test_graph_projection.py
+++ b/tests/unit/grapher/test_graph_projection.py
@@ -20,6 +20,7 @@ from excel_grapher.exporter.projection import (
     unregister_projection_manifest,
 )
 from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.grapher.compression import CompressionProvenanceRequiredError
 from excel_grapher.grapher.dependency_provenance import DependencyCause, EdgeProvenance
 from excel_grapher.grapher.node import Node
 from excel_grapher.series_bindings import WorkbookSeriesBindings, resolve_series_bindings
@@ -473,6 +474,9 @@ def test_projection_respects_compression_safety(test_name: str) -> None:
     else:
         graph.add_edge("Sheet1!B1", "Sheet1!C1")
         graph.add_edge("Sheet1!A1", "Sheet1!B1")
+        with pytest.raises(CompressionProvenanceRequiredError, match="provenance"):
+            IdentityTransitCompression().project(graph)
+        return
 
     projection = IdentityTransitCompression().project(graph)
     assert "Sheet1!B1" in projection

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,7 @@ wheels = [
 
 [[package]]
 name = "excel-grapher"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastpyxl" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#277](https://github.com/Teal-Insights/excel-grapher/issues/277): `compress_optimal` / `OptimalCompression` could produce unparseable formulas when inlining a local-ref call site after an identity transit rewrite.

Also addresses the related fail-fast request: compression now raises when structural candidates exist but dependency provenance was never captured, instead of silently removing zero nodes.

## Root cause

`_compress_one_transit` rewrote dependent formulas but only rebuilt provenance for the collapsed edge. Sibling edges kept stale byte offsets, so a subsequent inline sliced at the wrong positions (e.g. `ngine!C14/` instead of `Engine!C14`).

## Fix

- Add `refresh_direct_sites()` to re-locate direct-ref spans after formula rewrites, preserving local-ref needles from the pre-rewrite formula text.
- Call it from `_compress_one_transit` for surviving sibling edges.
- In `_inline_one_node`, refresh only pre-existing dependent edges; dependencies inherited from the inlined node get fresh spans via `direct_provenance_for_key_in_strings`.
- Add `CompressionProvenanceRequiredError` and `require_compression_provenance()` preflight for `compress_optimal` and `compress_identity_transits`.

## Tests

- Regression test for the issue #277 MCVE workbook (parseable compressed formula, `/100` preserved).
- Unit test that identity transit refresh keeps sibling edge spans aligned.
- Fail-fast tests for missing provenance; existing manual-graph and guard tests updated.

Fixes #277
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04f4a831-527e-4657-a7b5-18727a998b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04f4a831-527e-4657-a7b5-18727a998b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

