### PR TITLE
feat(series_bindings): grouped-row matrix geometry (schema 1.5.0)

### DIFF
--- a/excel_grapher/series_bindings/geometry.py
+++ b/excel_grapher/series_bindings/geometry.py
@@ -1,0 +1,131 @@
+"""Row and column geometry specs for series-binding label binds.
+
+Specs appear in bind-level `skip`/`include` lists, series-level
+`exclude_rows`, and `value_map` values. A row spec is a 1-based integer or an
+inclusive `"first:last"` string; a column spec is a column letter or an
+inclusive `"C:D"` string.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal
+
+from fastpyxl.utils import column_index_from_string
+
+__all__ = [
+    "expand_column_specs",
+    "expand_row_specs",
+    "parse_value_map",
+]
+
+_ROW_SPEC_RE = re.compile(r"^([1-9][0-9]*)(?::([1-9][0-9]*))?$")
+_COLUMN_SPEC_RE = re.compile(r"^([A-Z]{1,3})(?::([A-Z]{1,3}))?$")
+
+Axis = Literal["rows", "columns"]
+
+
+def _expand_row_spec(spec: Any) -> set[int]:
+    if isinstance(spec, bool):
+        raise ValueError(f"Invalid row spec: {spec!r}")
+    if isinstance(spec, int):
+        if spec < 1:
+            raise ValueError(f"Invalid row spec: {spec!r} (rows are 1-based)")
+        return {spec}
+    if isinstance(spec, str):
+        match = _ROW_SPEC_RE.match(spec.strip())
+        if match is None:
+            raise ValueError(f"Invalid row spec: {spec!r} (expected N or N:M)")
+        first = int(match.group(1))
+        last = int(match.group(2)) if match.group(2) else first
+        if last < first:
+            raise ValueError(f"Invalid row spec: {spec!r} (last row before first)")
+        return set(range(first, last + 1))
+    raise ValueError(f"Invalid row spec: {spec!r}")
+
+
+def _expand_column_spec(spec: Any) -> set[int]:
+    if not isinstance(spec, str):
+        raise ValueError(f"Invalid column spec: {spec!r}")
+    match = _COLUMN_SPEC_RE.match(spec.strip())
+    if match is None:
+        raise ValueError(f"Invalid column spec: {spec!r} (expected C or C:D)")
+    first = column_index_from_string(match.group(1))
+    last = column_index_from_string(match.group(2)) if match.group(2) else first
+    if last < first:
+        raise ValueError(f"Invalid column spec: {spec!r} (last column before first)")
+    return set(range(first, last + 1))
+
+
+def expand_row_specs(specs: Iterable[Any]) -> set[int]:
+    """Expand row specs (ints and `"N:M"` strings) into a set of row indices."""
+    rows: set[int] = set()
+    for spec in specs:
+        rows |= _expand_row_spec(spec)
+    return rows
+
+
+def expand_column_specs(specs: Iterable[Any]) -> set[int]:
+    """Expand column specs (`"C"` / `"C:D"` strings) into 1-based column indices."""
+    columns: set[int] = set()
+    for spec in specs:
+        columns |= _expand_column_spec(spec)
+    return columns
+
+
+def _classify_spec(spec: Any) -> Axis:
+    if isinstance(spec, int) and not isinstance(spec, bool):
+        return "rows"
+    if isinstance(spec, str):
+        if _ROW_SPEC_RE.match(spec.strip()):
+            return "rows"
+        if _COLUMN_SPEC_RE.match(spec.strip()):
+            return "columns"
+    raise ValueError(f"Invalid value_map spec: {spec!r} (expected row or column spec)")
+
+
+def parse_value_map(values: Mapping[Any, Any]) -> tuple[Axis, dict[Any, set[int]]]:
+    """Parse a `value_map` bind's `values` mapping into per-value index sets.
+
+    The axis is inferred from the spec syntax: row specs (`3`, `"3:4"`) key
+    data rows, column specs (`"C"`, `"C:D"`) key data columns. Mixing axes or
+    assigning one row/column to two values is an error.
+
+    Returns:
+        Tuple of the inferred axis and a mapping from each manifest value to
+        the set of 1-based row or column indices it covers.
+
+    Raises:
+        ValueError: On empty maps, malformed specs, mixed axes, or overlaps.
+    """
+    if not values:
+        raise ValueError("value_map requires a non-empty values mapping")
+
+    axis: Axis | None = None
+    parsed: dict[Any, set[int]] = {}
+    claimed: dict[int, Any] = {}
+    for value, spec in values.items():
+        specs = spec if isinstance(spec, list) else [spec]
+        indices: set[int] = set()
+        for item in specs:
+            item_axis = _classify_spec(item)
+            if axis is None:
+                axis = item_axis
+            elif item_axis != axis:
+                raise ValueError(
+                    f"value_map mixes row and column specs (value {value!r}: {item!r})"
+                )
+            indices |= _expand_row_spec(item) if item_axis == "rows" else _expand_column_spec(item)
+        unit = "row" if axis == "rows" else "column"
+        for index in indices:
+            if index in claimed:
+                raise ValueError(
+                    f"value_map assigns {unit} {index} to both {claimed[index]!r} and {value!r}"
+                )
+            claimed[index] = value
+        parsed[value] = indices
+
+    if axis is None:
+        raise ValueError("value_map requires at least one row or column spec")
+    return axis, parsed

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -9,6 +9,7 @@ _STRUCTURAL_FIELDS = frozenset(
         "id",
         "sheet",
         "data_range",
+        "exclude_rows",
         "layout",
         "structure",
         "key",

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -10,11 +10,17 @@ from typing import Any, Literal
 
 import fastpyxl
 import fastpyxl.utils.cell
+from fastpyxl.utils import column_index_from_string, get_column_letter
 
 from excel_grapher.core.address_keys import format_key, parse_address
 from excel_grapher.core.address_keys import normalize_key as normalize_address
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.series_bindings.coerce import coerce_constant, coerce_scalar
+from excel_grapher.series_bindings.geometry import (
+    expand_column_specs,
+    expand_row_specs,
+    parse_value_map,
+)
 from excel_grapher.series_bindings.issues import make_issue
 from excel_grapher.series_bindings.normalize import has_input_direction, has_output_direction
 from excel_grapher.series_bindings.ranges import expand_data_range_for_graph
@@ -145,6 +151,92 @@ def _bind_resolution_issues(
     return issues
 
 
+def _is_blank_label(raw: Any) -> bool:
+    return raw is None or (isinstance(raw, str) and not raw.strip())
+
+
+def _missing_policy(bind: dict[str, Any]) -> str:
+    """Return the effective missing-label policy (`missing: null` in YAML is None)."""
+    if "missing" not in bind:
+        return "error"
+    value = bind["missing"]
+    return "null" if value is None else str(value)
+
+
+def _label_source_indices(bind: dict[str, Any], *, axis: str) -> tuple[set[int] | None, bool]:
+    """Return (allowed source indices or None for all, whether include was used)."""
+    skip = bind.get("skip")
+    include = bind.get("include")
+    if skip is not None and include is not None:
+        raise ValueError("skip and include are mutually exclusive on a bind")
+    expand = expand_row_specs if axis == "rows" else expand_column_specs
+    if include is not None:
+        return expand(include), True
+    if skip is not None:
+        return expand(skip), False
+    return None, False
+
+
+def _is_label_source(index: int, sources: set[int] | None, *, is_include: bool) -> bool:
+    if sources is None:
+        return True
+    return index in sources if is_include else index not in sources
+
+
+def _resolve_label(
+    bind: dict[str, Any],
+    *,
+    graph: DependencyGraph,
+    reader: _WorkbookValues,
+    axis: str,
+    index: int,
+    address_for: Any,
+    concept_hint: str,
+) -> Any:
+    """Read a row_label or column_header source value honoring skip/include/fill.
+
+    Args:
+        bind: The bind mapping carrying skip/include/fill/missing fields.
+        graph: Dependency graph consulted before the workbook reader.
+        reader: Lazy workbook value reader for cells outside the graph.
+        axis: `rows` for row_label (walk up) or `columns` for column_header
+            (walk left).
+        index: 1-based data row (rows axis) or data column (columns axis).
+        address_for: Callable mapping a source index to a sheet-qualified
+            address.
+        concept_hint: Bind description used in missing-label error messages.
+
+    Returns:
+        The raw label value, or None when no source label exists and the
+        bind's missing policy is `null`.
+
+    Raises:
+        ValueError: When no source label exists and the policy is `error`.
+    """
+    sources, is_include = _label_source_indices(bind, axis=axis)
+    fill = bool(bind.get("fill", False))
+
+    def source_value(candidate: int) -> Any:
+        if not _is_label_source(candidate, sources, is_include=is_include):
+            return None
+        raw = _read_cell_value(graph, reader, address_for(candidate))
+        return None if _is_blank_label(raw) else raw
+
+    raw = source_value(index)
+    if raw is None and fill:
+        for candidate in range(index - 1, 0, -1):
+            raw = source_value(candidate)
+            if raw is not None:
+                break
+
+    if raw is None:
+        if _missing_policy(bind) == "null":
+            return None
+        direction = "at or above row" if axis == "rows" else "at or left of column"
+        raise ValueError(f"{concept_hint}: no source label {direction} {index}")
+    return raw
+
+
 def _execute_bind(
     bind: dict[str, Any],
     *,
@@ -175,8 +267,17 @@ def _execute_bind(
 
     if kind == "column_header":
         header_row = int(bind["header_row"])
-        header_address = format_key(sheet, f"{col}{header_row}")
-        raw = _read_cell_value(graph, reader, header_address)
+        raw = _resolve_label(
+            bind,
+            graph=graph,
+            reader=reader,
+            axis="columns",
+            index=column_index_from_string(col),
+            address_for=lambda c: format_key(sheet, f"{get_column_letter(c)}{header_row}"),
+            concept_hint=f"column_header row {header_row}",
+        )
+        if raw is None:
+            return None
         if read_as in {"auto", "string"} and isinstance(raw, str):
             return _normalize_string(raw, normalize)
         return coerce_scalar(raw, read_as)
@@ -188,11 +289,31 @@ def _execute_bind(
 
     if kind == "row_label":
         label_column = str(bind["label_column"])
-        label_address = format_key(sheet, f"{label_column}{row}")
-        raw = _read_cell_value(graph, reader, label_address)
+        raw = _resolve_label(
+            bind,
+            graph=graph,
+            reader=reader,
+            axis="rows",
+            index=row,
+            address_for=lambda r: format_key(sheet, f"{label_column}{r}"),
+            concept_hint=f"row_label column {label_column}",
+        )
+        if raw is None:
+            return None
         if read_as in {"auto", "string"} and isinstance(raw, str):
             return _normalize_string(raw, normalize)
         return coerce_scalar(raw, read_as)
+
+    if kind == "value_map":
+        axis, mapping = parse_value_map(bind.get("values") or {})
+        index = row if axis == "rows" else column_index_from_string(col)
+        for value, indices in mapping.items():
+            if index in indices:
+                return coerce_constant(value, read_as=read_as)
+        if _missing_policy(bind) == "null":
+            return None
+        unit = "row" if axis == "rows" else "column"
+        raise ValueError(f"value_map: no value covers data {unit} {index}")
 
     raise ValueError(f"Unknown bind kind: {kind!r}")
 
@@ -201,6 +322,15 @@ def _parse_data_cell(address: str) -> tuple[str, str, int]:
     sheet, coord = parse_address(address)
     col, row = fastpyxl.utils.cell.coordinate_from_string(coord)
     return sheet, col, row
+
+
+def _apply_exclude_rows(addresses: list[str], series: dict[str, Any]) -> list[str]:
+    """Drop addresses on rows the series declares as never-data via `exclude_rows`."""
+    specs = series.get("exclude_rows")
+    if not specs:
+        return addresses
+    excluded = expand_row_specs(specs)
+    return [address for address in addresses if _parse_data_cell(address)[2] not in excluded]
 
 
 def _include_in_record(field: dict[str, Any], default: bool) -> bool:
@@ -449,6 +579,7 @@ def resolve_series_binding(
 
     try:
         expanded_addresses = expand_data_range_for_graph(graph, data_range, workbook=workbook)
+        expanded_addresses = _apply_exclude_rows(expanded_addresses, series)
     except (ValueError, TypeError) as exc:
         return {
             "series_id": series_id,

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout and row_hierarchy bind (matrix supported with explicit binds; row_hierarchy schema-valid only). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests)."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"],
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout and row_hierarchy bind (matrix supported with explicit binds; row_hierarchy schema-valid only). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry — skip/include/fill/missing on row_label and column_header binds, the value_map bind kind, and series-level exclude_rows."
     },
     "workbook": {
       "type": "string",
@@ -68,6 +68,23 @@
         { "type": "null" }
       ]
     },
+    "RowSpec": {
+      "description": "One 1-based row index, or an inclusive row range string like 3:8.",
+      "oneOf": [
+        { "type": "integer", "minimum": 1 },
+        { "type": "string", "pattern": "^[1-9][0-9]*(:[1-9][0-9]*)?$" }
+      ]
+    },
+    "ColumnSpec": {
+      "type": "string",
+      "pattern": "^[A-Z]{1,3}(:[A-Z]{1,3})?$",
+      "description": "One column letter, or an inclusive column range string like C:D."
+    },
+    "MissingPolicy": {
+      "description": "What to do when no source label exists for a data cell: error (default) fails resolution; null keys the cell on None. YAML null is accepted as a spelling of \"null\".",
+      "enum": ["error", "null", null],
+      "default": "error"
+    },
     "ReadAs": {
       "type": "string",
       "enum": ["string", "int", "float", "number", "bool", "datetime", "auto"],
@@ -118,6 +135,7 @@
         { "$ref": "#/$defs/BindCell" },
         { "$ref": "#/$defs/BindColumnHeader" },
         { "$ref": "#/$defs/BindRowLabel" },
+        { "$ref": "#/$defs/BindValueMap" },
         { "$ref": "#/$defs/BindRowHierarchy" },
         { "$ref": "#/$defs/BindConstant" }
       ]
@@ -146,6 +164,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["kind", "header_row"],
+      "not": { "required": ["skip", "include"] },
       "properties": {
         "kind": { "const": "column_header" },
         "header_row": {
@@ -153,6 +172,22 @@
           "minimum": 1,
           "description": "1-based row index containing column headers for the data columns."
         },
+        "skip": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ColumnSpec" },
+          "description": "Columns in header_row that are not label sources for this dimension. Mutually exclusive with include."
+        },
+        "include": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ColumnSpec" },
+          "description": "The only columns in header_row that are label sources for this dimension. Mutually exclusive with skip."
+        },
+        "fill": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, a data column whose header source is skipped or empty inherits the nearest non-skipped, non-empty header to its left."
+        },
+        "missing": { "$ref": "#/$defs/MissingPolicy" },
         "read": { "$ref": "#/$defs/ReadAs" },
         "normalize": { "$ref": "#/$defs/Normalize" }
       }
@@ -161,12 +196,61 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["kind", "label_column"],
+      "not": { "required": ["skip", "include"] },
       "description": "Read the label on the same row as the data cell from label_column (typical for indicator text in column A).",
       "properties": {
         "kind": { "const": "row_label" },
         "label_column": { "$ref": "#/$defs/ColumnLetter" },
+        "skip": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RowSpec" },
+          "description": "Rows in label_column that are not label sources for this dimension (e.g. group header rows for a sub-label key). Mutually exclusive with include."
+        },
+        "include": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RowSpec" },
+          "description": "The only rows in label_column that are label sources for this dimension (e.g. group header rows for a band key). Mutually exclusive with skip."
+        },
+        "fill": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, a data row whose label source is skipped or empty inherits the nearest non-skipped, non-empty label above it."
+        },
+        "missing": { "$ref": "#/$defs/MissingPolicy" },
         "read": { "$ref": "#/$defs/ReadAs" },
         "normalize": { "$ref": "#/$defs/Normalize" }
+      }
+    },
+    "BindValueMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "values"],
+      "description": "Key data rows or columns by manifest values when labels are absent from the sheet. Axis is inferred from spec syntax: row specs (3, 3:4) key data rows; column specs (C, C:D) key data columns. Map keys within one bind must share one scalar type.",
+      "properties": {
+        "kind": { "const": "value_map" },
+        "values": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "oneOf": [
+              { "$ref": "#/$defs/RowSpec" },
+              { "$ref": "#/$defs/ColumnSpec" },
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "oneOf": [
+                    { "$ref": "#/$defs/RowSpec" },
+                    { "$ref": "#/$defs/ColumnSpec" }
+                  ]
+                }
+              }
+            ]
+          },
+          "description": "Mapping from dimension value to the row or column specs it covers."
+        },
+        "missing": { "$ref": "#/$defs/MissingPolicy" },
+        "read": { "$ref": "#/$defs/ReadAs" }
       }
     },
     "BindRowHierarchy": {
@@ -365,6 +449,11 @@
         "layout": {
           "$ref": "#/$defs/Layout",
           "description": "Optional analyst-facing layout intent; triggers layout-specific schema and validation rules when set."
+        },
+        "exclude_rows": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RowSpec" },
+          "description": "Rows within data_range that are never data (e.g. group header or separator rows referenced by lookup formulas). Applied before graph-leaf intersection."
         },
         "editable": {
           "type": "boolean",

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -76,7 +76,75 @@ def _validate_bind_smoke(bind: Any, *, series_id: str, context: str) -> list[Val
                 series_id=series_id,
             )
         ]
-    return []
+    return _validate_bind_geometry(bind, series_id=series_id, context=context)
+
+
+def _validate_bind_geometry(
+    bind: dict[str, Any], *, series_id: str, context: str
+) -> list[ValidationIssue]:
+    """Statically check skip/include specs and value_map axis and overlap rules."""
+    from excel_grapher.series_bindings.geometry import (
+        expand_column_specs,
+        expand_row_specs,
+        parse_value_map,
+    )
+
+    issues: list[ValidationIssue] = []
+    kind = bind.get("kind")
+
+    if bind.get("skip") is not None and bind.get("include") is not None:
+        issues.append(
+            _issue(
+                "error",
+                "invalid_bind_geometry",
+                f"{context}: skip and include are mutually exclusive",
+                series_id=series_id,
+            )
+        )
+
+    expand = expand_row_specs if kind == "row_label" else expand_column_specs
+    if kind in {"row_label", "column_header"}:
+        for field in ("skip", "include"):
+            specs = bind.get(field)
+            if specs is None:
+                continue
+            try:
+                expand(specs)
+            except ValueError as exc:
+                issues.append(
+                    _issue(
+                        "error",
+                        "invalid_bind_geometry",
+                        f"{context}: {exc}",
+                        series_id=series_id,
+                    )
+                )
+
+    if kind == "value_map":
+        values = bind.get("values")
+        key_types = {type(key) for key in values} if isinstance(values, dict) else set()
+        if len(key_types) > 1:
+            issues.append(
+                _issue(
+                    "error",
+                    "invalid_bind_geometry",
+                    f"{context}: value_map keys must share one scalar type",
+                    series_id=series_id,
+                )
+            )
+        try:
+            parse_value_map(values or {})
+        except (ValueError, TypeError) as exc:
+            issues.append(
+                _issue(
+                    "error",
+                    "invalid_bind_geometry",
+                    f"{context}: {exc}",
+                    series_id=series_id,
+                )
+            )
+
+    return issues
 
 
 def _validate_series_structure(series: dict[str, Any]) -> list[ValidationIssue]:
@@ -98,6 +166,22 @@ def _validate_series_structure(series: dict[str, Any]) -> list[ValidationIssue]:
                     "error",
                     "sheet_mismatch",
                     f"series sheet {sheet!r} does not match data_range sheet {range_sheet!r}",
+                    series_id=series_id,
+                )
+            )
+
+    exclude_rows = series.get("exclude_rows")
+    if exclude_rows is not None:
+        from excel_grapher.series_bindings.geometry import expand_row_specs
+
+        try:
+            expand_row_specs(exclude_rows)
+        except ValueError as exc:
+            issues.append(
+                _issue(
+                    "error",
+                    "invalid_bind_geometry",
+                    f"exclude_rows: {exc}",
                     series_id=series_id,
                 )
             )

--- a/excel_grapher/series_bindings/versions.py
+++ b/excel_grapher/series_bindings/versions.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-SUPPORTED_SCHEMA_VERSIONS: frozenset[str] = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"})
+SUPPORTED_SCHEMA_VERSIONS: frozenset[str] = frozenset(
+    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"}
+)
 
 IMPLEMENTED_BIND_KINDS: frozenset[str] = frozenset(
     {
@@ -10,6 +12,7 @@ IMPLEMENTED_BIND_KINDS: frozenset[str] = frozenset(
         "cell",
         "column_header",
         "row_label",
+        "value_map",
         "constant",
     }
 )

--- a/tests/fixtures/series_bindings/grouped_matrix_helpers.py
+++ b/tests/fixtures/series_bindings/grouped_matrix_helpers.py
@@ -1,0 +1,142 @@
+"""Shared helpers for grouped-row matrix layout binding tests.
+
+Models the "Discrete Risks" band pattern: a group label (SCENARIO) appears
+once per band in column A, sub-rows carry a second row dimension (SHOCK_TYPE)
+in the same column, and a decorative blank row separates bands. A SUM formula
+references the whole block so blank rows become graph leaves, exercising
+`exclude_rows`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import xlsxwriter
+
+FIXTURES = Path(__file__).resolve().parent
+MATRIX_GROUPED_ROWS_BINDINGS = FIXTURES / "matrix_grouped_rows_1_5_0.yaml"
+
+GROUPED_MATRIX_PERIODS: tuple[int, ...] = (2024, 2025)
+
+# (row, scenario, shock_type, values) for data rows only.
+GROUPED_MATRIX_DATA_ROWS: tuple[tuple[int, str, str, list[float]], ...] = (
+    (3, "Paris", "Revenue", [1.1, 1.2]),
+    (4, "Paris", "Primary expenditure", [2.1, 2.2]),
+    (7, "Moderate", "Revenue", [3.1, 3.2]),
+    (8, "Moderate", "Primary expenditure", [4.1, 4.2]),
+)
+
+BAND_HEADER_ROWS: tuple[tuple[int, str], ...] = ((2, "Paris"), (6, "Moderate"))
+SEPARATOR_ROW = 5
+
+
+def write_grouped_matrix_workbook(path: Path) -> None:
+    """Build a banded workbook: header rows in column A, blank separator row.
+
+    Layout (data range `Inputs!C2:D8`):
+
+    ```text
+            A                     C       D
+    1                             2024    2025
+    2       Paris
+    3       Revenue               1.1     1.2
+    4       Primary expenditure   2.1     2.2
+    5
+    6       Moderate
+    7       Revenue               3.1     3.2
+    8       Primary expenditure   4.1     4.2
+    ```
+
+    `F1` sums the whole block, so even blank cells inside the data range are
+    referenced and appear as graph leaves.
+    """
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Inputs")
+    for col_offset, period in enumerate(GROUPED_MATRIX_PERIODS):
+        ws.write_number(0, 2 + col_offset, period)
+    for row, label in BAND_HEADER_ROWS:
+        ws.write(row - 1, 0, label)
+    for row, _scenario, shock_type, values in GROUPED_MATRIX_DATA_ROWS:
+        ws.write(row - 1, 0, shock_type)
+        for col_offset, value in enumerate(values):
+            ws.write_number(row - 1, 2 + col_offset, value)
+    total = sum(sum(values) for _r, _s, _k, values in GROUPED_MATRIX_DATA_ROWS)
+    ws.write_formula("F1", "=SUM(C2:D8)", None, total)
+    wb.close()
+
+
+def grouped_matrix_structure() -> dict[str, Any]:
+    """Return the grouped-row matrix structure block (banded column A)."""
+    return {
+        "measure": {
+            "concept": "OBS_VALUE",
+            "dtype": "float",
+            "bind": {"kind": "data_cell", "read": "float"},
+        },
+        "dimensions": [
+            {
+                "concept": "SCENARIO",
+                "role": "key",
+                "scope": "cell",
+                "bind": {
+                    "kind": "row_label",
+                    "label_column": "A",
+                    "include": [2, 6],
+                    "fill": True,
+                    "read": "string",
+                },
+            },
+            {
+                "concept": "SHOCK_TYPE",
+                "role": "key",
+                "scope": "cell",
+                "bind": {
+                    "kind": "row_label",
+                    "label_column": "A",
+                    "skip": [2, 6],
+                    "read": "string",
+                },
+            },
+            {
+                "concept": "TIME_PERIOD",
+                "role": "key",
+                "scope": "cell",
+                "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+            },
+        ],
+    }
+
+
+def grouped_matrix_series(**overrides: Any) -> dict[str, Any]:
+    """Return an inline grouped-row matrix series entry for tests."""
+    series: dict[str, Any] = {
+        "id": "discrete_risks",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:D8",
+        "layout": "matrix",
+        "exclude_rows": [2, "5:6"],
+        "input": {"setter": {"name": "set_discrete_risks"}},
+        "structure": grouped_matrix_structure(),
+        "key": ["SCENARIO", "SHOCK_TYPE", "TIME_PERIOD"],
+    }
+    series.update(overrides)
+    return series
+
+
+def grouped_matrix_bindings_document(**series_overrides: Any) -> dict[str, Any]:
+    """Return a binding manifest document for grouped-row matrix tests."""
+    return {
+        "schema_version": "1.5.0",
+        "workbook": "grouped_inputs.xlsx",
+        "series": [grouped_matrix_series(**series_overrides)],
+    }
+
+
+def expected_grouped_matrix_keys() -> set[tuple[str, str, int]]:
+    """Expected (SCENARIO, SHOCK_TYPE, TIME_PERIOD) composite keys."""
+    return {
+        (scenario, shock_type, period)
+        for _row, scenario, shock_type, _values in GROUPED_MATRIX_DATA_ROWS
+        for period in GROUPED_MATRIX_PERIODS
+    }

--- a/tests/fixtures/series_bindings/matrix_grouped_rows_1_5_0.yaml
+++ b/tests/fixtures/series_bindings/matrix_grouped_rows_1_5_0.yaml
@@ -1,0 +1,51 @@
+schema_version: "1.5.0"
+workbook: grouped_inputs.xlsx
+series:
+  - id: discrete_risks
+    sheet: Inputs
+    data_range: Inputs!C2:D8
+    layout: matrix
+    exclude_rows: [2, "5:6"]
+    input:
+      setter:
+        name: set_discrete_risks
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind:
+          kind: data_cell
+          read: float
+      dimensions:
+        - concept: SCENARIO
+          role: key
+          scope: cell
+          bind:
+            kind: row_label
+            label_column: A
+            include: [2, 6]
+            fill: true
+            read: string
+        - concept: SHOCK_TYPE
+          role: key
+          scope: cell
+          bind:
+            kind: row_label
+            label_column: A
+            skip: [2, 6]
+            read: string
+        - concept: TIME_PERIOD
+          role: key
+          scope: cell
+          bind:
+            kind: column_header
+            header_row: 1
+            read: int
+    key:
+      - SCENARIO
+      - SHOCK_TYPE
+      - TIME_PERIOD
+    notes: >-
+      Grouped-row matrix: SCENARIO band headers in column A (rows 2 and 6)
+      fill down over their bands; SHOCK_TYPE sub-labels share column A on the
+      data rows; header and separator rows are excluded from the data set.

--- a/tests/integration/user_flows/test_grouped_rows_matrix_bindings.py
+++ b/tests/integration/user_flows/test_grouped_rows_matrix_bindings.py
@@ -1,0 +1,39 @@
+"""Integration tests for grouped-row matrix bindings (Discrete Risks band MCVE)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from excel_grapher.series_bindings import (
+    load_series_bindings,
+    run_binding_checks,
+    validate_bindings_workbook,
+)
+from excel_grapher.series_bindings.workflow import setter_names
+from tests.fixtures.series_bindings.grouped_matrix_helpers import (
+    MATRIX_GROUPED_ROWS_BINDINGS,
+    write_grouped_matrix_workbook,
+)
+
+
+def test_grouped_rows_matrix_bindings_validate(tmp_path: Path) -> None:
+    workbook = tmp_path / "grouped_inputs.xlsx"
+    write_grouped_matrix_workbook(workbook)
+    bindings = load_series_bindings(MATRIX_GROUPED_ROWS_BINDINGS)
+    result = validate_bindings_workbook(workbook, MATRIX_GROUPED_ROWS_BINDINGS)
+    assert result["report"]["ok"] is True, result["report"]["issues"]
+    assert not any(issue["level"] == "error" for issue in result["report"]["issues"])
+    assert len(result["input_series"]) == len(setter_names(bindings))
+
+
+def test_grouped_rows_matrix_bindings_run_checks(tmp_path: Path) -> None:
+    workbook = tmp_path / "grouped_inputs.xlsx"
+    write_grouped_matrix_workbook(workbook)
+    result = run_binding_checks(
+        workbook,
+        MATRIX_GROUPED_ROWS_BINDINGS,
+        module_dir=tmp_path / "bindings_module_grouped",
+        package_name="bindings_module_grouped",
+    )
+    assert result["setters"] == ["set_discrete_risks"]
+    assert result["computes"] == []

--- a/tests/unit/series_bindings/test_grouped_rows_codegen.py
+++ b/tests/unit/series_bindings/test_grouped_rows_codegen.py
@@ -1,0 +1,84 @@
+"""Setter codegen round-trip tests for grouped-row matrix bindings."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.runtime.cache import EvalContext, coerce_inputs_dict
+from excel_grapher.series_bindings import (
+    expand_data_range,
+    load_series_bindings,
+    resolve_series_binding,
+)
+from excel_grapher.series_bindings.setter_codegen import (
+    emit_input_coerce_helpers,
+    emit_setter_function,
+    emit_setter_helpers,
+    emit_setters_block,
+)
+from tests.fixtures.series_bindings.grouped_matrix_helpers import (
+    MATRIX_GROUPED_ROWS_BINDINGS,
+    write_grouped_matrix_workbook,
+)
+
+
+def _exec_setters(lines: list[str]) -> dict[str, object]:
+    namespace: dict[str, object] = {
+        "EvalContext": EvalContext,
+        "coerce_inputs_dict": coerce_inputs_dict,
+    }
+    source_lines = lines
+    if "def coerce_setter_input(" not in "\n".join(lines):
+        source_lines = emit_input_coerce_helpers() + emit_setter_helpers() + lines
+    exec("\n".join(source_lines), namespace)
+    return namespace
+
+
+def test_grouped_rows_matrix_setter_round_trip(tmp_path: Path) -> None:
+    wb_path = tmp_path / "grouped_inputs.xlsx"
+    write_grouped_matrix_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!C2:D8"),
+        load_values=True,
+    )
+    bindings = load_series_bindings(MATRIX_GROUPED_ROWS_BINDINGS)
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+
+    code = "\n".join(emit_setters_block(graph, wb_path, bindings))
+    assert code.count("def set_discrete_risks(") == 1
+
+    ns = _exec_setters(emit_setter_function(series, resolved))
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_discrete_risks"],
+    )
+    ctx = EvalContext(
+        inputs=coerce_inputs_dict({"Inputs!C3": 1.1}),
+        resolver=lambda _a: None,
+    )
+    setter(
+        ctx,
+        [
+            {
+                "SCENARIO": "Paris",
+                "SHOCK_TYPE": "Primary expenditure",
+                "TIME_PERIOD": 2025,
+                "OBS_VALUE": 9.9,
+            },
+            {
+                "SCENARIO": "Moderate",
+                "SHOCK_TYPE": "Revenue",
+                "TIME_PERIOD": 2024,
+                "OBS_VALUE": 8.8,
+            },
+        ],
+    )
+    assert ctx.inputs["Inputs!D4"] == 9.9
+    assert ctx.inputs["Inputs!C7"] == 8.8
+    assert ctx.inputs["Inputs!C3"] == 1.1

--- a/tests/unit/series_bindings/test_grouped_rows_resolve.py
+++ b/tests/unit/series_bindings/test_grouped_rows_resolve.py
@@ -1,0 +1,394 @@
+"""Resolution tests for grouped-row matrix geometry (schema 1.5.0).
+
+Covers `skip`/`include` label-source restriction, `fill` propagation,
+`missing` policy, the `value_map` bind kind, and series-level `exclude_rows`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import xlsxwriter
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import (
+    expand_data_range,
+    load_series_bindings,
+    resolve_series_binding,
+)
+from tests.fixtures.series_bindings.grouped_matrix_helpers import (
+    MATRIX_GROUPED_ROWS_BINDINGS,
+    expected_grouped_matrix_keys,
+    grouped_matrix_series,
+    write_grouped_matrix_workbook,
+)
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
+
+
+def _grouped_graph(tmp_path: Path) -> tuple[Path, Any]:
+    wb_path = tmp_path / "grouped_inputs.xlsx"
+    write_grouped_matrix_workbook(wb_path)
+    targets = expand_data_range("Inputs!C2:D8")
+    graph = create_dependency_graph(wb_path, targets, load_values=True)
+    return wb_path, graph
+
+
+def test_resolve_grouped_matrix_fixture(tmp_path: Path) -> None:
+    wb_path, graph = _grouped_graph(tmp_path)
+    bindings = load_series_bindings(MATRIX_GROUPED_ROWS_BINDINGS)
+    series = bindings["series"][0]
+
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+    assert resolved["requires_address"] is False
+    assert len(resolved["leaves"]) == 8
+
+    by_key = {
+        (
+            leaf["key"]["SCENARIO"],
+            leaf["key"]["SHOCK_TYPE"],
+            leaf["key"]["TIME_PERIOD"],
+        ): leaf
+        for leaf in resolved["leaves"]
+    }
+    assert set(by_key) == expected_grouped_matrix_keys()
+
+    paris_revenue_2024 = by_key[("Paris", "Revenue", 2024)]
+    assert paris_revenue_2024["address"] == "Inputs!C3"
+    assert paris_revenue_2024["coordinates"]["OBS_VALUE"] == 1.1
+
+    moderate_pe_2025 = by_key[("Moderate", "Primary expenditure", 2025)]
+    assert moderate_pe_2025["address"] == "Inputs!D8"
+    assert moderate_pe_2025["coordinates"]["OBS_VALUE"] == 4.2
+
+
+def test_exclude_rows_drops_referenced_blank_rows(tmp_path: Path) -> None:
+    """Blank header/separator rows are graph leaves (SUM over the block) but excluded."""
+    wb_path, graph = _grouped_graph(tmp_path)
+    assert "Inputs!C2" in graph
+    assert "Inputs!C5" in graph
+
+    series = grouped_matrix_series()
+    resolved = resolve_series_binding(graph, wb_path, series)
+    addresses = {leaf["address"] for leaf in resolved["leaves"]}
+    for excluded in ("Inputs!C2", "Inputs!D2", "Inputs!C5", "Inputs!D5", "Inputs!C6", "Inputs!D6"):
+        assert excluded not in addresses
+    assert len(addresses) == 8
+
+
+def test_missing_label_errors_by_default_without_exclude_rows(tmp_path: Path) -> None:
+    """Without exclude_rows, unlabeled rows fail loudly instead of mis-keying."""
+    wb_path, graph = _grouped_graph(tmp_path)
+    series = grouped_matrix_series()
+    del series["exclude_rows"]
+
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is False
+    codes = {issue["code"] for issue in resolved["issues"]}
+    assert "bind_resolution_failed" in codes
+
+
+def test_missing_null_yields_none_coordinate(tmp_path: Path) -> None:
+    wb_path = tmp_path / "sparse.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write(0, 2, 2024)
+    ws.write("A2", "Grouped")
+    ws.write_number("C2", 1.0)
+    ws.write_number("C3", 2.0)  # A3 has no label
+    wb.close()
+    graph = create_dependency_graph(wb_path, ["Inputs!C2", "Inputs!C3"], load_values=True)
+
+    series = {
+        "id": "sparse",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:C3",
+        "layout": "matrix",
+        "input": {"setter": {"name": "set_sparse"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+            "dimensions": [
+                {
+                    "concept": "GROUP",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "row_label",
+                        "label_column": "A",
+                        "missing": "null",
+                        "read": "string",
+                    },
+                },
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                },
+            ],
+        },
+        "key": ["GROUP", "TIME_PERIOD"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+    by_address = {leaf["address"]: leaf for leaf in resolved["leaves"]}
+    assert by_address["Inputs!C2"]["key"]["GROUP"] == "Grouped"
+    assert by_address["Inputs!C3"]["key"]["GROUP"] is None
+
+
+def test_fill_down_covers_merged_style_sparse_group_column(tmp_path: Path) -> None:
+    """Sparse (or merged) group labels in column A fill down over their band."""
+    wb_path = tmp_path / "sparse_groups.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write(0, 2, 2024)
+    rows = [
+        ("Paris", "Revenue", 1.0),
+        (None, "Primary expenditure", 2.0),
+        ("Moderate", "Revenue", 3.0),
+        (None, "Primary expenditure", 4.0),
+    ]
+    for offset, (scenario, shock, value) in enumerate(rows):
+        if scenario is not None:
+            ws.write(1 + offset, 0, scenario)
+        ws.write(1 + offset, 1, shock)
+        ws.write_number(1 + offset, 2, value)
+    wb.close()
+    targets = expand_data_range("Inputs!C2:C5")
+    graph = create_dependency_graph(wb_path, targets, load_values=True)
+
+    series = {
+        "id": "sparse_groups",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:C5",
+        "layout": "matrix",
+        "input": {"setter": {"name": "set_sparse_groups"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+            "dimensions": [
+                {
+                    "concept": "SCENARIO",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "row_label",
+                        "label_column": "A",
+                        "fill": True,
+                        "read": "string",
+                    },
+                },
+                {
+                    "concept": "SHOCK_TYPE",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "row_label", "label_column": "B", "read": "string"},
+                },
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                },
+            ],
+        },
+        "key": ["SCENARIO", "SHOCK_TYPE", "TIME_PERIOD"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+    keys = {(leaf["key"]["SCENARIO"], leaf["key"]["SHOCK_TYPE"]) for leaf in resolved["leaves"]}
+    assert keys == {
+        ("Paris", "Revenue"),
+        ("Paris", "Primary expenditure"),
+        ("Moderate", "Revenue"),
+        ("Moderate", "Primary expenditure"),
+    }
+
+
+def test_value_map_binds_rows_without_sheet_labels(tmp_path: Path) -> None:
+    """value_map keys rows by manifest values when labels are absent from the sheet."""
+    wb_path = tmp_path / "no_labels.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write(0, 2, 2024)
+    for offset, value in enumerate([1.0, 2.0, 3.0, 4.0]):
+        ws.write_number(1 + offset, 2, value)
+    wb.close()
+    targets = expand_data_range("Inputs!C2:C5")
+    graph = create_dependency_graph(wb_path, targets, load_values=True)
+
+    series = {
+        "id": "no_labels",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:C5",
+        "layout": "matrix",
+        "input": {"setter": {"name": "set_no_labels"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+            "dimensions": [
+                {
+                    "concept": "SCENARIO",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "value_map",
+                        "values": {"Paris": "2:3", "Moderate": [4, 5]},
+                    },
+                },
+                {
+                    "concept": "SHOCK_TYPE",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "value_map",
+                        "values": {"Revenue": [2, 4], "Primary expenditure": [3, 5]},
+                    },
+                },
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                },
+            ],
+        },
+        "key": ["SCENARIO", "SHOCK_TYPE", "TIME_PERIOD"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+    keys = {(leaf["key"]["SCENARIO"], leaf["key"]["SHOCK_TYPE"]) for leaf in resolved["leaves"]}
+    assert keys == {
+        ("Paris", "Revenue"),
+        ("Paris", "Primary expenditure"),
+        ("Moderate", "Revenue"),
+        ("Moderate", "Primary expenditure"),
+    }
+
+
+def test_value_map_uncovered_row_errors_by_default(tmp_path: Path) -> None:
+    wb_path = tmp_path / "uncovered.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write(0, 2, 2024)
+    ws.write_number("C2", 1.0)
+    ws.write_number("C3", 2.0)
+    wb.close()
+    graph = create_dependency_graph(wb_path, ["Inputs!C2", "Inputs!C3"], load_values=True)
+
+    series = {
+        "id": "uncovered",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:C3",
+        "layout": "matrix",
+        "input": {"setter": {"name": "set_uncovered"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+            "dimensions": [
+                {
+                    "concept": "SCENARIO",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "value_map", "values": {"Paris": 2}},
+                },
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                },
+            ],
+        },
+        "key": ["SCENARIO", "TIME_PERIOD"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is False
+    codes = {issue["code"] for issue in resolved["issues"]}
+    assert "bind_resolution_failed" in codes
+
+
+def test_value_map_column_axis(tmp_path: Path) -> None:
+    """Column-letter specs key data columns instead of rows."""
+    wb_path = tmp_path / "col_map.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("A2", "Revenue")
+    ws.write_number("C2", 1.0)
+    ws.write_number("D2", 2.0)
+    wb.close()
+    graph = create_dependency_graph(wb_path, ["Inputs!C2", "Inputs!D2"], load_values=True)
+
+    series = {
+        "id": "col_map",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:D2",
+        "layout": "series",
+        "input": {"setter": {"name": "set_col_map"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "value_map", "values": {2024: "C", 2025: "D"}},
+                },
+            ],
+        },
+        "key": ["TIME_PERIOD"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+    by_key = {leaf["key"]["TIME_PERIOD"]: leaf["address"] for leaf in resolved["leaves"]}
+    assert by_key == {2024: "Inputs!C2", 2025: "Inputs!D2"}
+
+
+def test_column_header_fill_right_covers_merged_style_headers(tmp_path: Path) -> None:
+    """A header spanning several columns (merged anchor) fills rightward."""
+    wb_path = tmp_path / "wide_header.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("C1", "Baseline")  # D1 empty: covered cell of a merged header
+    ws.write("A2", "Revenue")
+    ws.write_number("C2", 1.0)
+    ws.write_number("D2", 2.0)
+    wb.close()
+    graph = create_dependency_graph(wb_path, ["Inputs!C2", "Inputs!D2"], load_values=True)
+
+    series = {
+        "id": "wide_header",
+        "sheet": "Inputs",
+        "data_range": "Inputs!C2:D2",
+        "layout": "series",
+        "input": {"setter": {"name": "set_wide_header"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+            "dimensions": [
+                {
+                    "concept": "SCENARIO",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "column_header",
+                        "header_row": 1,
+                        "fill": True,
+                        "read": "string",
+                    },
+                },
+                {
+                    "concept": "OFFSET",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "value_map",
+                        "values": {1: "C", 2: "D"},
+                    },
+                },
+            ],
+        },
+        "key": ["SCENARIO", "OFFSET"],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    assert resolved["ok"] is True, resolved["issues"]
+    scenarios = {leaf["key"]["SCENARIO"] for leaf in resolved["leaves"]}
+    assert scenarios == {"Baseline"}

--- a/tests/unit/series_bindings/test_grouped_rows_schema.py
+++ b/tests/unit/series_bindings/test_grouped_rows_schema.py
@@ -1,0 +1,139 @@
+"""Schema and graph-validation tests for grouped-row matrix geometry (1.5.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import (
+    load_series_bindings,
+    validate_series_bindings,
+)
+from excel_grapher.series_bindings.schema import (
+    SeriesBindingsSchemaError,
+    validate_bindings_document,
+)
+from excel_grapher.series_bindings.versions import (
+    IMPLEMENTED_BIND_KINDS,
+    SUPPORTED_SCHEMA_VERSIONS,
+)
+from tests.fixtures.series_bindings.grouped_matrix_helpers import (
+    MATRIX_GROUPED_ROWS_BINDINGS,
+    grouped_matrix_bindings_document,
+    write_grouped_matrix_workbook,
+)
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
+
+
+def test_schema_version_1_5_0_supported() -> None:
+    assert "1.5.0" in SUPPORTED_SCHEMA_VERSIONS
+    assert "value_map" in IMPLEMENTED_BIND_KINDS
+
+
+def test_schema_accepts_grouped_rows_fixture() -> None:
+    bindings = load_series_bindings(MATRIX_GROUPED_ROWS_BINDINGS)
+    series = bindings["series"][0]
+    assert series["exclude_rows"] == [2, "5:6"]
+    scenario_bind = series["structure"]["dimensions"][0]["bind"]
+    assert scenario_bind["include"] == [2, 6]
+    assert scenario_bind["fill"] is True
+
+
+def test_schema_rejects_skip_and_include_together() -> None:
+    doc = grouped_matrix_bindings_document()
+    bind = doc["series"][0]["structure"]["dimensions"][0]["bind"]
+    bind["skip"] = [3]
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_bad_row_spec_string() -> None:
+    doc = grouped_matrix_bindings_document()
+    doc["series"][0]["exclude_rows"] = ["5-6"]
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_bad_missing_value() -> None:
+    doc = grouped_matrix_bindings_document()
+    bind = doc["series"][0]["structure"]["dimensions"][0]["bind"]
+    bind["missing"] = "skip"
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_accepts_missing_null_as_yaml_null() -> None:
+    """`missing: null` in YAML parses to None; the schema accepts both spellings."""
+    doc = grouped_matrix_bindings_document()
+    bind = doc["series"][0]["structure"]["dimensions"][0]["bind"]
+    bind["missing"] = None
+    validate_bindings_document(doc)
+    bind["missing"] = "null"
+    validate_bindings_document(doc)
+
+
+def test_schema_accepts_value_map_bind() -> None:
+    doc = grouped_matrix_bindings_document()
+    doc["series"][0]["structure"]["dimensions"][0]["bind"] = {
+        "kind": "value_map",
+        "values": {"Paris": "3:4", "Moderate": [7, 8]},
+    }
+    validate_bindings_document(doc)
+
+
+def test_schema_rejects_value_map_without_values() -> None:
+    doc = grouped_matrix_bindings_document()
+    doc["series"][0]["structure"]["dimensions"][0]["bind"] = {"kind": "value_map"}
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def _validated_graph_and_bindings(tmp_path: Path, doc: dict[str, Any]) -> Any:
+    from excel_grapher.series_bindings.ranges import expand_data_range
+
+    wb_path = tmp_path / "grouped_inputs.xlsx"
+    write_grouped_matrix_workbook(wb_path)
+    targets = expand_data_range("Inputs!C2:D8")
+    graph = create_dependency_graph(wb_path, targets, load_values=True)
+    bindings = validate_bindings_document(doc)
+    return wb_path, graph, bindings
+
+
+def test_validate_grouped_rows_fixture_ok(tmp_path: Path) -> None:
+    wb_path, graph, bindings = _validated_graph_and_bindings(
+        tmp_path, grouped_matrix_bindings_document()
+    )
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    assert report["ok"] is True, report["issues"]
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "bind_not_implemented" not in codes
+
+
+def test_validate_value_map_mixed_axis_errors(tmp_path: Path) -> None:
+    doc = grouped_matrix_bindings_document()
+    doc["series"][0]["structure"]["dimensions"][0]["bind"] = {
+        "kind": "value_map",
+        "values": {"Paris": "3:4", "Moderate": "C:D"},
+    }
+    wb_path, graph, bindings = _validated_graph_and_bindings(tmp_path, doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    assert report["ok"] is False
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "invalid_bind_geometry" in codes
+
+
+def test_validate_value_map_overlapping_specs_errors(tmp_path: Path) -> None:
+    doc = grouped_matrix_bindings_document()
+    doc["series"][0]["structure"]["dimensions"][0]["bind"] = {
+        "kind": "value_map",
+        "values": {"Paris": "3:5", "Moderate": [5, 6]},
+    }
+    wb_path, graph, bindings = _validated_graph_and_bindings(tmp_path, doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    assert report["ok"] is False
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "invalid_bind_geometry" in codes

--- a/tests/unit/series_bindings/test_versions.py
+++ b/tests/unit/series_bindings/test_versions.py
@@ -19,7 +19,8 @@ FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
 
 
 def test_supported_schema_versions() -> None:
-    assert frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"}) == SUPPORTED_SCHEMA_VERSIONS
+    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"})
+    assert expected == SUPPORTED_SCHEMA_VERSIONS
 
 
 def test_validate_explicit_matrix_no_implementation_warnings(tmp_path: Path) -> None:

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -165,7 +165,8 @@ df = pd.DataFrame({"TIME_PERIOD": [4, 5], "OBS_VALUE": [7.5, 8.0]})
 set_borvelia_primary_balance(ctx, df)
 ```
 
-`layout: matrix` setters are **not** implemented yet; matrix-shaped input is out of scope.
+`layout: matrix` setters accept records or a tidy DataFrame with all `key` fields plus the measure
+concept; positional 1D measure values are rejected for matrix bindings.
 
 ### Record dicts
 
@@ -222,7 +223,8 @@ Optional:
 | `cell` | series | **supported** | Fixed address (e.g. country in `A2`) |
 | `column_header` | cell | **supported** | Header row for the data column |
 | `row_label` | series/cell | **supported** | Label text on the data row |
-| `row_hierarchy` | cell | **schema only** | Inferred hierarchy from row labels; not supported by resolver/codegen |
+| `value_map` | cell | **supported** | Key rows or columns by manifest values (1.5.0) |
+| `row_hierarchy` | cell | **schema only** | Inferred hierarchy from row labels; superseded by explicit grouped-row geometry (1.5.0) |
 | `constant` | series | **supported** | Fixed scalar (e.g. scalar layout key) |
 
 Normalization: `strip`, `strip_trailing_unit` (removes trailing `(…)` unit clauses from indicator text).
@@ -291,6 +293,151 @@ set_macro_matrix(ctx, [
     {"INDICATOR": "Inflation", "TIME_PERIOD": 2025, "OBS_VALUE": 2.8},
 ])
 ```
+
+## Grouped-row matrix geometry (1.5.0)
+
+The dense matrix above assumes every cell-scoped key is read from a label **directly adjacent** to
+the data cell: `row_label` immediately left, `column_header` immediately above. Schema **1.5.0**
+adds explicit geometry for banded blocks where that contract does not hold — a group label appears
+once per band and sub-rows carry a second row dimension:
+
+```text
+        A                     C       D
+1                             2024    2025
+2       Paris
+3       Revenue               1.1     1.2
+4       Primary expenditure   2.1     2.2
+5
+6       Moderate
+7       Revenue               3.1     3.2
+8       Primary expenditure   4.1     4.2
+```
+
+All geometry is declared explicitly in the manifest — there is no indentation or formatting
+inference (which is why the heuristic `row_hierarchy` bind remains schema-only).
+
+### Label sources: `skip`, `include`, `fill`, `missing`
+
+`row_label` and `column_header` binds accept four optional fields:
+
+- **`skip`** / **`include`** — restrict which rows (or header columns) are **label sources** for
+  this dimension. `skip` lists rows that are *not* sources; `include` lists the *only* sources.
+  They are mutually exclusive. Row specs are 1-based integers or inclusive `"first:last"` strings;
+  column specs are letters (`"C"`, `"C:D"`). Quote range strings — YAML parses a bare `[3:4]` as a
+  mapping, not a string.
+- **`fill`** — when `true`, a data row (or column) whose own label source is skipped or empty
+  inherits the nearest non-skipped, non-empty label **above** it (`row_label`) or to its **left**
+  (`column_header`). Because merged cells store their value only in the anchor cell, `fill: true`
+  also covers merged group headers with no further configuration.
+- **`missing`** — what to do when no source label exists for a data cell: `error` (default) fails
+  resolution with `bind_resolution_failed`; `null` keys the cell on `None`. YAML `null` is accepted
+  as a spelling of `"null"`. `None` keys participate in the composite key and leaf index like any
+  other value — callers pass `None` in that field to match.
+
+Two key dimensions may bind the **same** label column: in the banded sheet above, `SCENARIO` reads
+only the band header rows and fills down, while `SHOCK_TYPE` reads everything else:
+
+```yaml
+schema_version: "1.5.0"
+workbook: grouped_inputs.xlsx
+series:
+  - id: discrete_risks
+    sheet: Inputs
+    data_range: Inputs!C2:D8
+    layout: matrix
+    exclude_rows: [2, "5:6"]
+    input:
+      setter:
+        name: set_discrete_risks
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: {kind: data_cell, read: float}
+      dimensions:
+        - concept: SCENARIO
+          role: key
+          scope: cell
+          bind:
+            kind: row_label
+            label_column: A
+            include: [2, 6]     # band header rows are the only label sources
+            fill: true          # sub-rows inherit the band label above
+            read: string
+        - concept: SHOCK_TYPE
+          role: key
+          scope: cell
+          bind:
+            kind: row_label
+            label_column: A
+            skip: [2, 6]        # band header rows are not sub-labels
+            read: string
+        - concept: TIME_PERIOD
+          role: key
+          scope: cell
+          bind: {kind: column_header, header_row: 1, read: int}
+    key: [SCENARIO, SHOCK_TYPE, TIME_PERIOD]
+```
+
+This emits **one** `set_discrete_risks` accepting the full composite key — no per-band shards with
+group names smuggled through `series_context`:
+
+```python
+set_discrete_risks(ctx, [
+    {"SCENARIO": "Paris", "SHOCK_TYPE": "Revenue", "TIME_PERIOD": 2024, "OBS_VALUE": 9.9},
+])
+```
+
+For the simpler sparse/merged variant — group labels in their own column, blank (or merge-covered)
+on sub-rows — `fill: true` alone suffices; no `skip`/`include` lists are needed because emptiness
+already identifies the non-source rows.
+
+### Data membership: `exclude_rows`
+
+Which rows count as **data** is a series-level concern, separate from label geometry. By default
+resolution keeps cells that are graph input leaves, so unreferenced decorative rows drop out
+automatically. But a formula spanning the block (a `SUM` or a lookup table array) makes embedded
+blank rows graph leaves too. `exclude_rows` force-drops rows that are never data:
+
+- In the example, rows 2 and 6 (band headers) and row 5 (separator) are excluded even though the
+  block-wide `SUM` references them.
+- Excluded rows can still serve as **label sources** — `SCENARIO` reads its band labels from
+  excluded rows 2 and 6. Label reads go through the workbook, not the graph.
+- Without `exclude_rows`, an unlabeled row fails resolution loudly under `missing: error` (the
+  `SHOCK_TYPE` bind cannot label it) instead of mis-keying a record — configure nothing and you
+  get an error, not corruption.
+
+### Hardcoded keys: `value_map`
+
+When labels are absent from the sheet entirely (or unreliable), key rows or columns by manifest
+values. The axis is inferred from spec syntax — row specs (`3`, `"3:4"`) key data rows, column
+specs (`"C"`, `"C:D"`) key data columns; mixing axes or assigning one row to two values is a
+validation error (`invalid_bind_geometry`):
+
+```yaml
+- concept: SCENARIO
+  role: key
+  scope: cell
+  bind:
+    kind: value_map
+    values:
+      Paris: "3:4"
+      Moderate: [7, 8]     # lists allow disjoint rows, e.g. repeated sub-labels
+```
+
+`value_map` shares the `missing` policy: a data row covered by no entry is an error by default, or
+`None`-keyed with `missing: null`. Map keys are coerced through `read` (and `concept_scheme`
+dtypes) like `constant` values; keys within one bind must share one scalar type.
+
+### Choosing a mechanism
+
+| Sheet geometry | Mechanism |
+|----------------|-----------|
+| Dense block, labels directly adjacent | plain `row_label` / `column_header` |
+| Group labels merged or sparse in their own column | `fill: true` |
+| Group headers interleaved with sub-labels in one column | `skip`/`include` + `fill: true` |
+| Labels absent from the sheet | `value_map` |
+| Referenced non-data rows (headers, separators, subtotals) | `exclude_rows` |
 
 ## Boolean and datetime types (1.4.0)
 
@@ -377,6 +524,7 @@ Generated code imports `datetime` and emits `datetime.datetime(...)` literals on
 | **1.2.0** | Optional `input` / `output` direction blocks and output `compute_*` functions. |
 | **1.3.0** | `row_series` renamed to `series` (no resolver/codegen change). Legacy `row_series` accepted at load time. |
 | **1.4.0** | `bool` and `datetime` read modes and dtypes; ISO date strings in manifest constants. |
+| **1.5.0** | Grouped-row matrix geometry: `skip`/`include`/`fill`/`missing` on `row_label` and `column_header` binds, the `value_map` bind kind, and series-level `exclude_rows`. |
 
 ## Validation and codegen closure
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds explicit hierarchical row/column geometry for `layout: matrix` bindings, so banded blocks (a group label once per band, sub-rows carrying a second row dimension) resolve to a single setter with the full composite key — no per-band shards with the group name smuggled through `series_context`, and no formatting/indentation heuristics. Closes the grouped-row half of #287's deferred geometry; complements the dense explicit matrix contract from #295.

## Manifest surface (schema 1.5.0)

- **`skip` / `include`** on `row_label` and `column_header` binds — restrict which rows (or header columns) are label sources for a dimension. Mutually exclusive (enforced at schema level). Two key dimensions may bind the same label column (e.g. `SCENARIO` reads only band header rows; `SHOCK_TYPE` reads everything else).
- **`fill: true`** — a data row/column whose label source is skipped or empty inherits the nearest non-skipped, non-empty label above (rows) or to the left (columns). Covers merged group headers for free, since merged cells store their value only in the anchor.
- **`missing: error | null`** (default `error`) — policy when no source label exists. `error` fails resolution with `bind_resolution_failed`; `null` keys the cell on `None` (which participates in the composite key and leaf index like any value). YAML `null` is accepted as a spelling of `"null"`.
- **`value_map` bind kind** — key rows or columns by manifest values when labels are absent from the sheet. Axis inferred from spec syntax (`3` / `"3:4"` = rows, `"C"` / `"C:D"` = columns); mixed axes and overlapping assignments are `invalid_bind_geometry` validation errors. Shares the `missing` policy.
- **`exclude_rows`** (series-level) — force-drop rows that are never data, for header/separator/subtotal rows dragged into the graph as leaves by block-spanning formulas (`SUM`, lookup table arrays). Excluded rows can still serve as label sources, since label reads go through the workbook rather than the graph.

Setter codegen, input coercion, and the leaf-index machinery are untouched: once resolution produces the group coordinate, the existing composite-key path handles everything, keeping the evaluator ↔ export parity surface unchanged.

## Behavior change

`row_label` / `column_header` on an **empty** label cell previously produced a silent `None` coordinate; it now fails resolution under the default `missing: error`. Opt back into `None` keys per dimension with `missing: null`. No in-tree manifest relied on the old behavior (full suite passes unchanged).

## MCVE

`tests/fixtures/series_bindings/matrix_grouped_rows_1_5_0.yaml` + `grouped_matrix_helpers.py` model the Discrete Risks band pattern: interleaved scenario bands (revenue + primary-expenditure row per band) in column A, a decorative blank separator row, and a block-wide `SUM` that pulls the blank rows into the graph. Resolution yields 8 uniquely keyed leaves and one generated `set_discrete_risks`.

## Testing

- `tests/unit/series_bindings/test_grouped_rows_resolve.py` — fill walk (sparse + merged-style), skip/include on a shared column, `missing` policies, `value_map` (rows, columns, uncovered-row error), `exclude_rows` vs referenced blank rows
- `tests/unit/series_bindings/test_grouped_rows_schema.py` — 1.5.0 schema accept/reject, skip⊕include, spec syntax, `value_map` axis/overlap validation
- `tests/unit/series_bindings/test_grouped_rows_codegen.py` — single-setter round trip through generated code
- `tests/integration/user_flows/test_grouped_rows_matrix_bindings.py` — validate + `run_binding_checks` smoke on the MCVE
- Full CI parity locally: `ruff check`, `ruff format --check`, `ty check`, `pytest` (1608 passed)

## Docs

`user_guide/05-series-bindings.qmd` gains a "Grouped-row matrix geometry (1.5.0)" section contrasting dense explicit matrix, fill/skip/include, `value_map`, `exclude_rows`, and schema-only `row_hierarchy`, with a mechanism decision table. Also fixes the stale "matrix setters are not implemented" line.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae30474a-ac46-4ff0-851d-c01a1d48a6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae30474a-ac46-4ff0-851d-c01a1d48a6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

