### PR TITLE
feat(exporter): emit list_setters/list_computes discovery helpers

### DIFF
--- a/examples/micro_workbooks/series_bindings.md
+++ b/examples/micro_workbooks/series_bindings.md
@@ -271,9 +271,10 @@ print(
 
 Passing the same binding into `CodeGenerator` appends a
 `set_borvelia_primary_balance` function. Callers pass **`SeriesInput`**:
-`list[dict]` records, a 1D iterable of measure values (single-key series), or a tidy
-pandas/polars `DataFrame` with binding `key` columns plus `OBS_VALUE`. The setter
-writes into the graph’s input map via `EvalContext.set_inputs`.
+`list[dict]` records, a 1D iterable of measure values (single-key
+series), or a tidy pandas/polars `DataFrame` with binding `key` columns
+plus `OBS_VALUE`. The setter writes into the graph’s input map via
+`EvalContext.set_inputs`.
 
 ``` python
 from excel_grapher.exporter import CodeGenerator
@@ -302,10 +303,10 @@ def set_borvelia_primary_balance(
 
 ### Calling the setter
 
-In an exported model, the generated setter is imported and called like any other
-package function. `ctx` is always required. For this binding, input needs only
-`TIME_PERIOD` and `OBS_VALUE` — not `REF_AREA` or `INDICATOR` (those come from the
-binding manifest).
+In an exported model, the generated setter is imported and called like
+any other package function. `ctx` is always required. For this binding,
+input needs only `TIME_PERIOD` and `OBS_VALUE` — not `REF_AREA` or
+`INDICATOR` (those come from the binding manifest).
 
 **Records:**
 
@@ -330,8 +331,9 @@ set_borvelia_primary_balance(ctx, [-2.0, -1.0, 0.0, 7.5, 8.0])
 
 **Tidy DataFrame** (pandas or polars, if installed):
 
-See [setter_dataframe_example.py](setter_dataframe_example.py) for a runnable script. In short,
-pass a tidy table with binding `key` columns plus `OBS_VALUE` only:
+See [setter_dataframe_example.py](setter_dataframe_example.py) for a
+runnable script. In short, pass a tidy table with binding `key` columns
+plus `OBS_VALUE` only:
 
 ``` python
 import pandas as pd
@@ -340,7 +342,8 @@ df = pd.DataFrame({"TIME_PERIOD": [4, 5], "OBS_VALUE": [7.5, 8.0]})
 set_borvelia_primary_balance(ctx, df)
 ```
 
-**Wide grid → tidy** (caller responsibility; setters do not accept wide grids):
+**Wide grid → tidy** (caller responsibility; setters do not accept wide
+grids):
 
 ``` python
 # One indicator row, periods as columns:
@@ -348,17 +351,22 @@ tidy = df_wide.T.reset_index().rename(columns={"index": "TIME_PERIOD", 0: "OBS_V
 set_borvelia_primary_balance(ctx, tidy)
 ```
 
-The notebook verifies records and positional input against dynamically executed codegen:
+The notebook below verifies records and positional input against
+dynamically executed codegen:
 
 ``` text
 Sheet1!I5 after records: 7.5
 Sheet1!J5 after records: 8.0
+```
+
+``` text
 Sheet1!I5 after positional: 7.5
 Sheet1!J5 after positional: 8.0
 ```
 
-Periods **4** and **5** correspond to columns I and J. Records and positional input
-both update those leaves without requiring sheet addresses in the input.
+Periods **4** and **5** correspond to columns I and J. Records and
+positional input both update those leaves without requiring sheet
+addresses in the input.
 
 ### Structured docstring callback
 
@@ -418,7 +426,7 @@ Updates workbook inputs from Records.
 Records match cells by key fields.
 
 Args:
-    records (Records): Records to apply to the workbook inputs.
+    records (SeriesInput): A list of records, a single record dict, a tidy pandas/polars DataFrame, or a 1-D iterable of measure values in key order.
         Required record fields:
             - TIME_PERIOD: Value for TIME_PERIOD.
             - OBS_VALUE: Value for OBS_VALUE.
@@ -440,6 +448,8 @@ Examples:
         {'TIME_PERIOD': 1, 'OBS_VALUE': -1.0},
         {'TIME_PERIOD': 2, 'OBS_VALUE': -0.5},
     ])
+
+    set_borvelia_primary_balance(ctx, [-1.0, -0.5])
 ```
 
 ### Output series
@@ -551,6 +561,25 @@ such as `REF_AREA` and `UNIT_MEASURE` from the binding. Address-keyed
 `compute_all(ctx=ctx)` remains available for the full target map;
 `compute_borvelia_primary_balance` is the tabular, dimension-keyed view
 of this series only.
+
+### Discovering the generated API
+
+The generated module also exposes two zero-argument discovery helpers,
+`list_setters()` and `list_computes()`. They return the names of the
+emitted `set_*` and `compute_*` functions, so tooling can enumerate the
+series API without parsing source:
+
+``` python
+from exported_model import list_setters, list_computes
+
+list_setters()   # ["set_borvelia_primary_balance"]
+list_computes()  # ["compute_borvelia_primary_balance"]
+```
+
+``` text
+list_setters():  ['set_borvelia_primary_balance']
+list_computes(): ['compute_borvelia_primary_balance']
+```
 
 ### Modular exports
 

--- a/examples/micro_workbooks/series_bindings.qmd
+++ b/examples/micro_workbooks/series_bindings.qmd
@@ -409,6 +409,27 @@ print(records_markdown_table(records))
 
 After the setter runs, period **4** and **5** records reflect the updated input values (`7.5` and `8.0`) while still carrying dimensions such as `REF_AREA` and `UNIT_MEASURE` from the binding. Address-keyed `compute_all(ctx=ctx)` remains available for the full target map; `compute_borvelia_primary_balance` is the tabular, dimension-keyed view of this series only.
 
+### Discovering the generated API
+
+The generated module also exposes two zero-argument discovery helpers, `list_setters()` and `list_computes()`. They return the names of the emitted `set_*` and `compute_*` functions, so tooling can enumerate the series API without parsing source:
+
+```python
+from exported_model import list_setters, list_computes
+
+list_setters()   # ["set_borvelia_primary_balance"]
+list_computes()  # ["compute_borvelia_primary_balance"]
+```
+
+```{python}
+#| echo: false
+print(
+    "```text\n"
+    f"list_setters():  {namespace['list_setters']()}\n"
+    f"list_computes(): {namespace['list_computes']()}\n"
+    "```\n"
+)
+```
+
 ### Modular exports
 
 For package-style exports, generated series setters and output compute functions are emitted from the package entrypoint and re-exported from the package root. This keeps the callable surface next to `make_context` and `compute_all`:

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -555,15 +555,30 @@ class CodeGenerator:
         )
 
     @staticmethod
-    def _emitted_function_names(lines: Sequence[str]) -> list[str]:
-        names: list[str] = []
-        for line in lines:
-            if not line.startswith("def "):
-                continue
-            name, _open_paren, _rest = line[4:].partition("(")
-            if name:
-                names.append(name)
-        return names
+    def _series_binding_public_names(
+        bindings: WorkbookSeriesBindings,
+    ) -> tuple[list[str], list[str]]:
+        """Return declared public setter and compute function names."""
+        from excel_grapher.series_bindings.workflow import compute_names, setter_names
+
+        return setter_names(bindings), compute_names(bindings)
+
+    @staticmethod
+    def _emit_series_binding_discovery_lines(
+        setter_names: Sequence[str],
+        compute_names: Sequence[str],
+    ) -> list[str]:
+        """Emit generated-code helpers that list public series-binding functions."""
+        return [
+            "def list_setters() -> list[str]:",
+            '    """Return generated series-binding setter function names."""',
+            f"    return {list(setter_names)!r}",
+            "",
+            "",
+            "def list_computes() -> list[str]:",
+            '    """Return generated series-binding compute function names."""',
+            f"    return {list(compute_names)!r}",
+        ]
 
     def _range_addresses_2d(self, start: str, end: str) -> list[list[str]]:
         """Generate all cell addresses in a range as a 2D list (rows x cols)."""
@@ -1933,9 +1948,9 @@ class CodeGenerator:
         )
 
         # Generate entry point helpers
-        lines.append("def make_context(inputs=None):")
+        lines.append("def make_context(inputs: dict[str, object] | None = None) -> EvalContext:")
         lines.append('    """Create an EvalContext with merged inputs."""')
-        lines.append("    merged = dict(DEFAULT_INPUTS)")
+        lines.append("    merged: dict[str, object] = dict(DEFAULT_INPUTS)")
         if parts["has_constants"]:
             lines.append("    merged.update(CONSTANTS)")
         lines.append("    if inputs is not None:")
@@ -1949,9 +1964,14 @@ class CodeGenerator:
         )
         lines.append("")
         lines.append("")
+        series_setter_names: list[str] = []
+        series_compute_names: list[str] = []
         if series_bindings is not None:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
+            series_setter_names, series_compute_names = self._series_binding_public_names(
+                series_bindings
+            )
             lines.extend(
                 self._emit_series_binding_setters(
                     series_bindings,
@@ -1963,13 +1983,24 @@ class CodeGenerator:
                 )
             )
             lines.append("")
+        lines.extend(
+            self._emit_series_binding_discovery_lines(
+                series_setter_names,
+                series_compute_names,
+            )
+        )
+        lines.append("")
+        lines.append("")
         lines.append("TARGETS = {")
         for target, handler in self._targets_to_entries(normalized_targets):
             lines.append(f"    {repr(target)}: {handler},")
         lines.append("}")
         lines.append("")
         lines.append("")
-        lines.append("def compute_all(ctx=None, *, inputs=None):")
+        lines.append(
+            "def compute_all(ctx: EvalContext | None = None, *, "
+            "inputs: dict[str, object] | None = None) -> dict[str, object]:"
+        )
         lines.append('    """Compute all target cells and return results."""')
         lines.append("    if ctx is None:")
         lines.append("        ctx = make_context(inputs)")
@@ -2091,9 +2122,9 @@ class CodeGenerator:
             "import warnings",
             "",
             "",
-            "def make_context(inputs=None):",
+            "def make_context(inputs: dict[str, object] | None = None) -> EvalContext:",
             '    """Create an EvalContext with merged inputs."""',
-            "    merged = dict(DEFAULT_INPUTS)",
+            "    merged: dict[str, object] = dict(DEFAULT_INPUTS)",
             "    merged.update(CONSTANTS)",
             "    if inputs is not None:",
             "        merged.update(inputs)",
@@ -2108,6 +2139,7 @@ class CodeGenerator:
             "",
         ]
         series_setter_names: list[str] = []
+        series_compute_names: list[str] = []
         api_helpers_py: str | None = None
         if series_bindings is not None:
             if bindings_workbook is None:
@@ -2130,8 +2162,18 @@ class CodeGenerator:
                 if helper_imports:
                     api_lines.insert(4, f"from ._api_helpers import {', '.join(helper_imports)}")
             api_lines.extend(setter_lines)
-            series_setter_names = self._emitted_function_names(setter_lines)
+            series_setter_names, series_compute_names = self._series_binding_public_names(
+                series_bindings
+            )
             api_lines.append("")
+        api_lines.extend(
+            self._emit_series_binding_discovery_lines(
+                series_setter_names,
+                series_compute_names,
+            )
+        )
+        api_lines.append("")
+        api_lines.append("")
         api_lines.append("TARGETS = {")
         for target, handler in targets_entries:
             api_lines.append(f"    {repr(target)}: {handler},")
@@ -2140,7 +2182,8 @@ class CodeGenerator:
                 "}",
                 "",
                 "",
-                "def compute_all(ctx=None, *, inputs=None):",
+                "def compute_all(ctx: EvalContext | None = None, *, "
+                "inputs: dict[str, object] | None = None) -> dict[str, object]:",
                 '    """Compute all target cells and return results."""',
                 "    if ctx is None:",
                 "        ctx = make_context(inputs)",
@@ -2160,8 +2203,9 @@ class CodeGenerator:
         )
         api_py = "\n".join(api_lines)
 
-        api_exports = ["compute_all", "make_context"]
+        api_exports = ["compute_all", "make_context", "list_setters", "list_computes"]
         api_exports.extend(series_setter_names)
+        api_exports.extend(series_compute_names)
         api_imports = ", ".join(api_exports)
         all_exports = api_exports + ["DEFAULT_INPUTS"]
         init_py = "\n".join(

--- a/tests/fixtures/dep_tracking_baseline/baseline.json
+++ b/tests/fixtures/dep_tracking_baseline/baseline.json
@@ -1,10 +1,10 @@
 {
-  "version": 4,
+  "version": 5,
   "minimal_non_iterative_export": {
     "workload": "S!A1 leaf + S!B1 = S!A1+1",
-    "total_export_lines": 460,
+    "total_export_lines": 470,
     "embedded_runtime_lines": 400,
-    "embedded_runtime_share_pct": 87.0,
+    "embedded_runtime_share_pct": 85.1,
     "cache_eval_scaffold_lines": 54,
     "dep_tracking_lines": 0
   },

--- a/tests/integration/exporter/test_codegen_export_modular.py
+++ b/tests/integration/exporter/test_codegen_export_modular.py
@@ -96,6 +96,32 @@ def test_codegen_generate_modules_api_uses_target_map(tmp_path: Path) -> None:
     )
 
 
+def test_codegen_generate_modules_emits_empty_discovery_helpers(tmp_path: Path) -> None:
+    graph = _make_graph(_make_node("Sheet1!A1", None, 10.0))
+    files = CodeGenerator(graph).generate_modules(["Sheet1!A1"])
+
+    api_py = files["api.py"]
+    init_py = files["__init__.py"]
+    assert "def list_setters() -> list[str]:" in api_py
+    assert "def list_computes() -> list[str]:" in api_py
+    assert "list_setters" in init_py
+    assert "list_computes" in init_py
+
+    pkg_dir = tmp_path / "exported_discovery"
+    for filename, content in files.items():
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        pkg = importlib.import_module("exported_discovery")
+        assert pkg.list_setters() == []
+        assert pkg.list_computes() == []
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("exported_discovery", None)
+
+
 def test_codegen_generate_modules_splits_constants(tmp_path: Path) -> None:
     graph = _make_graph(
         _make_node("Sheet1!A1", None, 10.0),

--- a/tests/integration/user_flows/test_series_bindings_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_codegen.py
@@ -102,10 +102,16 @@ def test_codegen_includes_setters_and_updates_inputs(workbook: Path) -> None:
     ns: dict[str, object] = {}
     exec(code, ns)
     make_context = cast(Callable[[], Any], ns["make_context"])
+    list_setters = cast(Callable[[], list[str]], ns["list_setters"])
+    list_computes = cast(Callable[[], list[str]], ns["list_computes"])
     set_borvelia_primary_balance = cast(
         Callable[[Any, list[dict[str, object]]], None],
         ns["set_borvelia_primary_balance"],
     )
+
+    assert list_setters() == ["set_borvelia_primary_balance"]
+    assert list_computes() == []
+
     ctx = make_context()
     set_borvelia_primary_balance(ctx, [{"TIME_PERIOD": 4, "OBS_VALUE": 7.5}])
     assert ctx.inputs["Sheet1!I5"] == 7.5

--- a/tests/integration/user_flows/test_series_bindings_output_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_output_codegen.py
@@ -110,16 +110,23 @@ def test_codegen_includes_output_compute_and_setter(workbook: Path) -> None:
 
     assert "def set_borvelia_primary_balance(" in code
     assert "def compute_borvelia_primary_balance(" in code
+    assert "def list_setters() -> list[str]:" in code
+    assert "def list_computes() -> list[str]:" in code
     assert "Record = dict[str, object]" in code
     assert "-> Records:" in code
 
     ns: dict[str, object] = {}
     exec(code, ns)
     make_context = cast(Callable[[], Any], ns["make_context"])
+    list_setters = cast(Callable[[], list[str]], ns["list_setters"])
+    list_computes = cast(Callable[[], list[str]], ns["list_computes"])
     setter = cast(
         Callable[[Any, list[dict[str, object]]], None], ns["set_borvelia_primary_balance"]
     )
     compute = cast(Callable[..., list[dict[str, object]]], ns["compute_borvelia_primary_balance"])
+
+    assert list_setters() == ["set_borvelia_primary_balance"]
+    assert list_computes() == ["compute_borvelia_primary_balance"]
 
     ctx = make_context()
     setter(ctx, [{"TIME_PERIOD": 4, "OBS_VALUE": 7.5}])
@@ -179,7 +186,11 @@ def test_generate_modules_exports_output_compute(
         bindings_workbook=workbook,
     )
     assert "def compute_borvelia_primary_balance(" in files["api.py"]
+    assert "def list_setters() -> list[str]:" in files["api.py"]
+    assert "def list_computes() -> list[str]:" in files["api.py"]
     assert "compute_borvelia_primary_balance" in files["__init__.py"]
+    assert "list_setters" in files["__init__.py"]
+    assert "list_computes" in files["__init__.py"]
     assert "Record" in files["api.py"]
 
     pkg_dir = tmp_path / "exported_series_output"
@@ -191,6 +202,8 @@ def test_generate_modules_exports_output_compute(
     try:
         pkg = importlib.import_module("exported_series_output")
         ctx = pkg.make_context()
+        assert pkg.list_setters() == ["set_borvelia_primary_balance"]
+        assert pkg.list_computes() == ["compute_borvelia_primary_balance"]
         records = pkg.compute_borvelia_primary_balance(ctx=ctx)
         assert len(records) == 5
         assert all("OBS_VALUE" in r for r in records)

--- a/tests/integration/utils/parity_harness.py
+++ b/tests/integration/utils/parity_harness.py
@@ -263,7 +263,7 @@ DEP_TRACKING_CALL_MARKERS = frozenset(
 )
 
 # Baseline for non-iterative minimal export (S!A1 leaf + S!B1 formula).
-DEP_TRACKING_BASELINE_VERSION = 4
+DEP_TRACKING_BASELINE_VERSION = 5
 SLIM_CACHE_EVAL_SCAFFOLD_LINE_BUDGET = 54
 
 

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -1,5 +1,8 @@
 """Tests for codegen module."""
 
+from collections.abc import Callable
+from typing import cast
+
 import pytest
 
 from excel_grapher import DependencyGraph, Node
@@ -738,8 +741,24 @@ class TestCodeGeneratorContextManager:
         graph = _make_graph(_make_node("Sheet1!A1", None, 100.0))
         gen = CodeGenerator(graph)
         code = gen.generate(["Sheet1!A1"])
-        assert "def compute_all(ctx=None, *, inputs=None):" in code
+        assert (
+            "def compute_all(ctx: EvalContext | None = None, *, "
+            "inputs: dict[str, object] | None = None) -> dict[str, object]:"
+        ) in code
         assert "'Sheet1!A1'" in code
+
+    def test_generate_includes_empty_series_binding_discovery_helpers(self):
+        """Generated code should expose discovery helpers even without bindings."""
+        graph = _make_graph(_make_node("Sheet1!A1", None, 100.0))
+        code = CodeGenerator(graph).generate(["Sheet1!A1"])
+
+        namespace: dict[str, object] = {}
+        exec(code, namespace)
+        list_setters = cast(Callable[[], list[str]], namespace["list_setters"])
+        list_computes = cast(Callable[[], list[str]], namespace["list_computes"])
+
+        assert list_setters() == []
+        assert list_computes() == []
 
     def test_generate_entrypoint_uses_target_map(self):
         """Generated compute_all should iterate a shared targets map."""
@@ -793,7 +812,10 @@ class TestGenerateNamedRanges:
             _make_node("Sheet1!C1", "=Sheet1!B1+1", None),
         )
         code = CodeGenerator(graph).generate(["OneCell"])
-        assert "def compute_all(ctx=None, *, inputs=None):" in code
+        assert (
+            "def compute_all(ctx: EvalContext | None = None, *, "
+            "inputs: dict[str, object] | None = None) -> dict[str, object]:"
+        ) in code
         assert "'Sheet1!C1': xl_cell" in code
 
     def test_generate_expands_defined_name_range(self):

--- a/tests/unit/exporter/test_dep_tracking_codegen_emission.py
+++ b/tests/unit/exporter/test_dep_tracking_codegen_emission.py
@@ -6,7 +6,7 @@ Non-iterative exports without input-direction series bindings omit ``deps`` /
 
 Minimal non-iterative export baseline (``S!A1`` leaf + ``S!B1`` formula):
 
-- **460 total lines**; embedded runtime **400 lines** (~87% of export)
+- **470 total lines**; embedded runtime **400 lines** (~85% of export)
 - **0 dep-tracking lines**
 - **54 cache-eval scaffold lines** (``_evaluate_address``, ``xl_cell``, ``xl_eval``)
 

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -433,7 +433,15 @@ set_borvelia_primary_balance(ctx, [{"TIME_PERIOD": 3, "OBS_VALUE": -0.5}])
 results = compute_all(ctx=ctx)
 ```
 
-For modular package exports, generated series setters are emitted from the package entrypoint and re-exported from the package root, alongside `make_context` and `compute_all`.
+The generated module also exposes two zero-argument discovery helpers for enumerating the series
+API without parsing source:
+
+```python
+list_setters()   # ["set_borvelia_primary_balance"]
+list_computes()  # ["compute_borvelia_primary_balance"]
+```
+
+For modular package exports, generated series setters and output compute functions are emitted from the package entrypoint and re-exported from the package root, alongside `make_context`, `compute_all`, `list_setters`, and `list_computes`.
 
 ## Command-line validation
 

--- a/user_guide/06-export.qmd
+++ b/user_guide/06-export.qmd
@@ -25,6 +25,12 @@ For a multi-file package, `generate_modules()` returns a `dict[str, str]` keyed 
 (`__init__.py`, `api.py`, `data.py`, `runtime.py`, `internals.py`). Write those files into a package
 directory of your choice, then import the package as usual.
 
+Every export — single-file and modular — also emits two zero-argument discovery helpers,
+`list_setters()` and `list_computes()`, that return the names of the generated series-binding
+`set_*` and `compute_*` functions (empty lists when no series bindings are supplied). In the
+modular build they live in `api.py` and are re-exported from the package root, so downstream
+tooling can enumerate the generated callable surface without parsing source.
+
 ## Series bindings
 
 Optional sidecar manifests (`.bindings.yaml`) declare structured input/output APIs on exported code.
@@ -141,67 +147,47 @@ graph simplification; prefer projections for export and viz workflows.
 
 ## Exported code sketch
 
-A (truncated) sketch of the exported code:
+Build a tiny two-cell graph (`S!A1` leaf, `S!B1 = S!A1*2`) and generate standalone code:
 
-```python
-"""Standalone runtime for generated Excel formula code."""
+```{python}
+from excel_grapher import DependencyGraph, Node
+from excel_grapher.exporter import CodeGenerator
 
-from __future__ import annotations
+graph = DependencyGraph()
+graph.add_node(
+    Node(sheet="S", column="A", row=1, formula=None, normalized_formula=None, value=10.0, is_leaf=True)
+)
+graph.add_node(
+    Node(sheet="S", column="B", row=1, formula="=S!A1*2", normalized_formula="=S!A1*2", value=None, is_leaf=False)
+)
+graph.add_edge("S!B1", "S!A1")
 
-from enum import Enum
+code = CodeGenerator(graph).generate(["S!B1"])
+```
 
+The exported module opens with the embedded `xl_*` runtime (a few hundred lines, elided here).
+The workbook-specific tail below shows the shape of the output: leaf cells become `DEFAULT_INPUTS`
+data, formula cells become `ctx`-taking functions dispatched through a `TARGETS` map, and the public
+entry points are `make_context`, `compute_all`, and the series-binding discovery helpers
+`list_setters` / `list_computes`:
 
-class XlError(str, Enum):
-    """Excel error values."""
-    VALUE = "#VALUE!"
-    REF = "#REF!"
-    DIV = "#DIV/0!"
-    NA = "#N/A"
-    NAME = "#NAME?"
-    NUM = "#NUM!"
-    NULL = "#NULL!"
+```{python}
+# | echo: false
+from IPython.display import Markdown, display
 
-
-def to_number(value) -> float | XlError:
-    ...
-
-
-def xl_mul(left, right) -> float | XlError:
-    ...
-
-
-from functools import lru_cache
-
-
-# --- Cell functions ---
-
-@lru_cache(maxsize=None)
-def cell_s_a1():
-    """Leaf cell: S!A1"""
-    return 10
-
-
-@lru_cache(maxsize=None)
-def cell_s_b1():
-    """Formula: =A1*2"""
-    return xl_mul(cell_s_a1(), 2.0)
-
-
-def compute_all():
-    """Compute all target cells and return results."""
-    return {
-        "S!B1": cell_s_b1(),
-    }
+_lines = code.splitlines()
+_start = next(i for i, line in enumerate(_lines) if line.startswith("DEFAULT_INPUTS"))
+display(Markdown("```python\n" + "\n".join(_lines[_start:]) + "\n```"))
 ```
 
 ### Exported code results
 
-```python
+The generated module is plain Python; execute it and call `compute_all()`:
+
+```{python}
 namespace: dict = {}
 exec(code, namespace)
-generated_results = namespace["compute_all"]()
-print(generated_results)
-# {'S!B1': 20.0}
+namespace["compute_all"]()
 ```
 
 **Tradeoffs for the exported-code approach:**


### PR DESCRIPTION
## Summary

Closes #304.

- `CodeGenerator.generate()` and `generate_modules()` now emit two zero-argument discovery helpers into the exported module: `list_setters()` and `list_computes()`, returning the names of the generated series-binding `set_*` / `compute_*` functions (empty lists when no bindings are supplied). In the modular build they live in `api.py` and are re-exported from the package root alongside `make_context` / `compute_all`.
- The generated entry points `make_context`, `compute_all`, `list_setters`, and `list_computes` are now type-annotated. The generated `merged` inputs dict is typed as `dict[str, object]` so the emitted code stays `ty`-clean (avoids a `MutableMapping.update` overload error and a cascading redundant-cast warning).
- Naming note: the issue text says `list_computers`; we shipped `list_computes` to match the codebase's existing "computes" vocabulary (`compute_names`, `result["computes"]`, `compute_*`).

## Docs

- Documented the new emission in `user_guide/06-export.qmd` and `user_guide/05-series-bindings.qmd`.
- Added a live demo of the helpers to the `series_bindings` micro-workbook example (re-rendered `.md`).
- Replaced the stale (pre-`EvalContext`) "exported code sketch" in the export guide with a live, executed cell that shows the real generated tail.

## Implementation notes

- The dep-tracking baseline shifted (the helpers add ~10 lines per export): `total_export_lines` 460 → 470, embedded-runtime share 87.0% → 85.1%; baseline `version` bumped 4 → 5.

## Test plan

- [x] `uv run pytest` (full suite): 1551 passed, 4 xfailed
- [x] `uv run pre-commit run --all-files`: ruff check, ruff format, ty all pass
- [x] Generated-code `ty`/no-diagnostics regression tests pass (single-file + modular)
- [x] New coverage: empty discovery helpers (single-file + modular non-binding), setters-present/computes-empty partitioning, and setter+compute round trip
- [x] Rendered `user_guide/06-export.qmd` and `examples/micro_workbooks/series_bindings.qmd` cells execute cleanly