### PR TITLE
chore: relicense project under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Teal Insights
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from excel_grapher.core import XlError  # and other shared types, if needed
 
 ### Installation
 
-This is a proprietary package. Install from the private GitHub repository:
+Released under the [MIT license](LICENSE). Install from GitHub:
 
 **Using `uv` (recommended):**
 
@@ -60,8 +60,6 @@ pip install git+https://github.com/Teal-Insights/excel-grapher
 # With extras:
 pip install "excel-grapher[networkx] @ git+https://github.com/Teal-Insights/excel-grapher"
 ```
-
-> **Note:** You must have access to the Teal-Insights GitHub organization and appropriate SSH keys or tokens configured.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.1.1"
 
 description = "Build and analyze dependency graphs from Excel workbooks"
 readme = "README.md"
-license = { text = "Proprietary" }
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 authors = [
     { name = "Teal Insights", email = "info@tealinsights.com" },
@@ -13,7 +13,7 @@ keywords = ["excel", "dependency", "graph", "spreadsheet", "formula", "transpile
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: Other/Proprietary License",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
- Add standard MIT `LICENSE` file (copyright Teal Insights, 2026)
- Update `pyproject.toml` metadata and Trove classifier from proprietary to MIT
- Update README installation section to reflect open-source licensing and remove private-repo access note

## Test plan
- [x] Pre-commit hooks passed on commit
- [ ] Verify package metadata resolves `license = { file = "LICENSE" }` on build/publish