### PR TITLE
fix(exporter): emit TypeAlias for SeriesInput in exported code

### DIFF
--- a/excel_grapher/series_bindings/codegen_literals.py
+++ b/excel_grapher/series_bindings/codegen_literals.py
@@ -46,27 +46,28 @@ def emit_setter_type_alias_lines(*, include_datetime: bool) -> list[str]:
     """Emit shared type aliases for generated setter blocks."""
     sequence_import = [
         "from collections.abc import Sequence",
-        "from typing import TYPE_CHECKING",
+        "from typing import TYPE_CHECKING, TypeAlias",
         "",
     ]
     scalar_type = (
-        "Scalar = str | int | float | bool | datetime | None"
+        "Scalar: TypeAlias = str | int | float | bool | datetime | None"
         if include_datetime
-        else "Scalar = str | int | float | bool | None"
+        else "Scalar: TypeAlias = str | int | float | bool | None"
     )
     return sequence_import + [
         scalar_type,
-        "Record = dict[str, object]",
-        "Records = list[Record]",
-        "SeriesInput = Records | Record | Sequence[Scalar]",
+        "Record: TypeAlias = dict[str, object]",
+        "Records: TypeAlias = list[Record]",
         "",
         "if TYPE_CHECKING:",
         "    import pandas as pd",
         "    import polars as pl",
         "",
-        "    SeriesInput = Records | Record | Sequence[Scalar] | pd.DataFrame | pl.DataFrame",
+        "    DataFrameInput: TypeAlias = pd.DataFrame | pl.DataFrame",
         "else:",
-        "    SeriesInput = Records | Record | Sequence[Scalar] | object",
+        "    DataFrameInput: TypeAlias = object",
+        "",
+        "SeriesInput: TypeAlias = Records | Record | Sequence[Scalar] | DataFrameInput",
         "",
     ]
 

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -127,7 +127,7 @@ def emit_input_coerce_helpers() -> list[str]:
 SERIES_HELPERS_STDLIB_IMPORTS: tuple[str, ...] = (
     "from collections.abc import Iterable, Mapping, Sequence",
     "from datetime import date, datetime, timedelta",
-    "from typing import TYPE_CHECKING, Any, Literal, TypeGuard, cast",
+    "from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeGuard, cast",
 )
 """Standard-library imports required by `emit_series_helpers_definitions`."""
 
@@ -146,21 +146,22 @@ def emit_series_helpers_definitions() -> list[str]:
     """
     package_dir = Path(__file__).resolve().parent
     lines = [
-        'Layout = Literal["scalar", "series", "matrix"]',
-        'EmptyMeasure = Literal["skip", "write", "error"]',
-        "SetterInput = object",
-        "Scalar = str | int | float | bool | datetime | None",
-        "Record = dict[str, object]",
-        "Records = list[Record]",
-        "SeriesInput = Records | Record | Sequence[Scalar]",
+        'Layout: TypeAlias = Literal["scalar", "series", "matrix"]',
+        'EmptyMeasure: TypeAlias = Literal["skip", "write", "error"]',
+        "SetterInput: TypeAlias = object",
+        "Scalar: TypeAlias = str | int | float | bool | datetime | None",
+        "Record: TypeAlias = dict[str, object]",
+        "Records: TypeAlias = list[Record]",
         "",
         "if TYPE_CHECKING:",
         "    import pandas as pd",
         "    import polars as pl",
         "",
-        "    SeriesInput = Records | Record | Sequence[Scalar] | pd.DataFrame | pl.DataFrame",
+        "    DataFrameInput: TypeAlias = pd.DataFrame | pl.DataFrame",
         "else:",
-        "    SeriesInput = Records | Record | Sequence[Scalar] | object",
+        "    DataFrameInput: TypeAlias = object",
+        "",
+        "SeriesInput: TypeAlias = Records | Record | Sequence[Scalar] | DataFrameInput",
         "",
     ]
     lines.extend(_emit_python_module_body(package_dir / "coerce.py"))

--- a/tests/unit/series_bindings/test_codegen_literals.py
+++ b/tests/unit/series_bindings/test_codegen_literals.py
@@ -28,30 +28,22 @@ def test_emit_setter_type_alias_lines_omit_datetime_when_unused() -> None:
     lines = emit_setter_type_alias_lines(include_datetime=False)
     assert lines[:2] == [
         "from collections.abc import Sequence",
-        "from typing import TYPE_CHECKING",
+        "from typing import TYPE_CHECKING, TypeAlias",
     ]
-    assert "Scalar = str | int | float | bool | None" in lines
+    assert "Scalar: TypeAlias = str | int | float | bool | None" in lines
     assert "if TYPE_CHECKING:" in lines
     assert any(
-        line.strip()
-        == "SeriesInput = Records | Record | Sequence[Scalar] | pd.DataFrame | pl.DataFrame"
-        for line in lines
+        line.strip() == "DataFrameInput: TypeAlias = pd.DataFrame | pl.DataFrame" for line in lines
     )
-    assert any(
-        line.strip() == "SeriesInput = Records | Record | Sequence[Scalar] | object"
-        for line in lines
-    )
+    assert any(line.strip() == "DataFrameInput: TypeAlias = object" for line in lines)
+    assert "SeriesInput: TypeAlias = Records | Record | Sequence[Scalar] | DataFrameInput" in lines
 
 
 def test_emit_setter_type_alias_lines_include_datetime_when_needed() -> None:
     lines = emit_setter_type_alias_lines(include_datetime=True)
     assert lines[0] == "from collections.abc import Sequence"
-    assert "Scalar = str | int | float | bool | datetime | None" in lines
-    assert any(
-        line.strip()
-        == "SeriesInput = Records | Record | Sequence[Scalar] | pd.DataFrame | pl.DataFrame"
-        for line in lines
-    )
+    assert "Scalar: TypeAlias = str | int | float | bool | datetime | None" in lines
+    assert "SeriesInput: TypeAlias = Records | Record | Sequence[Scalar] | DataFrameInput" in lines
 
 
 def test_emit_compute_preamble_lines_include_datetime_when_needed() -> None:

--- a/tests/unit/series_bindings/test_keyless_scalar.py
+++ b/tests/unit/series_bindings/test_keyless_scalar.py
@@ -175,6 +175,6 @@ def test_keyless_scalar_codegen_signature_uses_scalar_alias(tmp_path: Path) -> N
     lines = emit_setters_block(graph, wb_path, bindings)
     code = "\n".join(lines)
 
-    assert "Scalar = str | int | float | bool | None" in code
-    assert "Scalar = str | int | float | bool | datetime | None" not in code
+    assert "Scalar: TypeAlias = str | int | float | bool | None" in code
+    assert "Scalar: TypeAlias = str | int | float | bool | datetime | None" not in code
     assert "records: Records | Record | Scalar," in code

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -234,12 +234,7 @@ def test_emit_setters_block_emits_helpers_once(tmp_path: Path) -> None:
     assert code.count("def _coerce_records(") == 1
     assert code.count("def coerce_setter_input(") == 1
     assert code.count("if TYPE_CHECKING:") == 1
-    assert (
-        code.count(
-            "SeriesInput = Records | Record | Sequence[Scalar] | pd.DataFrame | pl.DataFrame"
-        )
-        >= 1
-    )
+    assert "SeriesInput: TypeAlias = Records | Record | Sequence[Scalar] | DataFrameInput" in code
     assert "_KEY_ORDER_BORVELIA_PRIMARY_BALANCE" in code
     assert "_apply_series_records(" in code
     assert "def set_borvelia_primary_balance(" in code
@@ -556,7 +551,7 @@ def test_emit_setters_block_includes_datetime_aliases_when_needed(tmp_path: Path
     }
     code = "\n".join(emit_setters_block(graph, wb_path, bindings))
     assert "from datetime import date, datetime, timedelta" in code
-    assert "Scalar = str | int | float | bool | datetime | None" in code
+    assert "Scalar: TypeAlias = str | int | float | bool | datetime | None" in code
 
 
 def test_emit_setter_scalar_bool_measure_round_trips(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Emit `TypeAlias` annotations for generated setter type aliases (`SeriesInput`, `Scalar`, `Record`, etc.) so type checkers treat them as types, not variables.
- Refactor the DataFrame branch to use a `DataFrameInput` helper alias, matching `setter_input_types.py`.
- Fixes Pylance `reportInvalidTypeForm` ("Variable not allowed in type expression") when `api.py` imports `SeriesInput` from `_api_helpers.py` for setter signatures.

## Test plan

- [x] `uv run pytest tests/unit/series_bindings/test_codegen_literals.py tests/unit/series_bindings/test_setter_codegen.py tests/unit/series_bindings/test_keyless_scalar.py tests/integration/exporter/test_series_bindings_api_helpers_module.py`
- [x] Re-export a workbook and confirm Pylance accepts `records: SeriesInput` in generated `api.py`