### PR TITLE
Fix SUMPRODUCT criteria array semantics (#265, #267)

### DIFF
--- a/excel_grapher/core/excel_function_meta.py
+++ b/excel_grapher/core/excel_function_meta.py
@@ -35,6 +35,21 @@ FUNCTION_META: dict[str, ExcelFunctionMeta] = {
     "CONCAT": ExcelFunctionMeta("CONCAT", ()),
 }
 
+# Functions whose range arguments must stay as object-dtype ndarrays (evaluator + codegen).
+NUMPY_ARRAY_ARG_INDICES: dict[str, frozenset[int]] = {
+    "LOOKUP": frozenset({1, 2}),
+    "VLOOKUP": frozenset({1}),
+    "HLOOKUP": frozenset({1}),
+    "INDEX": frozenset({0}),
+    "MATCH": frozenset({1}),
+    "SUMPRODUCT": frozenset(range(10)),
+}
+
+
+def numpy_array_arg_indices(function_name: str) -> frozenset[int]:
+    """Return argument indices that keep numpy arrays for ``function_name``."""
+    return NUMPY_ARRAY_ARG_INDICES.get(function_name.upper(), frozenset())
+
 
 def is_ref_only_arg(function_name: str, arg_index: int) -> bool:
     """True if this argument position is ref_only (no domain required for cell refs)."""

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -89,6 +89,7 @@ def _xl_compare(op: str, left: CellValue, right: CellValue) -> CellValue:
         result = np.empty(arr_left.shape, dtype=object)
         for indices in np.ndindex(arr_left.shape):
             cell = _compare_scalars(op, arr_left[indices], arr_right[indices])
+            # Fail-fast: first cell error replaces the whole array (matches xl_sumproduct).
             if isinstance(cell, XlError):
                 return cell
             result[indices] = cell
@@ -120,6 +121,7 @@ def _xl_arithmetic(
                 return ln
             if isinstance(rn, XlError):
                 return rn
+            # Fail-fast per cell (aligned with xl_sumproduct error propagation).
             if op == "+":
                 result[indices] = ln + rn
             elif op == "-":
@@ -130,6 +132,14 @@ def _xl_arithmetic(
                 if rn == 0:
                     return XlError.DIV
                 result[indices] = ln / rn
+            elif op == "^":
+                try:
+                    value = ln**rn
+                except (ValueError, OverflowError):
+                    return XlError.NUM
+                if isinstance(value, complex):
+                    return XlError.NUM
+                result[indices] = value
             else:
                 raise ValueError(f"Unknown arithmetic operator: {op}")
         return result
@@ -150,15 +160,42 @@ def _xl_arithmetic(
         if rn == 0:
             return XlError.DIV
         return ln / rn
+    if op == "^":
+        try:
+            value = ln**rn
+        except (ValueError, OverflowError):
+            return XlError.NUM
+        if isinstance(value, complex):
+            return XlError.NUM
+        return value
     raise ValueError(f"Unknown arithmetic operator: {op}")
 
 
-def xl_concat(left: CellValue, right: CellValue) -> str | XlError:
+def _concat_scalars(left: CellValue, right: CellValue) -> str:
+    return to_string(left) + to_string(right)
+
+
+def _xl_concat(left: CellValue, right: CellValue) -> CellValue:
     if isinstance(left, XlError):
         return left
     if isinstance(right, XlError):
         return right
-    return to_string(left) + to_string(right)
+
+    if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
+        pair = _broadcast_pair(left, right)
+        if isinstance(pair, XlError):
+            return pair
+        arr_left, arr_right = pair
+        result = np.empty(arr_left.shape, dtype=object)
+        for indices in np.ndindex(arr_left.shape):
+            result[indices] = _concat_scalars(arr_left[indices], arr_right[indices])
+        return result
+
+    return _concat_scalars(left, right)
+
+
+def xl_concat(left: CellValue, right: CellValue) -> CellValue:
+    return _xl_concat(left, right)
 
 
 def xl_eq(left: CellValue, right: CellValue) -> CellValue:
@@ -207,21 +244,8 @@ def xl_mul(left: CellValue, right: CellValue) -> CellValue:
     return _xl_arithmetic("*", left, right)
 
 
-def xl_pow(left: CellValue, right: CellValue) -> float | XlError:
-    if isinstance(left, XlError):
-        return left
-    if isinstance(right, XlError):
-        return right
-    ln = to_number(left)
-    rn = to_number(right)
-    if isinstance(ln, XlError):
-        return ln
-    if isinstance(rn, XlError):
-        return rn
-    try:
-        return ln**rn
-    except (ValueError, OverflowError):
-        return XlError.NUM
+def xl_pow(left: CellValue, right: CellValue) -> CellValue:
+    return _xl_arithmetic("^", left, right)
 
 
 def xl_neg(value: CellValue) -> float | XlError:

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -1,12 +1,34 @@
-"""Excel-style scalar operators (representation-agnostic)."""
+"""Excel-style scalar and array operators (representation-agnostic)."""
 
 from __future__ import annotations
+
+import numpy as np
 
 from .coercions import excel_casefold, to_number, to_string
 from .types import CellValue, XlError
 
 
-def _xl_compare(op: str, left: CellValue, right: CellValue) -> bool | XlError:
+def _broadcast_pair(
+    left: CellValue,
+    right: CellValue,
+) -> tuple[np.ndarray, np.ndarray] | XlError:
+    """Broadcast scalar/array operands to matching object ndarrays."""
+    if isinstance(left, XlError):
+        return left
+    if isinstance(right, XlError):
+        return right
+    if isinstance(left, np.ndarray) and isinstance(right, np.ndarray):
+        if left.shape != right.shape:
+            return XlError.VALUE
+        return left, right
+    if isinstance(left, np.ndarray):
+        return left, np.full(left.shape, right, dtype=object)
+    if isinstance(right, np.ndarray):
+        return np.full(right.shape, left, dtype=object), right
+    raise TypeError("expected at least one ndarray operand")
+
+
+def _compare_scalars(op: str, left: CellValue, right: CellValue) -> bool | XlError:
     if isinstance(left, XlError):
         return left
     if isinstance(right, XlError):
@@ -53,6 +75,84 @@ def _xl_compare(op: str, left: CellValue, right: CellValue) -> bool | XlError:
     return _cmp_float(float(ln), float(rn))
 
 
+def _xl_compare(op: str, left: CellValue, right: CellValue) -> CellValue:
+    if isinstance(left, XlError):
+        return left
+    if isinstance(right, XlError):
+        return right
+
+    if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
+        pair = _broadcast_pair(left, right)
+        if isinstance(pair, XlError):
+            return pair
+        arr_left, arr_right = pair
+        result = np.empty(arr_left.shape, dtype=object)
+        for indices in np.ndindex(arr_left.shape):
+            cell = _compare_scalars(op, arr_left[indices], arr_right[indices])
+            if isinstance(cell, XlError):
+                return cell
+            result[indices] = cell
+        return result
+
+    return _compare_scalars(op, left, right)
+
+
+def _xl_arithmetic(
+    op: str,
+    left: CellValue,
+    right: CellValue,
+) -> CellValue:
+    if isinstance(left, XlError):
+        return left
+    if isinstance(right, XlError):
+        return right
+
+    if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
+        pair = _broadcast_pair(left, right)
+        if isinstance(pair, XlError):
+            return pair
+        arr_left, arr_right = pair
+        result = np.empty(arr_left.shape, dtype=object)
+        for indices in np.ndindex(arr_left.shape):
+            ln = to_number(arr_left[indices])
+            rn = to_number(arr_right[indices])
+            if isinstance(ln, XlError):
+                return ln
+            if isinstance(rn, XlError):
+                return rn
+            if op == "+":
+                result[indices] = ln + rn
+            elif op == "-":
+                result[indices] = ln - rn
+            elif op == "*":
+                result[indices] = ln * rn
+            elif op == "/":
+                if rn == 0:
+                    return XlError.DIV
+                result[indices] = ln / rn
+            else:
+                raise ValueError(f"Unknown arithmetic operator: {op}")
+        return result
+
+    ln = to_number(left)
+    rn = to_number(right)
+    if isinstance(ln, XlError):
+        return ln
+    if isinstance(rn, XlError):
+        return rn
+    if op == "+":
+        return ln + rn
+    if op == "-":
+        return ln - rn
+    if op == "*":
+        return ln * rn
+    if op == "/":
+        if rn == 0:
+            return XlError.DIV
+        return ln / rn
+    raise ValueError(f"Unknown arithmetic operator: {op}")
+
+
 def xl_concat(left: CellValue, right: CellValue) -> str | XlError:
     if isinstance(left, XlError):
         return left
@@ -61,27 +161,27 @@ def xl_concat(left: CellValue, right: CellValue) -> str | XlError:
     return to_string(left) + to_string(right)
 
 
-def xl_eq(left: CellValue, right: CellValue) -> bool | XlError:
+def xl_eq(left: CellValue, right: CellValue) -> CellValue:
     return _xl_compare("=", left, right)
 
 
-def xl_ne(left: CellValue, right: CellValue) -> bool | XlError:
+def xl_ne(left: CellValue, right: CellValue) -> CellValue:
     return _xl_compare("<>", left, right)
 
 
-def xl_lt(left: CellValue, right: CellValue) -> bool | XlError:
+def xl_lt(left: CellValue, right: CellValue) -> CellValue:
     return _xl_compare("<", left, right)
 
 
-def xl_gt(left: CellValue, right: CellValue) -> bool | XlError:
+def xl_gt(left: CellValue, right: CellValue) -> CellValue:
     return _xl_compare(">", left, right)
 
 
-def xl_le(left: CellValue, right: CellValue) -> bool | XlError:
+def xl_le(left: CellValue, right: CellValue) -> CellValue:
     return _xl_compare("<=", left, right)
 
 
-def xl_ge(left: CellValue, right: CellValue) -> bool | XlError:
+def xl_ge(left: CellValue, right: CellValue) -> CellValue:
     return _xl_compare(">=", left, right)
 
 
@@ -91,62 +191,20 @@ def xl_iferror(value: CellValue, value_if_error: CellValue) -> CellValue:
     return value
 
 
-def xl_div(left: CellValue, right: CellValue) -> float | XlError:
-    if isinstance(left, XlError):
-        return left
-    if isinstance(right, XlError):
-        return right
-    ln = to_number(left)
-    rn = to_number(right)
-    if isinstance(ln, XlError):
-        return ln
-    if isinstance(rn, XlError):
-        return rn
-    if rn == 0:
-        return XlError.DIV
-    return ln / rn
+def xl_div(left: CellValue, right: CellValue) -> CellValue:
+    return _xl_arithmetic("/", left, right)
 
 
-def xl_add(left: CellValue, right: CellValue) -> float | XlError:
-    if isinstance(left, XlError):
-        return left
-    if isinstance(right, XlError):
-        return right
-    ln = to_number(left)
-    rn = to_number(right)
-    if isinstance(ln, XlError):
-        return ln
-    if isinstance(rn, XlError):
-        return rn
-    return ln + rn
+def xl_add(left: CellValue, right: CellValue) -> CellValue:
+    return _xl_arithmetic("+", left, right)
 
 
-def xl_sub(left: CellValue, right: CellValue) -> float | XlError:
-    if isinstance(left, XlError):
-        return left
-    if isinstance(right, XlError):
-        return right
-    ln = to_number(left)
-    rn = to_number(right)
-    if isinstance(ln, XlError):
-        return ln
-    if isinstance(rn, XlError):
-        return rn
-    return ln - rn
+def xl_sub(left: CellValue, right: CellValue) -> CellValue:
+    return _xl_arithmetic("-", left, right)
 
 
-def xl_mul(left: CellValue, right: CellValue) -> float | XlError:
-    if isinstance(left, XlError):
-        return left
-    if isinstance(right, XlError):
-        return right
-    ln = to_number(left)
-    rn = to_number(right)
-    if isinstance(ln, XlError):
-        return ln
-    if isinstance(rn, XlError):
-        return rn
-    return ln * rn
+def xl_mul(left: CellValue, right: CellValue) -> CellValue:
+    return _xl_arithmetic("*", left, right)
 
 
 def xl_pow(left: CellValue, right: CellValue) -> float | XlError:

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -13,6 +13,7 @@ from excel_grapher.core.address_keys import (
     parse_address,
 )
 from excel_grapher.core.addressing import index_excel_range
+from excel_grapher.core.excel_function_meta import numpy_array_arg_indices
 from excel_grapher.core.range_shorthand import (
     SheetBounds,
     resolve_whole_column,
@@ -75,16 +76,6 @@ _SKIP_ERROR_PRECHECK = {
     "INDEX",
     "MATCH",
     "XLOOKUP",
-}
-
-# Argument indices that must stay as numpy arrays (aligned with export codegen).
-_ARRAY_ARG_INDICES: dict[str, set[int]] = {
-    "LOOKUP": {1, 2},
-    "VLOOKUP": {1},
-    "HLOOKUP": {1},
-    "INDEX": {0},
-    "MATCH": {1},
-    "SUMPRODUCT": set(range(10)),
 }
 
 if TYPE_CHECKING:
@@ -369,7 +360,7 @@ class FormulaEvaluator:
         """
         if not isinstance(value, ExcelRange):
             return value
-        if arg_index in _ARRAY_ARG_INDICES.get(func_name, set()):
+        if arg_index in numpy_array_arg_indices(func_name):
             return self._resolve_range(value)
         if value.start_row == value.end_row and value.start_col == value.end_col:
             return self._auto_resolve_single_cell(value)

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -32,19 +32,23 @@ from .helpers import (
     get_error,
     to_bool,
     to_number,
+    xl_add,
     xl_column,
     xl_columns,
     xl_concat,
+    xl_div,
     xl_eq,
     xl_ge,
     xl_gt,
     xl_le,
     xl_lt,
+    xl_mul,
     xl_ne,
     xl_offset_ref,
     xl_percent,
     xl_pow,
     xl_row,
+    xl_sub,
 )
 from .parser import (
     AstNode,
@@ -393,9 +397,15 @@ class FormulaEvaluator:
             return arr[0, 0]
         return value
 
+    def _resolve_binary_operand(self, value: CellValue) -> CellValue:
+        """Resolve range references to arrays for element-wise binary operators."""
+        if isinstance(value, ExcelRange):
+            return self._resolve_range(value)
+        return value
+
     def _eval_binary_op(self, node: BinaryOpNode) -> CellValue:
-        left = self._evaluate_ast(node.left)
-        right = self._evaluate_ast(node.right)
+        left = self._resolve_binary_operand(self._evaluate_ast(node.left))
+        right = self._resolve_binary_operand(self._evaluate_ast(node.right))
 
         # Propagate errors
         if isinstance(left, XlError):
@@ -421,24 +431,15 @@ class FormulaEvaluator:
             }
             return cmp_fns[op](left, right)
 
-        # Arithmetic operators - coerce to numbers
-        ln = to_number(left)
-        rn = to_number(right)
-        if isinstance(ln, XlError):
-            return ln
-        if isinstance(rn, XlError):
-            return rn
-
+        # Arithmetic operators - element-wise when operands include arrays
         if op == "+":
-            return ln + rn
+            return xl_add(left, right)
         if op == "-":
-            return ln - rn
+            return xl_sub(left, right)
         if op == "*":
-            return ln * rn
+            return xl_mul(left, right)
         if op == "/":
-            if rn == 0:
-                return XlError.DIV
-            return ln / rn
+            return xl_div(left, right)
         if op == "^":
             return xl_pow(left, right)
 

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -16,6 +16,7 @@ from excel_grapher.core.address_keys import (
     quote_sheet_if_needed,
     sort_node_keys,
 )
+from excel_grapher.core.excel_function_meta import numpy_array_arg_indices
 from excel_grapher.evaluator.errors import MissingNormalizedFormulaError
 from excel_grapher.evaluator.name_utils import (
     address_to_python_name,
@@ -1027,17 +1028,7 @@ class CodeGenerator:
             return "False"
 
         # Functions that need numpy arrays for their array/table arguments
-        # Maps function name -> set of argument indices that need np.array wrapping
-        numpy_array_args: dict[str, set[int]] = {
-            "LOOKUP": {1, 2},  # lookup_vector/array + optional result_vector
-            "VLOOKUP": {1},  # table_array is 2nd arg (index 1)
-            "HLOOKUP": {1},  # table_array is 2nd arg (index 1)
-            "INDEX": {0},  # array is 1st arg (index 0)
-            "MATCH": {1},  # lookup_array is 2nd arg (index 1)
-            "SUMPRODUCT": set(range(10)),  # all args can be arrays
-        }
-
-        needs_numpy_wrap = numpy_array_args.get(upper_name, set())
+        needs_numpy_wrap = numpy_array_arg_indices(upper_name)
 
         emitted_args = []
         for i, arg in enumerate(node.args):
@@ -1734,15 +1725,8 @@ class CodeGenerator:
                 funcs.add(excel_func_to_python(node.name))
 
             # Check if this function needs numpy array wrapping for range args
-            numpy_array_args = {
-                "LOOKUP": {1, 2},
-                "VLOOKUP": {1},
-                "HLOOKUP": {1},
-                "INDEX": {0},
-                "MATCH": {1},
-                "SUMPRODUCT": set(range(10)),
-            }
-            if upper_name in numpy_array_args:
+            array_arg_indices = numpy_array_arg_indices(upper_name)
+            if array_arg_indices:
                 skip_index_array = (
                     upper_name == "INDEX"
                     and node.args
@@ -1752,7 +1736,7 @@ class CodeGenerator:
                 for i, arg in enumerate(node.args):
                     if skip_index_array and upper_name == "INDEX":
                         break
-                    if i in numpy_array_args[upper_name] and isinstance(arg, RangeNode):
+                    if i in array_arg_indices and isinstance(arg, RangeNode):
                         funcs.add("numpy")
                         break
             for arg in node.args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "excel-grapher"
-version = "0.6.6"
+version = "0.6.7"
+
 description = "Build and analyze dependency graphs from Excel workbooks"
 readme = "README.md"
 license = { text = "Proprietary" }

--- a/tests/unit/core/test_operators_array.py
+++ b/tests/unit/core/test_operators_array.py
@@ -1,0 +1,103 @@
+"""Element-wise array semantics for shared Excel operators."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import pytest
+
+from excel_grapher.core.operators import xl_concat, xl_eq, xl_mul, xl_pow
+from excel_grapher.core.types import XlError
+
+
+def _as_ndarray(result: object) -> np.ndarray:
+    assert isinstance(result, np.ndarray)
+    return cast(np.ndarray, result)
+
+
+def test_xl_pow_elementwise_array_and_scalar() -> None:
+    left = np.array([[2.0, 3.0], [4.0, 5.0]], dtype=object)
+    result = xl_pow(left, 2)
+    arr = _as_ndarray(result)
+    assert arr.shape == (2, 2)
+    assert arr.tolist() == [[4.0, 9.0], [16.0, 25.0]]
+
+
+def test_xl_pow_broadcasts_scalar_base_across_array_exponent() -> None:
+    right = np.array([[2.0, 3.0]], dtype=object)
+    arr = _as_ndarray(xl_pow(3.0, right))
+    assert arr.tolist() == [[9.0, 27.0]]
+
+
+def test_xl_pow_shape_mismatch_returns_value() -> None:
+    left = np.array([[1.0, 2.0]], dtype=object)
+    right = np.array([[1.0, 2.0, 3.0]], dtype=object)
+    assert xl_pow(left, right) == XlError.VALUE
+
+
+def test_xl_pow_propagates_top_level_errors() -> None:
+    left = np.array([[2.0]], dtype=object)
+    assert xl_pow(XlError.DIV, left) == XlError.DIV
+    assert xl_pow(left, XlError.NA) == XlError.NA
+
+
+def test_xl_pow_invalid_power_returns_num() -> None:
+    assert xl_pow(-1.0, 0.5) == XlError.NUM
+
+
+def test_xl_eq_elementwise_string_equality() -> None:
+    left = np.array([["Software", "Hardware"], ["Software", "Other"]], dtype=object)
+    assert _as_ndarray(xl_eq(left, "Software")).tolist() == [[True, False], [True, False]]
+
+
+def test_xl_eq_array_compare_fail_fast_on_first_cell_error() -> None:
+    left = np.array([[1.0, XlError.NA]], dtype=object)
+    assert xl_eq(left, 1.0) == XlError.NA
+
+
+def test_xl_mul_array_arithmetic_fail_fast_on_first_cell_error() -> None:
+    left = np.array([[True, XlError.DIV]], dtype=object)
+    assert xl_mul(left, 1) == XlError.DIV
+
+
+def test_xl_concat_elementwise_arrays() -> None:
+    left = np.array([["a", "b"], ["c", "d"]], dtype=object)
+    right = np.array([["1", "2"], ["3", "4"]], dtype=object)
+    assert _as_ndarray(xl_concat(left, right)).tolist() == [["a1", "b2"], ["c3", "d4"]]
+
+
+def test_xl_concat_broadcasts_scalar_suffix() -> None:
+    left = np.array([["x", "y"]], dtype=object)
+    assert _as_ndarray(xl_concat(left, "!")).tolist() == [["x!", "y!"]]
+
+
+def test_xl_concat_broadcasts_scalar_prefix() -> None:
+    right = np.array([[1.0, 2.0]], dtype=object)
+    assert _as_ndarray(xl_concat("v", right)).tolist() == [["v1", "v2"]]
+
+
+def test_xl_concat_shape_mismatch_returns_value() -> None:
+    left = np.array([["a"]], dtype=object)
+    right = np.array([["b", "c"]], dtype=object)
+    assert xl_concat(left, right) == XlError.VALUE
+
+
+def test_xl_concat_propagates_top_level_errors() -> None:
+    left = np.array([["a"]], dtype=object)
+    assert xl_concat(XlError.REF, left) == XlError.REF
+    assert xl_concat(left, XlError.VALUE) == XlError.VALUE
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        (2.0, 3.0, 8.0),
+        ("a", "b", "ab"),
+    ],
+)
+def test_xl_pow_and_concat_scalar_paths_unchanged(left, right, expected) -> None:
+    if isinstance(expected, str):
+        assert xl_concat(left, right) == expected
+    else:
+        assert xl_pow(left, right) == expected

--- a/tests/unit/gaps/test_sumproduct_criteria_gaps.py
+++ b/tests/unit/gaps/test_sumproduct_criteria_gaps.py
@@ -1,0 +1,69 @@
+"""SUMPRODUCT criteria/array semantics (issue #267).
+
+Regression coverage for element-wise range comparisons and products inside
+``SUMPRODUCT``, e.g. ``(range="label")*values`` and ``(range>threshold)*1``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from excel_grapher import FormulaEvaluator, create_dependency_graph
+from excel_grapher.evaluator.types import XlError
+from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
+from tests.unit.gaps.workbook_helpers import (
+    write_software_revenue_sumproduct,
+    write_sumproduct_category_filter,
+    write_sumproduct_threshold_count,
+)
+
+
+def _evaluate(path: Path, address: str) -> object:
+    graph = create_dependency_graph(
+        path,
+        [address],
+        load_values=True,
+        use_cached_dynamic_refs=True,
+    )
+    with FormulaEvaluator(graph) as evaluator:
+        return evaluator.evaluate(address)
+
+
+def test_software_revenue_sumproduct_category_filter(tmp_path: Path) -> None:
+    """``SUMPRODUCT((cats="Software")*prices)`` returns filtered revenue (K21 / #267)."""
+    workbook = write_software_revenue_sumproduct(tmp_path / "software_revenue.xlsx")
+    result = _evaluate(workbook, "Product Lookup!K21")
+    assert result != XlError.VALUE
+    assert result == pytest.approx(10598.0)
+
+
+def test_sumproduct_string_equality_filter(tmp_path: Path) -> None:
+    """String equality criteria inside ``SUMPRODUCT`` (financial_model ``I14`` shape)."""
+    workbook = write_sumproduct_category_filter(tmp_path / "category_filter.xlsx")
+    result = _evaluate(workbook, "Product Lookup!I14")
+    assert result != XlError.VALUE
+    assert result == pytest.approx(630.0)
+
+
+def test_sumproduct_numeric_threshold_count(tmp_path: Path) -> None:
+    """Numeric comparison criteria ``(range>threshold)*1`` inside ``SUMPRODUCT``."""
+    workbook = write_sumproduct_threshold_count(tmp_path / "threshold_count.xlsx")
+    result = _evaluate(workbook, "Product Lookup!I18")
+    assert result != XlError.VALUE
+    assert result == pytest.approx(3.0)
+
+
+def test_software_revenue_sumproduct_eval_codegen_parity(tmp_path: Path) -> None:
+    """Evaluator and export agree on K21 category-filtered ``SUMPRODUCT``."""
+    workbook = write_software_revenue_sumproduct(tmp_path / "software_revenue_parity.xlsx")
+    graph = create_dependency_graph(
+        workbook,
+        ["Product Lookup!K21"],
+        load_values=True,
+        use_cached_dynamic_refs=True,
+    )
+    result = assert_codegen_matches_evaluator(graph, ["Product Lookup!K21"])
+    assert result.evaluator_results["Product Lookup!K21"] == pytest.approx(10598.0)
+    assert result.generated_results["Product Lookup!K21"] == pytest.approx(10598.0)

--- a/tests/unit/gaps/test_sumproduct_criteria_gaps.py
+++ b/tests/unit/gaps/test_sumproduct_criteria_gaps.py
@@ -7,10 +7,13 @@ Regression coverage for element-wise range comparisons and products inside
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
+import numpy as np
 import pytest
 
-from excel_grapher import FormulaEvaluator, create_dependency_graph
+from excel_grapher import DependencyGraph, FormulaEvaluator, Node, create_dependency_graph
+from excel_grapher.core.address_keys import parse_address
 from excel_grapher.evaluator.types import XlError
 from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
 from tests.unit.gaps.workbook_helpers import (
@@ -18,6 +21,22 @@ from tests.unit.gaps.workbook_helpers import (
     write_sumproduct_category_filter,
     write_sumproduct_threshold_count,
 )
+from tests.utils.excel_workbook_parity import assert_workbook_parity
+
+
+def _make_node(address: str, formula: str | None, value: object) -> Node:
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=formula,
+        value=value,
+        is_leaf=formula is None,
+    )
 
 
 def _evaluate(path: Path, address: str) -> object:
@@ -53,6 +72,65 @@ def test_sumproduct_numeric_threshold_count(tmp_path: Path) -> None:
     result = _evaluate(workbook, "Product Lookup!I18")
     assert result != XlError.VALUE
     assert result == pytest.approx(3.0)
+
+
+def test_standalone_range_comparison_returns_elementwise_array() -> None:
+    """Multi-cell range compares at formula top level return ndarrays (not a single scalar)."""
+    graph = DependencyGraph()
+    for row, category in enumerate(["Software", "Hardware", "Software"], start=5):
+        graph.add_node(_make_node(f"PL!C{row}", None, category))
+    graph.add_node(
+        _make_node("PL!D10", '=PL!C5:PL!C7="Software"', None),
+    )
+    with FormulaEvaluator(graph) as evaluator:
+        result = evaluator.evaluate("PL!D10")
+    assert isinstance(result, np.ndarray)
+    assert cast(np.ndarray, result).tolist() == [[True], [False], [True]]
+
+
+def test_sumproduct_criteria_evaluator_matches_excel_cached_values(tmp_path: Path) -> None:
+    """Evaluator agrees with Excel cached values embedded in gap workbooks."""
+    cases = [
+        (write_software_revenue_sumproduct(tmp_path / "cached_k21.xlsx"), "Product Lookup!K21"),
+        (write_sumproduct_category_filter(tmp_path / "cached_i14.xlsx"), "Product Lookup!I14"),
+        (write_sumproduct_threshold_count(tmp_path / "cached_i18.xlsx"), "Product Lookup!I18"),
+    ]
+    for workbook, address in cases:
+        graph = create_dependency_graph(
+            workbook,
+            [address],
+            load_values=True,
+            use_cached_dynamic_refs=True,
+        )
+        assert_workbook_parity(graph, [address])
+
+
+def test_sumproduct_category_filter_eval_codegen_parity(tmp_path: Path) -> None:
+    """Evaluator and export agree on I14 string-equality ``SUMPRODUCT``."""
+    workbook = write_sumproduct_category_filter(tmp_path / "category_filter_parity.xlsx")
+    graph = create_dependency_graph(
+        workbook,
+        ["Product Lookup!I14"],
+        load_values=True,
+        use_cached_dynamic_refs=True,
+    )
+    result = assert_codegen_matches_evaluator(graph, ["Product Lookup!I14"])
+    assert result.evaluator_results["Product Lookup!I14"] == pytest.approx(630.0)
+    assert result.generated_results["Product Lookup!I14"] == pytest.approx(630.0)
+
+
+def test_sumproduct_threshold_count_eval_codegen_parity(tmp_path: Path) -> None:
+    """Evaluator and export agree on I18 threshold-count ``SUMPRODUCT``."""
+    workbook = write_sumproduct_threshold_count(tmp_path / "threshold_count_parity.xlsx")
+    graph = create_dependency_graph(
+        workbook,
+        ["Product Lookup!I18"],
+        load_values=True,
+        use_cached_dynamic_refs=True,
+    )
+    result = assert_codegen_matches_evaluator(graph, ["Product Lookup!I18"])
+    assert result.evaluator_results["Product Lookup!I18"] == pytest.approx(3.0)
+    assert result.generated_results["Product Lookup!I18"] == pytest.approx(3.0)
 
 
 def test_software_revenue_sumproduct_eval_codegen_parity(tmp_path: Path) -> None:

--- a/tests/unit/gaps/test_sumproduct_criteria_gaps.py
+++ b/tests/unit/gaps/test_sumproduct_criteria_gaps.py
@@ -1,4 +1,4 @@
-"""SUMPRODUCT criteria/array semantics (issue #267).
+"""SUMPRODUCT criteria/array semantics (issues #265 and #267).
 
 Regression coverage for element-wise range comparisons and products inside
 ``SUMPRODUCT``, e.g. ``(range="label")*values`` and ``(range>threshold)*1``.
@@ -19,6 +19,7 @@ from tests.integration.utils.parity_harness import assert_codegen_matches_evalua
 from tests.unit.gaps.workbook_helpers import (
     write_software_revenue_sumproduct,
     write_sumproduct_category_filter,
+    write_sumproduct_price_threshold_k24,
     write_sumproduct_threshold_count,
 )
 from tests.utils.excel_workbook_parity import assert_workbook_parity
@@ -74,6 +75,14 @@ def test_sumproduct_numeric_threshold_count(tmp_path: Path) -> None:
     assert result == pytest.approx(3.0)
 
 
+def test_sumproduct_price_threshold_count_k24(tmp_path: Path) -> None:
+    """``SUMPRODUCT(($E$5:$E$19>1000)*1)`` counts prices above threshold (K24 / #265)."""
+    workbook = write_sumproduct_price_threshold_k24(tmp_path / "price_threshold_k24.xlsx")
+    result = _evaluate(workbook, "Product Lookup!K24")
+    assert result != XlError.VALUE
+    assert result == pytest.approx(7.0)
+
+
 def test_standalone_range_comparison_returns_elementwise_array() -> None:
     """Multi-cell range compares at formula top level return ndarrays (not a single scalar)."""
     graph = DependencyGraph()
@@ -92,6 +101,7 @@ def test_sumproduct_criteria_evaluator_matches_excel_cached_values(tmp_path: Pat
     """Evaluator agrees with Excel cached values embedded in gap workbooks."""
     cases = [
         (write_software_revenue_sumproduct(tmp_path / "cached_k21.xlsx"), "Product Lookup!K21"),
+        (write_sumproduct_price_threshold_k24(tmp_path / "cached_k24.xlsx"), "Product Lookup!K24"),
         (write_sumproduct_category_filter(tmp_path / "cached_i14.xlsx"), "Product Lookup!I14"),
         (write_sumproduct_threshold_count(tmp_path / "cached_i18.xlsx"), "Product Lookup!I18"),
     ]
@@ -145,3 +155,17 @@ def test_software_revenue_sumproduct_eval_codegen_parity(tmp_path: Path) -> None
     result = assert_codegen_matches_evaluator(graph, ["Product Lookup!K21"])
     assert result.evaluator_results["Product Lookup!K21"] == pytest.approx(10598.0)
     assert result.generated_results["Product Lookup!K21"] == pytest.approx(10598.0)
+
+
+def test_sumproduct_price_threshold_k24_eval_codegen_parity(tmp_path: Path) -> None:
+    """Evaluator and export agree on K24 price-threshold ``SUMPRODUCT`` (#265)."""
+    workbook = write_sumproduct_price_threshold_k24(tmp_path / "price_threshold_k24_parity.xlsx")
+    graph = create_dependency_graph(
+        workbook,
+        ["Product Lookup!K24"],
+        load_values=True,
+        use_cached_dynamic_refs=True,
+    )
+    result = assert_codegen_matches_evaluator(graph, ["Product Lookup!K24"])
+    assert result.evaluator_results["Product Lookup!K24"] == pytest.approx(7.0)
+    assert result.generated_results["Product Lookup!K24"] == pytest.approx(7.0)

--- a/tests/unit/gaps/workbook_helpers.py
+++ b/tests/unit/gaps/workbook_helpers.py
@@ -67,3 +67,16 @@ def write_sumproduct_threshold_count(path: Path) -> Path:
         ws.write_formula(17, 8, "=SUMPRODUCT((D5:D12>200)*1)", None, 3)
 
     return write_workbook(path, populate)
+
+
+def write_sumproduct_price_threshold_k24(path: Path) -> Path:
+    """``SUMPRODUCT(($E$5:$E$19>1000)*1)`` (advanced_formula ``K24`` / issue #265)."""
+
+    def populate(workbook: xlsxwriter.Workbook) -> None:
+        ws = workbook.add_worksheet("Product Lookup")
+        prices = [1499, 800, 1200, 600, 999, 750, 1100, 500, 1300, 700, 1600, 900, 1400, 850, 1500]
+        for row, price in enumerate(prices, start=5):
+            ws.write_number(row - 1, 4, price)
+        ws.write_formula(23, 10, "=SUMPRODUCT(($E$5:$E$19>1000)*1)", None, 7)
+
+    return write_workbook(path, populate)

--- a/tests/unit/gaps/workbook_helpers.py
+++ b/tests/unit/gaps/workbook_helpers.py
@@ -1,0 +1,69 @@
+"""Tiny workbook builders for gap reproduction tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import xlsxwriter
+
+
+def write_workbook(path: Path, populate) -> Path:
+    """Build a workbook via ``populate(workbook)``."""
+    workbook = xlsxwriter.Workbook(path)
+    populate(workbook)
+    workbook.close()
+    return path
+
+
+def write_software_revenue_sumproduct(path: Path) -> Path:
+    """Category-filtered revenue sum (advanced_formula ``K21`` / issue #267)."""
+
+    def populate(workbook: xlsxwriter.Workbook) -> None:
+        ws = workbook.add_worksheet("Product Lookup")
+        categories = (["Software", "Hardware"] * 7) + ["Software"]
+        prices = [1499, 800, 1200, 600, 999, 750, 1100, 500, 1300, 700, 1600, 900, 1400, 850, 1500]
+        for row, (category, price) in enumerate(zip(categories, prices, strict=True), start=5):
+            ws.write_string(row - 1, 2, category)
+            ws.write_number(row - 1, 4, price)
+        ws.write_formula(
+            20,
+            10,
+            '=SUMPRODUCT(($C$5:$C$19="Software")*$E$5:$E$19)',
+            None,
+            10598,
+        )
+
+    return write_workbook(path, populate)
+
+
+def write_sumproduct_category_filter(path: Path) -> Path:
+    r"""``SUMPRODUCT((range="label")*values)`` (financial_model ``I14``)."""
+
+    def populate(workbook: xlsxwriter.Workbook) -> None:
+        ws = workbook.add_worksheet("Product Lookup")
+        categories = ["Software", "Hardware", "Software", "Hardware"] * 2
+        values = [100, 50, 200, 75, 150, 60, 180, 90]
+        for row, (category, value) in enumerate(zip(categories, values, strict=True), start=5):
+            ws.write_string(row - 1, 2, category)
+            ws.write_number(row - 1, 5, value)
+        ws.write_formula(
+            13,
+            8,
+            '=SUMPRODUCT((C5:C12="Software")*F5:F12)',
+            None,
+            630,
+        )
+
+    return write_workbook(path, populate)
+
+
+def write_sumproduct_threshold_count(path: Path) -> Path:
+    """``SUMPRODUCT((range>threshold)*1)`` (financial_model ``I18``)."""
+
+    def populate(workbook: xlsxwriter.Workbook) -> None:
+        ws = workbook.add_worksheet("Product Lookup")
+        for row, value in enumerate([100, 250, 200, 75, 300, 60, 180, 400], start=5):
+            ws.write_number(row - 1, 3, value)
+        ws.write_formula(17, 8, "=SUMPRODUCT((D5:D12>200)*1)", None, 3)
+
+    return write_workbook(path, populate)

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,7 @@ wheels = [
 
 [[package]]
 name = "excel-grapher"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastpyxl" },


### PR DESCRIPTION
Fixes #265
Fixes #267

## Summary

Excel compares ranges element-wise inside expressions like `(C5:C19="Software")` and `(E5:E19>1000)`. excel-grapher was collapsing those to a single scalar, which broke `SUMPRODUCT` criteria patterns:

- **#265** — `SUMPRODUCT(($E$5:$E$19>1000)*1)` at `'Product Lookup'!K24` (evaluator/codegen parity on threshold count)
- **#267** — `SUMPRODUCT(($C$5:$C$19="Software")*$E$5:$E$19)` at `'Product Lookup'!K21` (category-filtered revenue returned `#VALUE!`)

## Fix

1. **`excel_grapher/core/operators.py`** — element-wise array semantics in shared runtime:
   - `_broadcast_pair()` — broadcast scalar ↔ ndarray
   - `_xl_compare()` / `_xl_arithmetic()` — element-wise `=`, `>`, `*`, etc.
   - `xl_eq`, `xl_mul`, etc. delegate to these helpers (codegen already used them)

2. **`excel_grapher/evaluator/evaluator.py`**
   - `_resolve_binary_operand()` — resolve `ExcelRange` to ndarrays before binary ops
   - `_eval_binary_op()` — use `xl_add` / `xl_sub` / `xl_mul` / `xl_div` instead of scalar `to_number()` for arithmetic

3. **`excel_grapher/core/excel_function_meta.py`** — centralize `NUMPY_ARRAY_ARG_INDICES` for evaluator and codegen

Eval ↔ codegen parity holds because export embeds the same `operators.py`.

## Test plan

- [x] K24 price-threshold count (`#265`)
- [x] K21 category-filtered revenue (`#267`)
- [x] I14 string-equality and I18 numeric-threshold shapes
- [x] Evaluator ↔ export parity and Excel cached-value checks
- [x] Operator unit tests for element-wise compare/arithmetic/concat

## Follow-ups

Top-level array formula spill/intersection semantics tracked in #284. Per-cell error arrays (#285) and operator vectorization (#286) remain open.