### PR TITLE
fix: cache repeated dynamic ref expansions

### DIFF
--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -71,6 +71,28 @@ _VOLATILE_DYNAMIC_REF_FUNCS = frozenset(
 _VOLATILE_DYNAMIC_REF_PATTERN = re.compile(
     r"(?<![A-Z0-9_])(?:_XLFN\.|_XLUDF\.)?(?:NOW|TODAY|RANDBETWEEN|RANDARRAY|RAND|INFO)\s*\("
 )
+_POSITION_DEPENDENT_DYNAMIC_REF_PATTERN = re.compile(
+    r"(?<![A-Z0-9_])(?:ROW|COLUMN)\s*\(\s*\)",
+    re.IGNORECASE,
+)
+_DynamicRefCacheKey = tuple[str, str] | tuple[str, str, str]
+_DynamicRefTargets = tuple[set[str], set[str], set[str]]
+_DynamicRefDependencyCacheValue = tuple[
+    list[tuple[str, str]],
+    list[tuple[int, int]],
+    _DynamicRefTargets,
+]
+
+
+def _dynamic_ref_cache_key(
+    formula_for_infer: str,
+    current_sheet: str,
+    current_a1: str,
+) -> _DynamicRefCacheKey:
+    """Return the safest per-build cache key for dynamic-ref expansion."""
+    if _POSITION_DEPENDENT_DYNAMIC_REF_PATTERN.search(formula_for_infer):
+        return (formula_for_infer, current_sheet, current_a1)
+    return (formula_for_infer, current_sheet)
 
 
 def _parse_address_to_sheet_a1(addr: str) -> tuple[str, str]:
@@ -337,7 +359,11 @@ def create_dependency_graph(
     # Per-graph cache: (normalized_formula, current_sheet, current_a1) -> (offset_targets, indirect_targets, index_targets).
     # Populated by extract_expr_deps (constraint path); consumed by collect_provenance_for_formula
     # to avoid re-running the expensive expand_leaf_env_to_argument_env call.
-    _dyn_cache: dict[tuple[str, str, str], tuple[set[str], set[str], set[str]]] = {}
+    _dyn_cache: dict[tuple[str, str, str], _DynamicRefTargets] = {}
+    # Per-graph cache for the full dependency contribution of constraint-based
+    # dynamic refs. Position-independent repeated formulas can share this before
+    # rebuilding argument domains and rerunning INDEX/MATCH inference.
+    _dyn_dep_cache: dict[_DynamicRefCacheKey, _DynamicRefDependencyCacheValue] = {}
     # Shared cell-type cache for expand_leaf_env_to_argument_env: intermediate
     # formula cells inferred once are reused across BFS nodes, avoiding redundant
     # recursive domain inference when many dynamic-ref formulas share intermediates.
@@ -612,8 +638,29 @@ def create_dependency_graph(
                         )
                 else:
                     bounds = GlobalWorkbookBounds(sheet=current_sheet)
+                    if calls:
+                        formula_for_infer = normalizer.normalize(
+                            f if f.startswith("=") else "=" + f,
+                            current_sheet,
+                        )
+                        _cell_cache_key = (formula_for_infer, current_sheet, current_a1)
+                        _dyn_dep_cache_key = _dynamic_ref_cache_key(
+                            formula_for_infer,
+                            current_sheet,
+                            current_a1,
+                        )
+                        _cached_dynamic_deps = _dyn_dep_cache.get(_dyn_dep_cache_key)
+                        if _cached_dynamic_deps is not None:
+                            cached_deps, cached_dyn_spans, cached_targets = _cached_dynamic_deps
+                            deps.extend(cached_deps)
+                            dyn_spans.extend(cached_dyn_spans)
+                            _dyn_cache[_cell_cache_key] = cached_targets
+                            _dyn_stats["cache_hits"] += 1
+                            calls = []
                     argument_addrs: set[str] = set()
                     if calls:
+                        _deps_start = len(deps)
+                        _dyn_spans_start = len(dyn_spans)
                         for fn_name, inner, span in calls:
                             dyn_spans.append(span)
                             args = _split_function_args(inner)
@@ -819,6 +866,11 @@ def create_dependency_graph(
                         ):
                             sh, a1 = _parse_address_to_sheet_a1(addr)
                             deps.append((sh, a1))
+                        _dyn_dep_cache[_dyn_dep_cache_key] = (
+                            deps[_deps_start:],
+                            dyn_spans[_dyn_spans_start:],
+                            (offset_targets, indirect_targets, index_targets),
+                        )
             masked = mask_spans(masked, dyn_spans)
 
             # 1) Expand ranges, then mask them so later cell-ref parsing doesn't

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -75,13 +75,13 @@ _POSITION_DEPENDENT_DYNAMIC_REF_PATTERN = re.compile(
     r"(?<![A-Z0-9_])(?:ROW|COLUMN)\s*\(\s*\)",
     re.IGNORECASE,
 )
+# Position-independent formulas: (normalized_formula, sheet).
+# Formulas with argument-less ROW()/COLUMN(): (normalized_formula, sheet, cell_a1).
 _DynamicRefCacheKey = tuple[str, str] | tuple[str, str, str]
 _DynamicRefTargets = tuple[set[str], set[str], set[str]]
-_DynamicRefDependencyCacheValue = tuple[
-    list[tuple[str, str]],
-    list[tuple[int, int]],
-    _DynamicRefTargets,
-]
+# Deps and inferred targets are keyed by normalized formula; masking spans are not
+# cached because they refer to raw formula text offsets.
+_DynamicRefDependencyCacheValue = tuple[list[tuple[str, str]], _DynamicRefTargets]
 
 
 def _dynamic_ref_cache_key(
@@ -651,16 +651,15 @@ def create_dependency_graph(
                         )
                         _cached_dynamic_deps = _dyn_dep_cache.get(_dyn_dep_cache_key)
                         if _cached_dynamic_deps is not None:
-                            cached_deps, cached_dyn_spans, cached_targets = _cached_dynamic_deps
+                            cached_deps, cached_targets = _cached_dynamic_deps
                             deps.extend(cached_deps)
-                            dyn_spans.extend(cached_dyn_spans)
+                            dyn_spans.extend(span for _, _, span in calls)
                             _dyn_cache[_cell_cache_key] = cached_targets
-                            _dyn_stats["cache_hits"] += 1
+                            _dyn_stats["dep_cache_hits"] += 1
                             calls = []
                     argument_addrs: set[str] = set()
                     if calls:
                         _deps_start = len(deps)
-                        _dyn_spans_start = len(dyn_spans)
                         for fn_name, inner, span in calls:
                             dyn_spans.append(span)
                             args = _split_function_args(inner)
@@ -868,7 +867,6 @@ def create_dependency_graph(
                             deps.append((sh, a1))
                         _dyn_dep_cache[_dyn_dep_cache_key] = (
                             deps[_deps_start:],
-                            dyn_spans[_dyn_spans_start:],
                             (offset_targets, indirect_targets, index_targets),
                         )
             masked = mask_spans(masked, dyn_spans)
@@ -1137,7 +1135,7 @@ def create_dependency_graph(
     _bfs_t0 = time.perf_counter()
     _bfs_count = 0
     _bfs_next_log = 5000
-    _dyn_stats = {"infer_calls": 0, "cache_hits": 0}
+    _dyn_stats = {"infer_calls": 0, "cache_hits": 0, "dep_cache_hits": 0}
 
     try:
         while q:
@@ -1160,6 +1158,7 @@ def create_dependency_graph(
                             "last": key,
                             "infer_calls": _dyn_stats["infer_calls"],
                             "cache_hits": _dyn_stats["cache_hits"],
+                            "dep_cache_hits": _dyn_stats["dep_cache_hits"],
                             "env_cache_size": len(_shared_cell_type_cache),
                         },
                     )
@@ -1257,7 +1256,11 @@ def create_dependency_graph(
             if not graph.get_dependencies(key):
                 node.is_leaf = True
     finally:
-        if _dyn_stats["infer_calls"] or _dyn_stats["cache_hits"]:
+        if (
+            _dyn_stats["infer_calls"]
+            or _dyn_stats["cache_hits"]
+            or _dyn_stats["dep_cache_hits"]
+        ):
             _emit_trace(
                 DynamicRefTraceEvent(
                     kind="bfs-done",
@@ -1267,6 +1270,7 @@ def create_dependency_graph(
                         "nodes": _bfs_count,
                         "infer_calls": _dyn_stats["infer_calls"],
                         "cache_hits": _dyn_stats["cache_hits"],
+                        "dep_cache_hits": _dyn_stats["dep_cache_hits"],
                         "env_cache_size": len(_shared_cell_type_cache),
                     },
                 )

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -1256,11 +1256,7 @@ def create_dependency_graph(
             if not graph.get_dependencies(key):
                 node.is_leaf = True
     finally:
-        if (
-            _dyn_stats["infer_calls"]
-            or _dyn_stats["cache_hits"]
-            or _dyn_stats["dep_cache_hits"]
-        ):
+        if _dyn_stats["infer_calls"] or _dyn_stats["cache_hits"] or _dyn_stats["dep_cache_hits"]:
             _emit_trace(
                 DynamicRefTraceEvent(
                     kind="bfs-done",

--- a/tests/unit/grapher/test_dynamic_refs.py
+++ b/tests/unit/grapher/test_dynamic_refs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import random
 import warnings
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 import xlsxwriter
@@ -2410,6 +2410,124 @@ def _build_wide_index_sweep_workbook(path: Path, n_rows: int = 50) -> None:
         )
 
     wb.close()
+
+
+def _literal_constraint(*values: object) -> object:
+    return Literal.__getitem__(values)
+
+
+def _build_repeated_index_match_workbook(
+    path: Path,
+    *,
+    formula_count: int = 25,
+    country_count: int = 20,
+) -> tuple[list[str], dict[str, object]]:
+    """Create repeated INDEX/MATCH formulas sharing one controller/list pair."""
+    countries = [f"Country {i:03d}" for i in range(1, country_count + 1)]
+    wb = xlsxwriter.Workbook(path)
+    inputs = wb.add_worksheet("Inputs")
+    lookup = wb.add_worksheet("Lookup")
+    outputs = wb.add_worksheet("Outputs")
+
+    inputs.write("A1", countries[0])
+    for row, country in enumerate(countries, start=1):
+        lookup.write(row, 0, country)
+        lookup.write_number(row, 1, row * 10)
+
+    targets: list[str] = []
+    last_lookup_row = country_count + 1
+    for row in range(1, formula_count + 1):
+        address = f"A{row}"
+        outputs.write_formula(
+            address,
+            "=INDEX("
+            f"Lookup!$B$2:$B${last_lookup_row},"
+            f"MATCH(Inputs!$A$1,Lookup!$A$2:$A${last_lookup_row},0),"
+            "1"
+            ")",
+        )
+        targets.append(f"Outputs!{address}")
+
+    wb.close()
+
+    constraints: dict[str, object] = {"Inputs!A1": _literal_constraint(*countries)}
+    for row, country in enumerate(countries, start=2):
+        constraints[f"Lookup!A{row}"] = _literal_constraint(country)
+    return targets, constraints
+
+
+def test_repeated_identical_index_match_reuses_dynamic_ref_expansion(tmp_path: Path) -> None:
+    """Repeated identical INDEX/MATCH formulas should not redo MATCH inference."""
+    from unittest.mock import patch
+
+    formula_count = 25
+    country_count = 20
+    excel_path = tmp_path / "repeated_index_match.xlsx"
+    targets, constraints = _build_repeated_index_match_workbook(
+        excel_path,
+        formula_count=formula_count,
+        country_count=country_count,
+    )
+    config = DynamicRefConfig.from_constraints(constraints, {})
+
+    original_infer_match = dynamic_refs_mod._infer_exact_match_position_domain
+    match_infer_calls = 0
+
+    def counting_infer_match(*args: Any, **kwargs: Any):
+        nonlocal match_infer_calls
+        match_infer_calls += 1
+        return original_infer_match(*args, **kwargs)
+
+    with patch.object(
+        dynamic_refs_mod,
+        "_infer_exact_match_position_domain",
+        side_effect=counting_infer_match,
+    ):
+        graph = create_dependency_graph(
+            excel_path,
+            targets,
+            load_values=True,
+            dynamic_refs=config,
+        )
+
+    assert len(graph.leaf_keys()) == (2 * country_count) + 1
+    for target in targets:
+        deps = graph.get_dependencies(target)
+        assert "Inputs!A1" in deps
+        assert "Lookup!A2" in deps
+        assert "Lookup!B2" in deps
+
+    assert match_infer_calls == 1
+
+
+def _build_row_sensitive_index_workbook(path: Path) -> list[str]:
+    """Create identical formulas whose dynamic INDEX target depends on row context."""
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Sheet1")
+    for row in range(3):
+        ws.write_number(row, 0, row + 1)
+    for row in range(2):
+        ws.write_formula(row, 1, "=INDEX(Sheet1!$A$1:$A$3,ROW(),1)")
+    wb.close()
+    return ["Sheet1!B1", "Sheet1!B2"]
+
+
+def test_repeated_index_cache_keeps_row_sensitive_formulas_separate(tmp_path: Path) -> None:
+    """Identical formulas containing ROW() should still use each cell's position."""
+    excel_path = tmp_path / "row_sensitive_index.xlsx"
+    targets = _build_row_sensitive_index_workbook(excel_path)
+
+    graph = create_dependency_graph(
+        excel_path,
+        targets,
+        load_values=True,
+        dynamic_refs=DynamicRefConfig(cell_type_env={}, limits=DynamicRefLimits()),
+    )
+
+    assert "Sheet1!A1" in graph.get_dependencies("Sheet1!B1")
+    assert "Sheet1!A2" not in graph.get_dependencies("Sheet1!B1")
+    assert "Sheet1!A2" in graph.get_dependencies("Sheet1!B2")
+    assert "Sheet1!A1" not in graph.get_dependencies("Sheet1!B2")
 
 
 def test_wide_index_sweep_shared_env_cache(tmp_path: Path) -> None:

--- a/tests/unit/grapher/test_dynamic_refs.py
+++ b/tests/unit/grapher/test_dynamic_refs.py
@@ -2530,6 +2530,75 @@ def test_repeated_index_cache_keeps_row_sensitive_formulas_separate(tmp_path: Pa
     assert "Sheet1!A1" not in graph.get_dependencies("Sheet1!B2")
 
 
+def _build_equivalent_index_match_spellings_workbook(
+    path: Path,
+    *,
+    anchored_first: bool,
+) -> tuple[list[str], dict[str, object]]:
+    """Build two INDEX/MATCH formulas that normalize identically but differ in raw text."""
+    countries = [f"Country {i}" for i in range(1, 5)]
+    wb = xlsxwriter.Workbook(path)
+    inputs = wb.add_worksheet("Inputs")
+    lookup = wb.add_worksheet("Lookup")
+    outputs = wb.add_worksheet("Outputs")
+
+    inputs.write("A1", countries[0])
+    for row, country in enumerate(countries, start=1):
+        lookup.write(row, 0, country)
+        lookup.write_number(row, 1, row * 10)
+
+    anchored = (
+        "=INDEX(Lookup!$B$2:$B$5,MATCH(Inputs!$A$1,Lookup!$A$2:$A$5,0),1)"
+    )
+    unanchored = "=INDEX(Lookup!B2:B5,MATCH(Inputs!A1,Lookup!A2:A5,0),1)"
+    first, second = (
+        (anchored, unanchored) if anchored_first else (unanchored, anchored)
+    )
+    outputs.write_formula("A1", first)
+    outputs.write_formula("A2", second)
+    wb.close()
+
+    constraints: dict[str, object] = {"Inputs!A1": _literal_constraint(*countries)}
+    for row, country in enumerate(countries, start=2):
+        constraints[f"Lookup!A{row}"] = _literal_constraint(country)
+    return ["Outputs!A1", "Outputs!A2"], constraints
+
+
+@pytest.mark.parametrize("anchored_first", [True, False])
+def test_dynamic_dep_cache_masks_current_formula_text(
+    tmp_path: Path,
+    anchored_first: bool,
+) -> None:
+    """Normalized-equivalent formulas must mask spans from their own raw text."""
+    excel_path = tmp_path / f"index_match_spellings_{int(anchored_first)}.xlsx"
+    targets, constraints = _build_equivalent_index_match_spellings_workbook(
+        excel_path,
+        anchored_first=anchored_first,
+    )
+    config = DynamicRefConfig.from_constraints(constraints, {})
+
+    graph = create_dependency_graph(
+        excel_path,
+        targets,
+        load_values=True,
+        dynamic_refs=config,
+    )
+
+    expected = {
+        "Inputs!A1",
+        "Lookup!A2",
+        "Lookup!A3",
+        "Lookup!A4",
+        "Lookup!A5",
+        "Lookup!B2",
+        "Lookup!B3",
+        "Lookup!B4",
+        "Lookup!B5",
+    }
+    for target in targets:
+        assert set(graph.get_dependencies(target)) == expected
+
+
 def test_wide_index_sweep_shared_env_cache(tmp_path: Path) -> None:
     """Benchmark: many INDEX formulas should share env expansion work.
 

--- a/tests/unit/grapher/test_dynamic_refs.py
+++ b/tests/unit/grapher/test_dynamic_refs.py
@@ -2547,13 +2547,9 @@ def _build_equivalent_index_match_spellings_workbook(
         lookup.write(row, 0, country)
         lookup.write_number(row, 1, row * 10)
 
-    anchored = (
-        "=INDEX(Lookup!$B$2:$B$5,MATCH(Inputs!$A$1,Lookup!$A$2:$A$5,0),1)"
-    )
+    anchored = "=INDEX(Lookup!$B$2:$B$5,MATCH(Inputs!$A$1,Lookup!$A$2:$A$5,0),1)"
     unanchored = "=INDEX(Lookup!B2:B5,MATCH(Inputs!A1,Lookup!A2:A5,0),1)"
-    first, second = (
-        (anchored, unanchored) if anchored_first else (unanchored, anchored)
-    )
+    first, second = (anchored, unanchored) if anchored_first else (unanchored, anchored)
     outputs.write_formula("A1", first)
     outputs.write_formula("A2", second)
     wb.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Cache the full constraint-based dynamic-ref dependency contribution for repeated position-independent formulas within a graph build.
- Reuse cached dynamic dependencies before rebuilding argument domains or rerunning INDEX/MATCH inference.
- Keep formulas containing argument-less `ROW()` or `COLUMN()` keyed by the exact formula cell to preserve position-sensitive behavior.
- Add regression coverage for repeated identical INDEX/MATCH formulas and a row-sensitive cache guard.

## Verification

- `uv run pytest tests/unit/grapher/test_dynamic_refs.py -q`
- `uv run pytest tests/unit/grapher -q`
- `uv run ruff check excel_grapher/grapher/builder.py tests/unit/grapher/test_dynamic_refs.py`
- Issue 322 MCVE benchmark on this machine improved at 1000 repeated formulas from ~2.7s before the fix to ~1.2s after the fix, with unchanged leaf count.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40a37301-ac55-4274-bd61-4b541e6a907c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40a37301-ac55-4274-bd61-4b541e6a907c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

