### PR TITLE
fix(series-bindings): make setter docstrings layout-aware

### DIFF
--- a/excel_grapher/series_bindings/docstring_renderers.py
+++ b/excel_grapher/series_bindings/docstring_renderers.py
@@ -54,19 +54,86 @@ def _field_description_line(
     return f'{field_name}: {description} If supplied, expected value: "{expected_value}".'
 
 
+def _indent_lines(lines: list[str], prefix: str) -> list[str]:
+    """Indent non-empty lines, leaving blank lines free of trailing whitespace."""
+    return [f"{prefix}{line}" if line else "" for line in lines]
+
+
 def _render_record(record: Mapping[str, object]) -> str:
     fields = ", ".join(f"{field_name!r}: {value!r}" for field_name, value in record.items())
     return f"{{{fields}}}"
 
 
+def _measure_field(contract: SeriesBindingDocstringContract) -> str | None:
+    """Return the measure field name (the last required field), if any."""
+    if contract.required_fields:
+        return contract.required_fields[-1]
+    return None
+
+
+def _is_single_key(contract: SeriesBindingDocstringContract) -> bool:
+    """True when the binding has exactly one key field (one key plus the measure)."""
+    return len(contract.required_fields) == 2
+
+
+_SETTER_INPUT_TYPE_NAMES: dict[str, str] = {
+    "scalar": "Scalar | Record | Records",
+    "series": "SeriesInput",
+    "matrix": "SeriesInput",
+}
+
+
+def _setter_input_type_name(contract: SeriesBindingDocstringContract) -> str:
+    """Return the type-alias name advertised by the generated setter signature."""
+    return _SETTER_INPUT_TYPE_NAMES.get(contract.layout, "SeriesInput")
+
+
+def _setter_input_description(contract: SeriesBindingDocstringContract) -> str:
+    """Describe the input shapes accepted for the binding's layout."""
+    if contract.layout == "scalar":
+        return "A bare scalar value, a single record dict, or a list of records."
+    if contract.layout == "series" and _is_single_key(contract):
+        return (
+            "A list of records, a single record dict, a tidy pandas/polars "
+            "DataFrame, or a 1-D iterable of measure values in key order."
+        )
+    return "A list of records, a single record dict, or a tidy pandas/polars DataFrame."
+
+
+def _render_records_example(contract: SeriesBindingDocstringContract) -> list[str]:
+    lines = [f"{contract.function_name}(ctx, ["]
+    for record in contract.example_records:
+        lines.append(f"    {_render_record(record)},")
+    lines.append("])")
+    return lines
+
+
+def _render_scalar_example(contract: SeriesBindingDocstringContract) -> list[str]:
+    measure = _measure_field(contract)
+    value = contract.example_records[0].get(measure) if contract.example_records else None
+    return [f"{contract.function_name}(ctx, {value!r})"]
+
+
+def _render_positional_example(contract: SeriesBindingDocstringContract) -> list[str]:
+    measure = _measure_field(contract)
+    values = [record.get(measure) for record in contract.example_records]
+    return [f"{contract.function_name}(ctx, {values!r})"]
+
+
 def _render_example_call(contract: SeriesBindingDocstringContract) -> list[str]:
-    if contract.function_kind == "setter":
-        lines = [f"{contract.function_name}(ctx, ["]
-        for record in contract.example_records:
-            lines.append(f"    {_render_record(record)},")
-        lines.append("])")
-        return lines
-    return [f"{contract.function_name}(ctx=ctx)"]
+    if contract.function_kind != "setter":
+        return [f"{contract.function_name}(ctx=ctx)"]
+    if contract.layout == "scalar":
+        return _render_scalar_example(contract)
+    blocks = [_render_records_example(contract)]
+    if contract.layout == "series" and _is_single_key(contract):
+        blocks.append(_render_positional_example(contract))
+    lines: list[str] = []
+    for index, block in enumerate(blocks):
+        if index:
+            lines.append("")
+        lines.extend(block)
+    return lines
 
 
 def _required_and_optional_fields(
@@ -135,6 +202,10 @@ class PlainSeriesDocstringRenderer:
 
         lines: list[str] = []
         _append_intro(lines, doc)
+        if contract.function_kind == "setter":
+            lines.append("Accepted input:")
+            lines.append(f"    {_setter_input_description(contract)}")
+            lines.append("")
         lines.append("Required record fields:")
         lines.extend(
             [
@@ -158,7 +229,7 @@ class PlainSeriesDocstringRenderer:
                 *[f"    {line}" for line in _source_binding_lines(contract, series)],
                 "",
                 "Example:",
-                *[f"    {line}" for line in example_lines],
+                *_indent_lines(example_lines, "    "),
             ]
         )
         return "\n".join(lines)
@@ -180,6 +251,15 @@ class RstSeriesDocstringRenderer:
             lines.extend(["Purpose", "-------", doc.purpose, ""])
         if doc.record_matching:
             lines.extend(["Record matching", "---------------", doc.record_matching, ""])
+        if contract.function_kind == "setter":
+            lines.extend(
+                [
+                    "Accepted input",
+                    "--------------",
+                    _setter_input_description(contract),
+                    "",
+                ]
+            )
         lines.append("Required record fields")
         lines.append("----------------------")
         for name in required:
@@ -214,7 +294,10 @@ class GoogleSeriesDocstringRenderer:
         _append_intro(lines, doc)
         lines.append("Args:")
         if contract.function_kind == "setter":
-            lines.append("    records (Records): Records to apply to the workbook inputs.")
+            lines.append(
+                f"    records ({_setter_input_type_name(contract)}): "
+                f"{_setter_input_description(contract)}"
+            )
             _append_field_bullets(
                 lines,
                 doc=doc,
@@ -246,7 +329,7 @@ class GoogleSeriesDocstringRenderer:
         for line in _source_binding_lines(contract, series):
             lines.append(f"    {line}")
         lines.extend(["", "Examples:"])
-        lines.extend(f"    {line}" for line in example_lines)
+        lines.extend(_indent_lines(example_lines, "    "))
         return "\n".join(lines)
 
 
@@ -268,8 +351,8 @@ class NumpySeriesDocstringRenderer:
             lines.extend([doc.record_matching, ""])
         lines.extend(["Parameters", "----------"])
         if contract.function_kind == "setter":
-            lines.append("records : Records")
-            lines.append("    Records to apply to workbook inputs.")
+            lines.append(f"records : {_setter_input_type_name(contract)}")
+            lines.append(f"    {_setter_input_description(contract)}")
             _append_field_bullets(
                 lines,
                 doc=doc,

--- a/tests/unit/series_bindings/test_docstrings.py
+++ b/tests/unit/series_bindings/test_docstrings.py
@@ -25,6 +25,7 @@ from excel_grapher.series_bindings.docstring_renderers import (
     resolve_series_docstring_renderer,
 )
 from excel_grapher.series_bindings.docstrings import (
+    FieldContract,
     FieldDoc,
     SeriesBindingDocstringContext,
     SeriesBindingDocstringContract,
@@ -479,6 +480,115 @@ def _demo_contract_and_doc() -> tuple[SeriesBindingDocstringContract, SeriesFunc
     return contract, doc
 
 
+def _series_contract_and_doc(
+    *,
+    layout: str = "series",
+    keys: tuple[str, ...] = ("COUNTRY",),
+) -> tuple[SeriesBindingDocstringContract, SeriesFunctionDoc]:
+    example_records: list[dict[str, object]] = [
+        {**{key: country for key in keys}, "OBS_VALUE": value}
+        for country, value in (("Borvelia", 60.0), ("Litellia", 80.0))
+    ]
+    contract = SeriesBindingDocstringContract(
+        series_id="country_initial_debt",
+        function_name="set_country_initial_debt",
+        function_kind="setter",
+        data_range="Inputs!B10:B12",
+        layout=layout,
+        value_type="float",
+        required_fields=(*keys, "OBS_VALUE"),
+        fields={
+            **{
+                key: FieldContract(
+                    concept_name=key,
+                    dtype="string",
+                    required=True,
+                    expected_value=None,
+                )
+                for key in keys
+            },
+            "OBS_VALUE": FieldContract(
+                concept_name="Observation value",
+                dtype="float",
+                required=True,
+                expected_value=None,
+            ),
+        },
+        example_records=tuple(example_records),
+        notes="",
+    )
+    doc = SeriesFunctionDoc(
+        summary="Set country initial debt.",
+        purpose="Updates the bound range.",
+        record_matching="Match by key.",
+        field_descriptions={
+            **{key: FieldDoc(description=f"Describe {key}.") for key in keys},
+            "OBS_VALUE": FieldDoc(description="Observation value."),
+        },
+    )
+    return contract, doc
+
+
+def test_scalar_setter_docstring_describes_scalar_shapes() -> None:
+    contract, doc = _demo_contract_and_doc()
+    rendered = GoogleSeriesDocstringRenderer().render(contract, doc, series={"id": "demo"})
+    assert "bare scalar" in rendered
+    assert "tidy pandas/polars DataFrame" not in rendered
+    assert "set_demo(ctx, 2.0)" in rendered
+    assert "set_demo(ctx, [" not in rendered
+
+
+def test_series_setter_docstring_describes_series_shapes() -> None:
+    contract, doc = _series_contract_and_doc(layout="series", keys=("COUNTRY",))
+    rendered = GoogleSeriesDocstringRenderer().render(
+        contract, doc, series={"id": "country_initial_debt"}
+    )
+    assert "tidy pandas/polars DataFrame" in rendered
+    assert "1-D iterable of measure values in key order" in rendered
+    assert "set_country_initial_debt(ctx, [" in rendered
+    assert "set_country_initial_debt(ctx, [60.0, 80.0])" in rendered
+
+
+def test_series_multi_key_setter_omits_positional_shape() -> None:
+    contract, doc = _series_contract_and_doc(layout="series", keys=("COUNTRY", "TIME_PERIOD"))
+    rendered = GoogleSeriesDocstringRenderer().render(
+        contract, doc, series={"id": "country_initial_debt"}
+    )
+    assert "tidy pandas/polars DataFrame" in rendered
+    assert "1-D iterable of measure values in key order" not in rendered
+
+
+def test_matrix_setter_docstring_describes_matrix_shapes() -> None:
+    contract, doc = _series_contract_and_doc(layout="matrix", keys=("INDICATOR", "TIME_PERIOD"))
+    rendered = GoogleSeriesDocstringRenderer().render(
+        contract, doc, series={"id": "country_initial_debt"}
+    )
+    assert "tidy pandas/polars DataFrame" in rendered
+    assert "1-D iterable of measure values in key order" not in rendered
+    assert "set_country_initial_debt(ctx, [" in rendered
+
+
+@pytest.mark.parametrize(
+    "renderer_cls",
+    [
+        PlainSeriesDocstringRenderer,
+        RstSeriesDocstringRenderer,
+        GoogleSeriesDocstringRenderer,
+        NumpySeriesDocstringRenderer,
+    ],
+)
+def test_all_renderers_describe_layout_specific_input(renderer_cls: type) -> None:
+    scalar_contract, doc = _demo_contract_and_doc()
+    scalar_rendered = renderer_cls().render(scalar_contract, doc, series={"id": "demo"})
+    assert "bare scalar" in scalar_rendered
+
+    series_contract, series_doc = _series_contract_and_doc()
+    series_rendered = renderer_cls().render(
+        series_contract, series_doc, series={"id": "country_initial_debt"}
+    )
+    assert "tidy pandas/polars DataFrame" in series_rendered
+
+
 def test_resolve_series_docstring_renderer_builtin_names() -> None:
     for name in ("plain", "rst", "google", "numpy"):
         renderer = resolve_series_docstring_renderer(name)
@@ -547,7 +657,7 @@ def test_builtin_renderer_includes_sections(
     rendered = renderer_cls().render(contract, doc, series={"id": "demo"})
     assert "Set demo values." in rendered
     assert "TIME_PERIOD" in rendered
-    assert "set_demo(ctx, [" in rendered
+    assert "set_demo(ctx, 2.0)" in rendered
     for marker in markers:
         assert marker in rendered
 
@@ -560,7 +670,7 @@ def test_plain_renderer_includes_sections() -> None:
     assert "TIME_PERIOD:" in rendered
     assert "Source binding:" in rendered
     assert "Example:" in rendered
-    assert "set_demo(ctx, [" in rendered
+    assert "set_demo(ctx, 2.0)" in rendered
 
 
 def test_emit_docstring_literal_escapes_quotes_and_is_valid_python() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #298. The built-in series-binding docstring renderers (`google`, `plain`, `rst`, `numpy`) previously documented every generated `set_*` function as accepting **records only**, regardless of the binding `layout`. The generated setters actually accept a wider, layout-dependent union of input shapes, so the rendered docstrings were misleading.

The renderers are now layout-aware, deriving both the parameter description and the `Examples` block from `contract.layout` (which the contract already carries).

## What changed

`excel_grapher/series_bindings/docstring_renderers.py`:

- **Parameter description** is selected per layout instead of the hardcoded `records (Records): Records to apply to the workbook inputs.`:
  - `scalar` &rarr; `records (Scalar | Record | Records)`: a bare scalar value, a single record dict, or a list of records.
  - `series` (single-key) &rarr; `records (SeriesInput)`: records, a single dict, a tidy pandas/polars DataFrame, or a 1-D iterable of measure values in key order.
  - `series` (multi-key) / `matrix` &rarr; `records (SeriesInput)`: records, a single dict, or a tidy pandas/polars DataFrame.
- **Examples** are layout-appropriate:
  - `scalar`: emits the bare-scalar form, e.g. `set_country_name(ctx, 'Borvelia')`.
  - `series` (single-key): emits the records form plus a positional 1-D measure example, e.g. `set_country_initial_debt(ctx, [60.0, 80.0])`.
  - `series` (multi-key) / `matrix`: emits the records form.
- The `plain` and `rst` renderers, which previously omitted any input description, now include an `Accepted input` section.
- The positional/1-D measure shape is only advertised for single-key series bindings, matching the actual coercion layer (`_coerce_positional_records` rejects multi-key and matrix positional input).

## Notes on design

- The renderers only consume the existing `SeriesBindingDocstringContract` (no new inputs); `layout` and `required_fields` are sufficient. The measure field is taken as the last required field (matching `derive_doc_contract`), and "single key" is detected as exactly one key plus the measure.
- Type names (`Scalar | Record | Records`, `SeriesInput`) match the aliases emitted into standalone exported code, keeping rendered docstrings consistent with generated signatures.

## Testing

- TDD: added failing tests first, then implemented.
- New tests in `tests/unit/series_bindings/test_docstrings.py` cover scalar/series/matrix descriptions, the positional example, single- vs multi-key series, and all four renderers.
- Updated two existing assertions that expected the records-only example for the scalar demo contract.
- `uv run pytest tests/unit/series_bindings/ tests/integration/user_flows/test_series_bindings_codegen.py tests/integration/user_flows/test_series_bindings_output_codegen.py` passes.
- `ruff check`, `ruff format --check`, and `ty check` pass on the changed files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e816ad6-f0dd-4bb1-8ccc-f930f2778a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e816ad6-f0dd-4bb1-8ccc-f930f2778a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

