### PR TITLE
fix(evaluator): track runtime deps so dynamic-ref shifts invalidate correctly

### DIFF
--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -101,6 +101,14 @@ class FormulaEvaluator:
         self._leaf_values: dict[str, CellValue] = {}  # For auto-detection
         self._iteration_values: dict[str, CellValue] = {}
         self._blank_range_rects = normalize_blank_range_specs(self.blank_ranges)
+        # Runtime dependency edges recorded as cells are evaluated. Unlike the
+        # static graph edges (which freeze the build-time resolution of dynamic
+        # refs such as OFFSET/INDIRECT under `use_cached_dynamic_refs`), these
+        # follow argument-driven resolution shifts, so invalidation tracks the
+        # currently-resolved dependency chain. This mirrors the exported
+        # `EvalContext` runtime, keeping evaluator and export in parity.
+        self._runtime_deps: dict[str, set[str]] = {}
+        self._runtime_reverse_deps: dict[str, set[str]] = {}
 
     def __enter__(self) -> FormulaEvaluator:
         return self
@@ -108,18 +116,38 @@ class FormulaEvaluator:
     def __exit__(self, *args: object) -> None:
         return None
 
+    def _record_runtime_dependency(self, parent: str, child: str) -> None:
+        """Record that `parent` read `child` during the current evaluation."""
+        if parent == child:
+            return
+        self._runtime_deps.setdefault(parent, set()).add(child)
+        self._runtime_reverse_deps.setdefault(child, set()).add(parent)
+
     def _invalidate_with_dependents(self, key: str) -> None:
-        """Invalidate cache for a key and all cells that depend on it (transitively)."""
-        to_invalidate = {key}
-        queue = [key]
-        while queue:
-            current = queue.pop(0)
-            for dependent in self.graph.get_dependents(current):
-                if dependent not in to_invalidate:
-                    to_invalidate.add(dependent)
-                    queue.append(dependent)
-        for k in to_invalidate:
-            self._cache.pop(k, None)
+        """Invalidate cache for a key and all cells that depend on it (transitively).
+
+        Walks runtime dependency edges recorded during evaluation rather than the
+        static graph edges, so dependents reached through a shifted dynamic-ref
+        resolution are invalidated. Invalidated cells drop their outgoing edges so
+        the current dependency chain is re-recorded on recompute.
+        """
+        to_visit = [key]
+        seen: set[str] = set()
+        while to_visit:
+            addr = to_visit.pop()
+            if addr in seen:
+                continue
+            seen.add(addr)
+            self._cache.pop(addr, None)
+            to_visit.extend(self._runtime_reverse_deps.get(addr, set()))
+            for dep in self._runtime_deps.get(addr, set()):
+                parents = self._runtime_reverse_deps.get(dep)
+                if parents is not None:
+                    parents.discard(addr)
+                    if not parents:
+                        self._runtime_reverse_deps.pop(dep, None)
+            self._runtime_deps.pop(addr, None)
+            self._runtime_reverse_deps.pop(addr, None)
 
     def _iterative_target_handler(self, addr: str) -> Callable[[EvalContext, str], CellValue]:
         def handler(_ctx: EvalContext, _target: str) -> CellValue:
@@ -193,10 +221,15 @@ class FormulaEvaluator:
         return changed
 
     def _get_transitive_leaf_dependencies(self, address: str) -> set[str]:
-        """Get all leaf nodes that this address transitively depends on."""
+        """Get all leaf nodes that this address transitively depends on.
+
+        Walks runtime dependency edges (recorded during evaluation) so the leaf
+        set reflects the currently-resolved dynamic-ref chain rather than the
+        static build-time resolution.
+        """
         leaves: set[str] = set()
         visited: set[str] = set()
-        queue = [address]
+        queue = [normalize_address(address)]
 
         while queue:
             current = queue.pop(0)
@@ -213,7 +246,7 @@ class FormulaEvaluator:
                 leaves.add(current)
             else:
                 # Add its dependencies to the queue
-                for dep in self.graph.get_dependencies(current):
+                for dep in self._runtime_deps.get(current, set()):
                     if dep not in visited:
                         queue.append(dep)
 
@@ -221,6 +254,8 @@ class FormulaEvaluator:
 
     def _evaluate_cell(self, address: str) -> CellValue:
         norm = normalize_address(address)
+        if self._call_stack:
+            self._record_runtime_dependency(self._call_stack[-1], norm)
         if norm in self._cache:
             # Lazy invalidation: check if leaf dependencies have changed
             if self.auto_detect_changes and not self.eager_invalidation:

--- a/tests/integration/evaluator/test_dynamic_ref_cache_invalidation.py
+++ b/tests/integration/evaluator/test_dynamic_ref_cache_invalidation.py
@@ -1,0 +1,120 @@
+"""Dynamic-ref cache invalidation: evaluator must follow argument-driven resolution shifts.
+
+Reproduces issue #300. With `use_cached_dynamic_refs=True` the resolved target of an
+`OFFSET`/`INDIRECT` is frozen as a static dependency edge at graph-build time. When a
+dynamic-ref *argument* changes the range the function resolves to at runtime, an
+invalidation strategy keyed on those static edges misses changes propagating through the
+newly-resolved chain, producing a silently stale result.
+
+The exported runtime (`EvalContext`) records dependencies dynamically at eval time and
+self-corrects, so this is also an evaluator <-> export parity check.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from excel_grapher import DependencyGraph, FormulaEvaluator, Node
+from excel_grapher.core import CellValue
+from excel_grapher.core.address_keys import parse_address
+from excel_grapher.runtime.cache import xl_cell
+from excel_grapher.runtime.cache_context import EvalContext
+from excel_grapher.runtime.offset_runtime import xl_offset
+
+
+def _make_node(address: str, formula: str | None, value: object) -> Node:
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=formula,
+        value=value,
+        is_leaf=formula is None,
+    )
+
+
+def _frozen_cached_offset_graph() -> DependencyGraph:
+    """Graph mirroring a `use_cached_dynamic_refs=True` build of an argument-driven OFFSET.
+
+    `S!A1 = OFFSET(S!C1, 0, S!B1)` with cached `S!B1 = 0` freezes the resolved-target edge
+    to `S!C1`. `S!D1 = S!X1 * 2` is an independent in-graph chain that the OFFSET resolves
+    onto once `S!B1` becomes 1 (column C + 1 -> column D).
+    """
+    graph = DependencyGraph()
+    for node in (
+        _make_node("S!X1", None, 5),
+        _make_node("S!D1", "=S!X1*2", 10),
+        _make_node("S!C1", None, 100),
+        _make_node("S!B1", None, 0),
+        _make_node("S!A1", "=OFFSET(S!C1, 0, S!B1)", 100),
+    ):
+        graph.add_node(node)
+    # Frozen build-time edges at cached B1 = 0 (resolved target = C1) plus the OFFSET arg.
+    graph.add_edge("S!A1", "S!C1")
+    graph.add_edge("S!A1", "S!B1")
+    # Independent chain that the runtime resolution shifts onto when B1 -> 1.
+    graph.add_edge("S!D1", "S!X1")
+    return graph
+
+
+def _evaluator_sequence() -> list[object]:
+    """Drive the evaluator through the argument-shift -> dependency-change sequence."""
+    graph = _frozen_cached_offset_graph()
+    values: list[object] = []
+    with FormulaEvaluator(graph) as ev:
+        values.append(ev.evaluate("S!A1"))  # B1 = 0 -> resolves C1 = 100
+        graph.set_node_value("S!B1", 1)
+        values.append(ev.evaluate("S!A1"))  # B1 = 1 -> resolves D1 = X1*2 = 10
+        graph.set_node_value("S!X1", 50)
+        values.append(ev.evaluate("S!A1"))  # D1 now 100, so A1 must recompute to 100
+    return values
+
+
+def _exported_runtime_resolver() -> Callable[[str], Callable[[EvalContext], CellValue] | None]:
+    """Resolver mirroring exported code: dynamic OFFSET + an independent `D1 = X1*2` chain.
+
+    Uses the same `excel_grapher.runtime` primitives the exporter embeds. `xl_offset`
+    fetches its resolved target via `xl_cell`, so the runtime dependency edge follows the
+    argument-driven shift, exactly as generated standalone code does.
+    """
+
+    def _a1(ctx: EvalContext) -> CellValue:
+        # Base S!C1 = (sheet "S", row 1, col 3); column offset read from S!B1.
+        return xl_offset(ctx, ("S", 1, 3), 0, xl_cell(ctx, "S!B1"))
+
+    def _d1(ctx: EvalContext) -> CellValue:
+        factor = xl_cell(ctx, "S!X1")
+        assert isinstance(factor, (int, float))
+        return factor * 2
+
+    impls: dict[str, Callable[[EvalContext], CellValue]] = {"S!A1": _a1, "S!D1": _d1}
+    return impls.get
+
+
+def _exported_sequence() -> list[object]:
+    """Drive the library export runtime through the same input-change sequence."""
+    ctx = EvalContext(
+        inputs={"S!C1": 100, "S!B1": 0, "S!X1": 5},
+        resolver=_exported_runtime_resolver(),
+    )
+    values: list[object] = []
+    values.append(xl_cell(ctx, "S!A1"))  # B1 = 0 -> resolves C1 = 100
+    ctx.set_inputs({"S!B1": 1})
+    values.append(xl_cell(ctx, "S!A1"))  # B1 = 1 -> resolves D1 = X1*2 = 10
+    ctx.set_inputs({"S!X1": 50})
+    values.append(xl_cell(ctx, "S!A1"))  # D1 now 100, so A1 must recompute to 100
+    return values
+
+
+def test_evaluator_follows_argument_driven_resolution_shift() -> None:
+    """Changing an input through the shifted dependency chain must recompute the OFFSET cell."""
+    assert _evaluator_sequence() == [100, 10, 100]
+
+
+def test_dynamic_ref_invalidation_matches_exported_runtime() -> None:
+    """Evaluator and exported runtime agree across the argument-shift sequence (parity)."""
+    assert _evaluator_sequence() == _exported_sequence()


### PR DESCRIPTION
## Summary

Fixes #300. Under `use_cached_dynamic_refs=True`, an `OFFSET`/`INDIRECT`'s resolved target is frozen as a **static** dependency edge at graph-build time. `FormulaEvaluator` invalidated its cache by walking those static edges, so when a dynamic-ref **argument** shifted the resolved range at runtime, invalidation missed changes propagating through the newly-resolved chain — producing a **silently stale result**. The exported `EvalContext` records dependencies dynamically at eval time and self-corrects, so this was also an **evaluator ↔ export parity** divergence.

- Record **runtime dependency edges** (`_runtime_deps` / `_runtime_reverse_deps`) as cells are evaluated, captured at the top of `_evaluate_cell` (before the cache check), keyed on the current call-stack parent.
- `_invalidate_with_dependents` now walks those runtime reverse edges and drops an invalidated cell's outgoing edges so the current chain is re-recorded on recompute — the same algorithm as `EvalContext.invalidate`.
- `_get_transitive_leaf_dependencies` (lazy-invalidation mode) walks runtime edges too, so the dynamic-shift correctness holds on that path as well.

This is the parity-correct direction from the issue: the evaluator now tracks the same currently-resolved dependency chain the exported runtime does.

### #138 warning
The `use_cached_dynamic_refs` `UserWarning` already describes only the intended raise/uncomputable behavior (no mention of stale results), and an existing test asserts `"stale" not in message`. No text change was needed — the fix makes that promise actually hold (in-graph shifts recompute correctly; out-of-graph shifts still raise).

## Test plan

Added `tests/integration/evaluator/test_dynamic_ref_cache_invalidation.py` (written RED first, per TDD):

- [x] `test_evaluator_follows_argument_driven_resolution_shift` — reproduces the silent-staleness case: sequence returns `[100, 10, 100]` (was `[100, 10, 10]`).
- [x] `test_dynamic_ref_invalidation_matches_exported_runtime` — drives the library export runtime (`EvalContext` + `xl_offset` + `xl_cell` + `set_inputs`) through the same input-change sequence and asserts parity.
- [x] Full suite: **1549 passed, 4 xfailed**.
- [x] `ruff` (lint + format) and `ty` clean; commitizen check passed.