### PR TITLE
fix: enforce raise-only export boundary

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast as py_ast
 import re
 from collections.abc import Iterable, Mapping, Sequence, Set
 from pathlib import Path
@@ -1218,15 +1219,9 @@ class CodeGenerator:
         # Excel-style boolean coercion is not Python truthiness:
         # - "FALSE" should behave like False
         # - "0" should produce #VALUE! (per to_bool)
-        # We must coerce via to_bool(), and keep lazy branch evaluation.
-        # Erroring conditions propagate: raised errors pass through, and
-        # sentinel coercion failures are re-raised via xl_raise.
-        cond_var = self._next_temp_var()
+        # `xl_bool` keeps lazy branch evaluation while raising coercion errors.
         bool_var = self._next_temp_var()
-        return (
-            f"(xl_raise({bool_var}) if isinstance(({bool_var} := to_bool(({cond_var} := {cond_expr}))), XlError) "
-            f"else (({true_expr}) if {bool_var} else ({false_expr})))"
-        )
+        return f"(({true_expr}) if ({bool_var} := xl_bool({cond_expr})) else ({false_expr}))"
 
     def _emit_row(self, node: FunctionCallNode) -> str:
         if not node.args or (len(node.args) == 1 and isinstance(node.args[0], EmptyArgNode)):
@@ -1310,10 +1305,8 @@ class CodeGenerator:
         index_expr = self._emit_ast(node.args[0])
         value_exprs = [self._emit_ast(arg) for arg in node.args[1:]]
 
-        # Store index in temp vars to avoid evaluating twice and to keep typing clean.
-        # We coerce via to_int() (Excel-style numeric coercion + error propagation)
-        # to avoid `int(CellValue)` in generated code (which type-checkers reject).
-        var = self._next_temp_var()
+        # Store index in a temp var to avoid evaluating twice and to keep typing clean.
+        # `xl_int` performs Excel-style numeric coercion and raises on errors.
         idx_var = self._next_temp_var()
 
         # Build chained conditionals: if idx==1 then val1 else if idx==2 then val2 ...
@@ -1322,11 +1315,10 @@ class CodeGenerator:
         for i, val_expr in reversed(list(enumerate(value_exprs, start=1))):
             result = f"(({val_expr}) if {idx_var} == {i} else ({result}))"
 
-        # Wrap with error/bounds checking; sentinel index coercions re-raise.
+        # Wrap with bounds checking; coercion errors raise from `xl_int`.
         return (
-            f"(xl_raise({var}) if isinstance(({var} := {index_expr}), XlError) "
-            f"else (xl_raise({idx_var}) if isinstance(({idx_var} := to_int({var})), XlError) "
-            f"else xl_raise(XlError.VALUE) if {idx_var} < 1 or {idx_var} > {len(value_exprs)} else {result}))"
+            f"((xl_raise(XlError.VALUE) if ({idx_var} := xl_int({index_expr})) < 1 "
+            f"or {idx_var} > {len(value_exprs)} else {result}))"
         )
 
     def _is_constant_number(self, node: AstNode) -> bool:
@@ -1744,6 +1736,45 @@ class CodeGenerator:
 
         return "\n".join(lines)
 
+    @staticmethod
+    def _is_xlerror_type_expr(node: py_ast.AST) -> bool:
+        if isinstance(node, py_ast.Name):
+            return node.id == "XlError"
+        if isinstance(node, py_ast.Tuple):
+            return any(CodeGenerator._is_xlerror_type_expr(elt) for elt in node.elts)
+        return False
+
+    @classmethod
+    def _cell_function_has_xlerror_isinstance(cls, node: py_ast.FunctionDef) -> bool:
+        for child in py_ast.walk(node):
+            if not isinstance(child, py_ast.Call):
+                continue
+            if not isinstance(child.func, py_ast.Name) or child.func.id != "isinstance":
+                continue
+            if len(child.args) < 2:
+                continue
+            if cls._is_xlerror_type_expr(child.args[1]):
+                return True
+        return False
+
+    @classmethod
+    def _assert_raise_only_cell_boundary(cls, cell_code_lines: list[str]) -> None:
+        """Reject generated formula cells that inspect `XlError` sentinels."""
+        module = py_ast.parse("\n".join(cell_code_lines))
+        offenders = [
+            node.name
+            for node in module.body
+            if isinstance(node, py_ast.FunctionDef)
+            and node.name.startswith("cell_")
+            and cls._cell_function_has_xlerror_isinstance(node)
+        ]
+        if offenders:
+            joined = ", ".join(offenders)
+            raise ValueError(
+                "Generated formula cell functions must not inspect XlError sentinels "
+                f"with isinstance(): {joined}"
+            )
+
     def _collect_dependencies(self, address: str) -> list[str]:
         """Collect all cell addresses that a cell depends on (recursively).
 
@@ -1885,9 +1916,7 @@ class CodeGenerator:
                 funcs.add("xl_raise")
             # IF, IFERROR, CHOOSE are special - emitted as native Python conditionals
             elif upper_name == "IF":
-                funcs.add("XlError")
-                funcs.add("to_bool")
-                funcs.add("xl_raise")
+                funcs.add("xl_bool")
             elif upper_name == "IFERROR":
                 funcs.add("XlError")
                 funcs.add("xl_iferror")
@@ -1896,7 +1925,7 @@ class CodeGenerator:
                 funcs.add("xl_ifna")
             elif upper_name == "CHOOSE":
                 funcs.add("XlError")
-                funcs.add("to_int")
+                funcs.add("xl_int")
                 funcs.add("xl_raise")
             elif upper_name == "ROW":
                 funcs.add("xl_row")
@@ -2442,6 +2471,8 @@ class CodeGenerator:
             assert ast is not None
             self._note_operators_fastpath_from_ast(ast)
             used_xl_functions.update(self._extract_xl_functions(ast))
+
+        self._assert_raise_only_cell_boundary(cell_code_lines)
 
         # Always include per-call evaluation scaffolding.
         # XlError is commonly referenced by generated code (error literals, IF/IFERROR, and

--- a/excel_grapher/exporter/export_runtime/__init__.py
+++ b/excel_grapher/exporter/export_runtime/__init__.py
@@ -15,7 +15,9 @@ from .errors import XlErrorException, xl_raise
 from .lookup import xl_hlookup, xl_index, xl_lookup, xl_match, xl_vlookup, xl_xlookup
 from .offset import xl_offset, xl_range, xl_range_rows
 from .operators import (
+    xl_bool,
     xl_compare,
+    xl_int,
     xl_is_array,
     xl_map_arithmetic,
     xl_map_compare,
@@ -33,11 +35,13 @@ __all__ = [
     "Range",
     "XlErrorException",
     "flatten",
+    "xl_bool",
     "xl_compare",
     "xl_hlookup",
     "xl_iferror",
     "xl_ifna",
     "xl_index",
+    "xl_int",
     "xl_is_array",
     "xl_isblank",
     "xl_iserror",

--- a/excel_grapher/exporter/export_runtime/offset.py
+++ b/excel_grapher/exporter/export_runtime/offset.py
@@ -70,7 +70,11 @@ def xl_index_ref(
     col_num: CellValue | None,
 ) -> tuple[str, int, int] | tuple[str, int, int, int, int]:
     """Return INDEX reference metadata, raising on Excel reference errors."""
-    out = index_excel_range(_range_from_ref_info(ref), row_num, col_num)
+    out = index_excel_range(
+        cast("Any", _range_from_ref_info(ref)),
+        cast("Any", row_num),
+        cast("Any", col_num),
+    )
     if isinstance(out, XlError):
         raise XlErrorException(out)
     if out.start_row == out.end_row and out.start_col == out.end_col:

--- a/excel_grapher/exporter/export_runtime/offset.py
+++ b/excel_grapher/exporter/export_runtime/offset.py
@@ -7,14 +7,15 @@ from typing import Any, cast
 import fastpyxl.utils.cell
 
 from excel_grapher.core import XlError, to_number
+from excel_grapher.core.addressing import index_excel_range
 from excel_grapher.core.address_keys import format_cell_key
 from excel_grapher.core.types import XlErrorException
 from excel_grapher.runtime.cache import EvalContext, _parse_range_address, xl_cell
 
 from .ranges import Range
-from .values import CellValue, as_scalar
+from .values import CellValue, ExcelRange, as_scalar
 
-__all__ = ["xl_offset", "xl_range", "xl_range_rows"]
+__all__ = ["xl_index_ref", "xl_offset", "xl_range", "xl_range_rows"]
 
 
 def _format_address(sheet: str, row: int, col: int) -> str:
@@ -34,6 +35,47 @@ def _ctx_range(ctx: EvalContext, sheet: str, r1: int, c1: int, r2: int, c2: int)
         return xl_cell(ctx, address)
 
     return Range(sheet, r1, c1, r2, c2, resolve)
+
+
+def _range_from_ref_info(
+    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
+) -> ExcelRange:
+    """Normalize generated reference metadata into an `ExcelRange`."""
+    if isinstance(ref, ExcelRange):
+        return ref
+    match ref:
+        case (sheet, base_row, base_col):
+            return ExcelRange(
+                sheet=sheet,
+                start_row=base_row,
+                start_col=base_col,
+                end_row=base_row,
+                end_col=base_col,
+            )
+        case (sheet, base_row, base_col, base_end_row, base_end_col):
+            return ExcelRange(
+                sheet=sheet,
+                start_row=base_row,
+                start_col=base_col,
+                end_row=base_end_row,
+                end_col=base_end_col,
+            )
+        case _:
+            raise XlErrorException(XlError.VALUE)
+
+
+def xl_index_ref(
+    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
+    row_num: CellValue | None,
+    col_num: CellValue | None,
+) -> tuple[str, int, int] | tuple[str, int, int, int, int]:
+    """Return INDEX reference metadata, raising on Excel reference errors."""
+    out = index_excel_range(_range_from_ref_info(ref), row_num, col_num)
+    if isinstance(out, XlError):
+        raise XlErrorException(out)
+    if out.start_row == out.end_row and out.start_col == out.end_col:
+        return (out.sheet, out.start_row, out.start_col)
+    return (out.sheet, out.start_row, out.start_col, out.end_row, out.end_col)
 
 
 def xl_offset(

--- a/excel_grapher/exporter/export_runtime/offset.py
+++ b/excel_grapher/exporter/export_runtime/offset.py
@@ -7,8 +7,8 @@ from typing import Any, cast
 import fastpyxl.utils.cell
 
 from excel_grapher.core import XlError, to_number
-from excel_grapher.core.addressing import index_excel_range
 from excel_grapher.core.address_keys import format_cell_key
+from excel_grapher.core.addressing import index_excel_range
 from excel_grapher.core.types import XlErrorException
 from excel_grapher.runtime.cache import EvalContext, _parse_range_address, xl_cell
 

--- a/excel_grapher/exporter/export_runtime/operators.py
+++ b/excel_grapher/exporter/export_runtime/operators.py
@@ -6,7 +6,7 @@ cover coercion, Excel-specific error semantics, and lazy-range array broadcast.
 
 from __future__ import annotations
 
-from excel_grapher.core import XlError, to_number
+from excel_grapher.core import XlError, to_bool, to_int, to_number
 from excel_grapher.core.operators_reference import (
     apply_arithmetic,
     compare_scalars,
@@ -19,6 +19,8 @@ from .values import CellValue, ExcelRange, Grid, Scalar, as_scalar
 
 __all__ = [
     "xl_compare",
+    "xl_bool",
+    "xl_int",
     "xl_is_array",
     "xl_map_arithmetic",
     "xl_map_compare",
@@ -43,6 +45,28 @@ def xl_number(value: CellValue) -> float:
     if isinstance(number, XlError):
         raise _raise_error(number)
     return number
+
+
+def xl_int(value: CellValue) -> int:
+    """Coerce a scalar cell value to an integer, raising on Excel errors."""
+    scalar = as_scalar(value)
+    if isinstance(scalar, XlError):
+        raise _raise_error(scalar)
+    integer = to_int(scalar)
+    if isinstance(integer, XlError):
+        raise _raise_error(integer)
+    return integer
+
+
+def xl_bool(value: CellValue) -> bool:
+    """Coerce a scalar cell value to a boolean, raising on Excel errors."""
+    scalar = as_scalar(value)
+    if isinstance(scalar, XlError):
+        raise _raise_error(scalar)
+    boolean = to_bool(scalar)
+    if isinstance(boolean, XlError):
+        raise _raise_error(boolean)
+    return boolean
 
 
 def xl_is_array(value: object) -> bool:

--- a/tests/integration/exporter/test_raise_based_errors.py
+++ b/tests/integration/exporter/test_raise_based_errors.py
@@ -6,6 +6,7 @@ the evaluator keeps `XlError` sentinels. Parity is asserted on matching codes.
 
 from __future__ import annotations
 
+import ast as py_ast
 from typing import Any, cast
 
 import pytest
@@ -15,6 +16,8 @@ from excel_grapher.core.address_keys import parse_address
 from excel_grapher.core.types import XlErrorException
 from excel_grapher.evaluator.types import XlError
 from excel_grapher.exporter.codegen import CodeGenerator
+from excel_grapher.exporter.export_runtime.offset import xl_index_ref
+from excel_grapher.exporter.export_runtime.operators import xl_bool, xl_int
 from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
 
 
@@ -45,6 +48,76 @@ def _compute_all(graph: DependencyGraph, targets: list[str]) -> tuple[Any, dict[
     ns: dict[str, Any] = {}
     exec(code, ns)
     return ns["compute_all"], ns
+
+
+def _cell_function_sources(code: str) -> dict[str, str]:
+    module = py_ast.parse(code)
+    out: dict[str, str] = {}
+    for node in module.body:
+        if isinstance(node, py_ast.FunctionDef) and node.name.startswith("cell_"):
+            source = py_ast.get_source_segment(code, node)
+            assert source is not None
+            out[node.name] = source
+    return out
+
+
+def _has_xlerror_isinstance(function_source: str) -> bool:
+    function = py_ast.parse(function_source).body[0]
+    assert isinstance(function, py_ast.FunctionDef)
+    for node in py_ast.walk(function):
+        if not isinstance(node, py_ast.Call):
+            continue
+        if not isinstance(node.func, py_ast.Name) or node.func.id != "isinstance":
+            continue
+        if len(node.args) < 2:
+            continue
+        type_arg = node.args[1]
+        if isinstance(type_arg, py_ast.Name) and type_arg.id == "XlError":
+            return True
+        if isinstance(type_arg, py_ast.Tuple):
+            for elt in type_arg.elts:
+                if isinstance(elt, py_ast.Name) and elt.id == "XlError":
+                    return True
+    return False
+
+
+class TestExportRuntimeBoundaryHelpers:
+    """Export-owned coercion and reference helpers raise at the codegen boundary."""
+
+    @pytest.mark.parametrize(
+        ("helper", "bad_value"),
+        [
+            (xl_bool, "nope"),
+            (xl_int, "nope"),
+        ],
+    )
+    def test_scalar_coercion_wrappers_raise_errors(self, helper: Any, bad_value: object) -> None:
+        with pytest.raises(XlErrorException) as exc_info:
+            helper(bad_value)
+        assert exc_info.value.code == XlError.VALUE
+
+    def test_index_ref_raises_reference_errors(self) -> None:
+        with pytest.raises(XlErrorException) as exc_info:
+            xl_index_ref(("Sheet1", 1, 1, 3, 1), 99, None)
+        assert exc_info.value.code == XlError.REF
+
+
+class TestGeneratedBoundaryInvariant:
+    """Generated formula cells do not inspect `XlError` sentinels directly."""
+
+    def test_if_and_choose_use_raise_only_coercion_wrappers(self) -> None:
+        graph = _make_graph(
+            _make_node("S!A1", '=IF("nope", 1, 2)', None),
+            _make_node("S!A2", '=CHOOSE("nope", 1, 2)', None),
+        )
+        code = CodeGenerator(graph).generate(["S!A1", "S!A2"])
+        cells = _cell_function_sources(code)
+
+        assert "xl_bool(" in cells["cell_s_a1"]
+        assert "to_bool(" not in cells["cell_s_a1"]
+        assert "xl_int(" in cells["cell_s_a2"]
+        assert "to_int(" not in cells["cell_s_a2"]
+        assert not any(_has_xlerror_isinstance(source) for source in cells.values())
 
 
 class TestComputeAllRaises:

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -288,14 +288,14 @@ class TestEmitAstFunctions:
             ],
         )
         result = gen._emit_ast(node)
-        # IF is emitted as lazy conditional: error check, then conditional expression
+        # IF is emitted as a lazy conditional with raise-only boolean coercion.
         assert "xl_compare('>', xl_cell(ctx, 'Sheet1!A1'), 0.0)" in result
         assert "'positive'" in result
         assert "'non-positive'" in result
-        assert "XlError" in result  # Error propagation check
-        # Condition is evaluated once, coerced via to_bool(), then used in a lazy conditional.
-        assert "to_bool" in result
-        assert "if _t2 else" in result
+        assert "XlError" not in result
+        assert "to_bool" not in result
+        assert "xl_bool(" in result
+        assert "if (_t1 :=" in result
 
     def test_emit_function_vlookup(self, gen):
         """VLOOKUP function."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add raise-only `xl_bool`, `xl_int`, and export-owned `xl_index_ref` boundary helpers
- emit IF/CHOOSE with those wrappers instead of sentinel `isinstance(..., XlError)` guards
- validate generated formula cell functions to reject direct `XlError` sentinel type checks
- add regression coverage for the runtime helpers and generated-cell invariant
- update the IF codegen unit assertion for the wrapper-based boundary shape
- make the export-runtime/reference helper type boundary explicit so `ty check` passes

## Checks
Pre-commit config requires:
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`

Verified locally:
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests/integration/exporter/test_raise_based_errors.py tests/unit/exporter/test_emit_runtime.py`
- `uv run pytest`

CI:
- `Test, lint, and type check` passed on commit `f330a029e8c82ecc23a22178214e0ef4f8634960`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d914773a-8377-4b47-bdee-a83b70516e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d914773a-8377-4b47-bdee-a83b70516e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

