### PR TITLE
feat(series_bindings): add API grouping for export sequencing

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -2367,6 +2367,14 @@ class CodeGenerator:
         }
         if api_helpers_py is not None:
             modules["_api_helpers.py"] = api_helpers_py
+        if series_bindings is not None:
+            from excel_grapher.series_bindings.groups import (
+                any_series_has_groups,
+                emit_api_manifest_json,
+            )
+
+            if any_series_has_groups(series_bindings):
+                modules["api_manifest.json"] = emit_api_manifest_json(series_bindings)
         return modules
 
     def _workbook_sort_addresses(self, addresses: Iterable[str]) -> list[str]:

--- a/excel_grapher/series_bindings/compute_codegen.py
+++ b/excel_grapher/series_bindings/compute_codegen.py
@@ -18,6 +18,7 @@ from excel_grapher.series_bindings.docstrings import (
     emit_docstring_literal,
     resolve_series_function_docstring,
 )
+from excel_grapher.series_bindings.groups import any_series_has_groups, ordered_series_for_direction
 from excel_grapher.series_bindings.normalize import has_output_direction
 from excel_grapher.series_bindings.resolve import (
     resolve_series_bindings,
@@ -156,7 +157,17 @@ def emit_computes_block(
         if isinstance(s, dict) and has_output_direction(s)
     }
     failed: list[str] = []
-    for resolved in report["series"]:
+    resolved_by_id = {resolved["series_id"]: resolved for resolved in report["series"]}
+    if any_series_has_groups(bindings):
+        series_order = ordered_series_for_direction(bindings, "output")
+        resolution_order = [
+            resolved_by_id[series["id"]]
+            for series in series_order
+            if series["id"] in resolved_by_id
+        ]
+    else:
+        resolution_order = report["series"]
+    for resolved in resolution_order:
         if not resolved["ok"]:
             failed.append(resolved["series_id"])
             continue

--- a/excel_grapher/series_bindings/groups.py
+++ b/excel_grapher/series_bindings/groups.py
@@ -1,0 +1,203 @@
+"""View-level API grouping for series binding export sequencing and manifests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from excel_grapher.series_bindings.normalize import has_input_direction, has_output_direction
+from excel_grapher.series_bindings.types import WorkbookSeriesBindings
+
+Direction = Literal["input", "output"]
+API_MANIFEST_SCHEMA_VERSION = "1.0.0"
+
+
+def any_series_has_groups(bindings: WorkbookSeriesBindings) -> bool:
+    """Return whether any series entry declares API groups."""
+    for series in bindings.get("series", []):
+        if isinstance(series, dict) and series.get("groups"):
+            return True
+    return False
+
+
+def _primary_group(series: dict[str, Any]) -> dict[str, Any] | None:
+    groups = series.get("groups")
+    if not isinstance(groups, list) or not groups:
+        return None
+    first = groups[0]
+    return first if isinstance(first, dict) else None
+
+
+def _group_sort_key(
+    series: dict[str, Any],
+    manifest_index: int,
+    fn_name: str,
+) -> tuple[Any, ...]:
+    primary = _primary_group(series)
+    if primary is None:
+        return (1, (), manifest_index, manifest_index, fn_name)
+    path = tuple(str(part) for part in primary.get("path") or [])
+    order = primary.get("order")
+    order_key = manifest_index if order is None else (0, order)
+    return (0, path, order_key, manifest_index, fn_name)
+
+
+def _series_with_index(
+    bindings: WorkbookSeriesBindings,
+    *,
+    direction: Direction | None = None,
+) -> list[tuple[int, dict[str, Any]]]:
+    indexed: list[tuple[int, dict[str, Any]]] = []
+    for index, series in enumerate(bindings.get("series", [])):
+        if not isinstance(series, dict):
+            continue
+        if direction == "input" and not has_input_direction(series):
+            continue
+        if direction == "output" and not has_output_direction(series):
+            continue
+        indexed.append((index, series))
+    return indexed
+
+
+def _function_name(series: dict[str, Any], *, direction: Direction) -> str | None:
+    if direction == "input":
+        input_block = series.get("input") or {}
+        setter = input_block.get("setter") or series.get("setter")
+        if isinstance(setter, dict) and setter.get("name"):
+            return str(setter["name"])
+        return None
+    output_block = series.get("output") or {}
+    compute = output_block.get("compute")
+    if isinstance(compute, dict) and compute.get("name"):
+        return str(compute["name"])
+    return None
+
+
+def ordered_series_for_direction(
+    bindings: WorkbookSeriesBindings,
+    direction: Direction,
+) -> list[dict[str, Any]]:
+    """Return series entries ordered for export when groups are declared."""
+    indexed = _series_with_index(bindings, direction=direction)
+    if not any_series_has_groups(bindings):
+        return [series for _, series in indexed]
+
+    def sort_key(item: tuple[int, dict[str, Any]]) -> tuple[Any, ...]:
+        index, series = item
+        fn_name = _function_name(series, direction=direction) or series.get("id", "")
+        return _group_sort_key(series, index, str(fn_name))
+
+    return [series for _, series in sorted(indexed, key=sort_key)]
+
+
+def _ordered_function_names(
+    bindings: WorkbookSeriesBindings,
+    *,
+    direction: Direction,
+) -> list[str]:
+    names: list[str] = []
+    for series in ordered_series_for_direction(bindings, direction):
+        fn_name = _function_name(series, direction=direction)
+        if fn_name is not None:
+            names.append(fn_name)
+    if not any_series_has_groups(bindings):
+        return sorted(set(names))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            ordered.append(name)
+    return ordered
+
+
+def ordered_setter_names(bindings: WorkbookSeriesBindings) -> list[str]:
+    """Return setter function names ordered by declared API groups."""
+    return _ordered_function_names(bindings, direction="input")
+
+
+def ordered_compute_names(bindings: WorkbookSeriesBindings) -> list[str]:
+    """Return compute function names ordered by declared API groups."""
+    return _ordered_function_names(bindings, direction="output")
+
+
+def _insert_group_path(
+    tree: dict[str, Any],
+    path: list[str],
+    *,
+    direction: Direction,
+    fn_name: str,
+) -> None:
+    node = tree
+    for label in path:
+        if label not in node:
+            node[label] = {}
+        node = node[label]
+    node.setdefault("setters", [])
+    node.setdefault("computes", [])
+    bucket = "setters" if direction == "input" else "computes"
+    if fn_name not in node[bucket]:
+        node[bucket].append(fn_name)
+
+
+def _serialize_group_tree(node: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for label in sorted(node):
+        entry = node[label]
+        payload: dict[str, Any] = {}
+        if entry.get("setters"):
+            payload["setters"] = list(entry["setters"])
+        if entry.get("computes"):
+            payload["computes"] = list(entry["computes"])
+        child_labels = [key for key in entry if key not in {"setters", "computes"}]
+        for child_label in sorted(child_labels):
+            payload.update(_serialize_group_tree({child_label: entry[child_label]}))
+        result[label] = payload
+    return result
+
+
+def build_api_group_manifest(bindings: WorkbookSeriesBindings) -> dict[str, Any]:
+    """Build a machine-readable manifest of grouped export API symbols."""
+    tree: dict[str, Any] = {}
+    members: list[dict[str, Any]] = []
+
+    for direction in ("input", "output"):
+        for series in ordered_series_for_direction(bindings, direction):
+            fn_name = _function_name(series, direction=direction)
+            if fn_name is None:
+                continue
+            groups = series.get("groups") or []
+            member: dict[str, Any] = {
+                "series_id": series["id"],
+                "name": fn_name,
+                "direction": direction,
+            }
+            if groups:
+                member["groups"] = groups
+            members.append(member)
+            primary = _primary_group(series)
+            if primary is not None:
+                path = [str(part) for part in primary.get("path") or []]
+                if path:
+                    _insert_group_path(
+                        tree,
+                        path,
+                        direction=direction,
+                        fn_name=fn_name,
+                    )
+
+    return {
+        "schema_version": API_MANIFEST_SCHEMA_VERSION,
+        "bindings_schema_version": bindings.get("schema_version"),
+        "members": members,
+        "group_tree": _serialize_group_tree(tree),
+        "flat": {
+            "setters": ordered_setter_names(bindings),
+            "computes": ordered_compute_names(bindings),
+        },
+    }
+
+
+def emit_api_manifest_json(bindings: WorkbookSeriesBindings) -> str:
+    """Serialize the API group manifest as formatted JSON."""
+    return json.dumps(build_api_group_manifest(bindings), indent=2, sort_keys=False) + "\n"

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -18,6 +18,7 @@ _STRUCTURAL_FIELDS = frozenset(
         "editable",
         "sdmx_notes",
         "notes",
+        "groups",
     }
 )
 

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout and row_hierarchy bind (matrix supported with explicit binds; row_hierarchy schema-valid only). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry — skip/include/fill/missing on row_label and column_header binds, the value_map bind kind, and series-level exclude_rows."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"],
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout and row_hierarchy bind (matrix supported with explicit binds; row_hierarchy schema-valid only). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry — skip/include/fill/missing on row_label and column_header binds, the value_map bind kind, and series-level exclude_rows. 1.6.0: optional groups on series bindings for export API sequencing and documentation manifests."
     },
     "workbook": {
       "type": "string",
@@ -421,6 +421,26 @@
       "enum": ["series", "scalar", "matrix"],
       "description": "Optional declarative intent for analysts and layout-specific validation. Resolution and codegen use bind kinds, not layout name. series: one-dimensional data_range with at least one cell-scoped dimension when declared. scalar: single leaf. matrix: rectangular multi-row data_range with at least two dimensions and a cell-scoped dimension when declared."
     },
+    "BindingGroup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": {
+        "path": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Ordered group labels from outermost to innermost for export sequencing and documentation."
+        },
+        "order": {
+          "type": "number",
+          "description": "Optional intra-group sequencing hint for generated API symbols; never required."
+        }
+      }
+    },
     "SeriesBinding": {
       "type": "object",
       "additionalProperties": false,
@@ -503,6 +523,11 @@
         "notes": {
           "type": "string",
           "description": "Free-form analyst notes."
+        },
+        "groups": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/BindingGroup" },
+          "description": "Optional view-level API grouping for export sequencing and documentation manifests. Does not affect graph extraction or resolution."
         }
       },
       "allOf": [

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -18,6 +18,7 @@ from excel_grapher.series_bindings.docstrings import (
     emit_docstring_literal,
     resolve_series_function_docstring,
 )
+from excel_grapher.series_bindings.groups import any_series_has_groups, ordered_series_for_direction
 from excel_grapher.series_bindings.normalize import has_input_direction
 from excel_grapher.series_bindings.resolve import (
     resolve_series_bindings,
@@ -462,7 +463,17 @@ def emit_setters_block(
         if isinstance(s, dict) and has_input_direction(s)
     }
     failed: list[str] = []
-    for resolved in report["series"]:
+    resolved_by_id = {resolved["series_id"]: resolved for resolved in report["series"]}
+    if any_series_has_groups(bindings):
+        series_order = ordered_series_for_direction(bindings, "input")
+        resolution_order = [
+            resolved_by_id[series["id"]]
+            for series in series_order
+            if series["id"] in resolved_by_id
+        ]
+    else:
+        resolution_order = report["series"]
+    for resolved in resolution_order:
         if not resolved["ok"] and not resolved["requires_address"]:
             failed.append(resolved["series_id"])
             continue

--- a/excel_grapher/series_bindings/types.py
+++ b/excel_grapher/series_bindings/types.py
@@ -7,6 +7,13 @@ ValidationLevel = Literal["error", "warning"]
 Scalar = str | int | float | bool | datetime | None
 
 
+class BindingGroup(TypedDict):
+    """View-level API group membership for a series binding."""
+
+    path: list[str]
+    order: NotRequired[float | int]
+
+
 class WorkbookSeriesBindings(TypedDict):
     """Top-level workbook binding manifest (post-merge, post-schema validation)."""
 

--- a/excel_grapher/series_bindings/versions.py
+++ b/excel_grapher/series_bindings/versions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 SUPPORTED_SCHEMA_VERSIONS: frozenset[str] = frozenset(
-    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"}
+    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"}
 )
 
 IMPLEMENTED_BIND_KINDS: frozenset[str] = frozenset(

--- a/excel_grapher/series_bindings/workflow.py
+++ b/excel_grapher/series_bindings/workflow.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from excel_grapher.grapher import create_dependency_graph
 from excel_grapher.series_bindings.canonical import bindings_canonical_sha256
+from excel_grapher.series_bindings.groups import ordered_compute_names, ordered_setter_names
 from excel_grapher.series_bindings.input_series import derive_input_series
 from excel_grapher.series_bindings.load import SeriesBindingsLoadError, load_series_bindings
 from excel_grapher.series_bindings.ranges import expand_data_range
@@ -36,25 +37,13 @@ class BindingsCheckResult(TypedDict):
 
 
 def setter_names(bindings: WorkbookSeriesBindings) -> list[str]:
-    """Return sorted unique declared input setter function names."""
-    names: list[str] = []
-    for series in bindings["series"]:
-        input_block = series.get("input") or {}
-        setter = input_block.get("setter") or series.get("setter")
-        if isinstance(setter, dict) and setter.get("name"):
-            names.append(str(setter["name"]))
-    return sorted(set(names))
+    """Return declared input setter function names in export order."""
+    return ordered_setter_names(bindings)
 
 
 def compute_names(bindings: WorkbookSeriesBindings) -> list[str]:
-    """Return sorted unique declared output compute function names."""
-    names: list[str] = []
-    for series in bindings["series"]:
-        output_block = series.get("output") or {}
-        compute = output_block.get("compute")
-        if isinstance(compute, dict) and compute.get("name"):
-            names.append(str(compute["name"]))
-    return sorted(set(names))
+    """Return declared output compute function names in export order."""
+    return ordered_compute_names(bindings)
 
 
 def all_series_targets(

--- a/tests/integration/user_flows/test_series_bindings_groups_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_groups_codegen.py
@@ -1,0 +1,122 @@
+"""Integration: grouped series bindings drive export sequencing and manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import xlsxwriter
+
+from excel_grapher.exporter import CodeGenerator
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
+
+
+def _write_grouped_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number("A1", 1.0)
+    ws.write_number("B1", 2.0)
+    ws.write_number("C1", 3.0)
+    wb.close()
+
+
+GROUPED_BINDINGS: dict[str, Any] = {
+    "schema_version": "1.6.0",
+    "series": [
+        {
+            "id": "paris",
+            "sheet": "Sheet1",
+            "data_range": "Sheet1!C1",
+            "layout": "scalar",
+            "input": {"setter": {"name": "set_paris"}},
+            "groups": [{"path": ["Climate scenarios", "Paris"], "order": 2}],
+            "structure": {
+                "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+                "dimensions": [],
+            },
+            "key": [],
+        },
+        {
+            "id": "baseline",
+            "sheet": "Sheet1",
+            "data_range": "Sheet1!A1",
+            "layout": "scalar",
+            "input": {"setter": {"name": "set_baseline"}},
+            "groups": [{"path": ["Baseline setup"], "order": 1}],
+            "structure": {
+                "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+                "dimensions": [],
+            },
+            "key": [],
+        },
+        {
+            "id": "moderate",
+            "sheet": "Sheet1",
+            "data_range": "Sheet1!B1",
+            "layout": "scalar",
+            "input": {"setter": {"name": "set_moderate"}},
+            "groups": [{"path": ["Climate scenarios", "Moderate"], "order": 1}],
+            "structure": {
+                "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell", "read": "float"}},
+                "dimensions": [],
+            },
+            "key": [],
+        },
+    ],
+}
+
+
+def test_grouped_export_sequences_setters_and_emits_manifest(tmp_path: Path) -> None:
+    workbook = tmp_path / "grouped.xlsx"
+    _write_grouped_workbook(workbook)
+    bindings = validate_bindings_document(deepcopy(GROUPED_BINDINGS))
+    targets = expand_data_range("Sheet1!A1:C1", workbook=workbook)
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+
+    with CodeGenerator(graph) as gen:
+        modules = gen.generate_modules(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+    assert "api_manifest.json" in modules
+    manifest = json.loads(modules["api_manifest.json"])
+    assert manifest["flat"]["setters"] == [
+        "set_baseline",
+        "set_moderate",
+        "set_paris",
+    ]
+
+    api_py = modules["api.py"]
+    setter_defs = [
+        match.group(1) for match in re.finditer(r"^def (set_\w+)\(", api_py, flags=re.MULTILINE)
+    ]
+    assert setter_defs == ["set_baseline", "set_moderate", "set_paris"]
+
+    init_py = modules["__init__.py"]
+    all_match = re.search(r"__all__ = (\[.*?\])", init_py, flags=re.DOTALL)
+    assert all_match is not None
+    all_exports = eval(all_match.group(1))
+    setter_exports = [name for name in all_exports if name.startswith("set_")]
+    assert setter_exports == ["set_baseline", "set_moderate", "set_paris"]
+
+    list_setters_match = re.search(
+        r"def list_setters\(\).*?return (\[.*?\])",
+        api_py,
+        flags=re.DOTALL,
+    )
+    assert list_setters_match is not None
+    assert eval(list_setters_match.group(1)) == [
+        "set_baseline",
+        "set_moderate",
+        "set_paris",
+    ]
+
+    climate = manifest["group_tree"]["Climate scenarios"]
+    assert climate["Moderate"]["setters"] == ["set_moderate"]
+    assert climate["Paris"]["setters"] == ["set_paris"]

--- a/tests/unit/series_bindings/test_groups.py
+++ b/tests/unit/series_bindings/test_groups.py
@@ -1,0 +1,166 @@
+"""Unit tests for series binding API group ordering and manifest."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from excel_grapher.series_bindings.groups import (
+    any_series_has_groups,
+    build_api_group_manifest,
+    ordered_compute_names,
+    ordered_series_for_direction,
+    ordered_setter_names,
+)
+from excel_grapher.series_bindings.types import WorkbookSeriesBindings
+
+
+def _bindings(*series: dict[str, Any]) -> WorkbookSeriesBindings:
+    return {"schema_version": "1.6.0", "series": list(series)}
+
+
+def _setter_series(
+    series_id: str,
+    setter_name: str,
+    *,
+    groups: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": series_id,
+        "sheet": "S",
+        "data_range": "S!A1",
+        "input": {"setter": {"name": setter_name}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+            "dimensions": [],
+        },
+        "key": [],
+        "layout": "scalar",
+    }
+    if groups is not None:
+        entry["groups"] = groups
+    return entry
+
+
+def _compute_series(
+    series_id: str,
+    compute_name: str,
+    *,
+    groups: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": series_id,
+        "sheet": "S",
+        "data_range": "S!A1",
+        "output": {"compute": {"name": compute_name}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+            "dimensions": [],
+        },
+        "key": [],
+        "layout": "scalar",
+    }
+    if groups is not None:
+        entry["groups"] = groups
+    return entry
+
+
+def test_any_series_has_groups_false_when_all_omit_groups() -> None:
+    bindings = _bindings(
+        _setter_series("a", "set_a"),
+        _setter_series("b", "set_b"),
+    )
+    assert any_series_has_groups(bindings) is False
+
+
+def test_any_series_has_groups_true_when_one_declares_groups() -> None:
+    bindings = _bindings(
+        _setter_series("a", "set_a"),
+        _setter_series("b", "set_b", groups=[{"path": ["Macro"]}]),
+    )
+    assert any_series_has_groups(bindings) is True
+
+
+def test_ordered_setter_names_alpha_when_no_groups() -> None:
+    bindings = _bindings(
+        _setter_series("z", "set_z"),
+        _setter_series("a", "set_a"),
+    )
+    assert ordered_setter_names(bindings) == ["set_a", "set_z"]
+
+
+def test_ordered_setter_names_by_group_path_and_order() -> None:
+    bindings = _bindings(
+        _setter_series(
+            "paris",
+            "set_paris",
+            groups=[{"path": ["Climate scenarios", "Paris"], "order": 2}],
+        ),
+        _setter_series(
+            "baseline",
+            "set_baseline",
+            groups=[{"path": ["Baseline setup"], "order": 1}],
+        ),
+        _setter_series(
+            "moderate",
+            "set_moderate",
+            groups=[{"path": ["Climate scenarios", "Moderate"], "order": 1}],
+        ),
+        _setter_series("ungrouped", "set_ungrouped"),
+    )
+    assert ordered_setter_names(bindings) == [
+        "set_baseline",
+        "set_moderate",
+        "set_paris",
+        "set_ungrouped",
+    ]
+
+
+def test_ordered_setter_names_uses_manifest_order_within_group_when_order_omitted() -> None:
+    bindings = _bindings(
+        _setter_series("second", "set_second", groups=[{"path": ["Macro"]}]),
+        _setter_series("first", "set_first", groups=[{"path": ["Macro"]}]),
+    )
+    assert ordered_setter_names(bindings) == ["set_second", "set_first"]
+
+
+def test_ordered_compute_names_respects_groups() -> None:
+    bindings = _bindings(
+        _compute_series("b", "compute_b", groups=[{"path": ["Outputs"], "order": 2}]),
+        _compute_series("a", "compute_a", groups=[{"path": ["Outputs"], "order": 1}]),
+    )
+    assert ordered_compute_names(bindings) == ["compute_a", "compute_b"]
+
+
+def test_ordered_series_for_direction_filters_direction() -> None:
+    bindings = _bindings(
+        _setter_series("in_only", "set_in_only", groups=[{"path": ["Inputs"]}]),
+        _compute_series("out_only", "compute_out_only", groups=[{"path": ["Outputs"]}]),
+    )
+    input_ids = [s["id"] for s in ordered_series_for_direction(bindings, "input")]
+    output_ids = [s["id"] for s in ordered_series_for_direction(bindings, "output")]
+    assert input_ids == ["in_only"]
+    assert output_ids == ["out_only"]
+
+
+def test_build_api_group_manifest_nested_tree() -> None:
+    bindings = _bindings(
+        _setter_series(
+            "paris",
+            "set_paris",
+            groups=[{"path": ["Climate scenarios", "Paris"], "order": 1}],
+        ),
+        _compute_series(
+            "paris_out",
+            "compute_paris",
+            groups=[{"path": ["Climate scenarios", "Paris"], "order": 2}],
+        ),
+        _setter_series("baseline", "set_baseline", groups=[{"path": ["Baseline setup"]}]),
+    )
+    manifest = build_api_group_manifest(bindings)
+    assert manifest["schema_version"] == "1.0.0"
+    assert manifest["flat"]["setters"] == ordered_setter_names(bindings)
+    assert manifest["flat"]["computes"] == ordered_compute_names(bindings)
+    climate = manifest["group_tree"]["Climate scenarios"]
+    assert climate["Paris"]["setters"] == ["set_paris"]
+    assert climate["Paris"]["computes"] == ["compute_paris"]
+    assert manifest["group_tree"]["Baseline setup"]["setters"] == ["set_baseline"]

--- a/tests/unit/series_bindings/test_groups_schema.py
+++ b/tests/unit/series_bindings/test_groups_schema.py
@@ -1,0 +1,80 @@
+"""Schema tests for series binding API groups (schema 1.6.0)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from excel_grapher.series_bindings.schema import (
+    SeriesBindingsSchemaError,
+    validate_bindings_document,
+)
+from excel_grapher.series_bindings.versions import SUPPORTED_SCHEMA_VERSIONS
+
+
+def _scalar_series_doc(**series_overrides: Any) -> dict[str, Any]:
+    series: dict[str, Any] = {
+        "id": "bool_flag",
+        "sheet": "Flags",
+        "data_range": "Flags!B2",
+        "layout": "scalar",
+        "setter": {"name": "set_bool_flag"},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "IS_ACTIVE",
+                    "role": "key",
+                    "scope": "series",
+                    "bind": {"kind": "constant", "value": True},
+                }
+            ],
+        },
+        "key": ["IS_ACTIVE"],
+    }
+    series.update(series_overrides)
+    return {"schema_version": "1.6.0", "series": [series]}
+
+
+def test_schema_1_6_0_supported() -> None:
+    assert "1.6.0" in SUPPORTED_SCHEMA_VERSIONS
+
+
+def test_schema_accepts_groups_with_path_and_order() -> None:
+    doc = _scalar_series_doc(
+        groups=[{"path": ["Climate scenarios", "Paris"], "order": 13}],
+    )
+    bindings = validate_bindings_document(doc)
+    assert bindings["series"][0]["groups"] == [
+        {"path": ["Climate scenarios", "Paris"], "order": 13},
+    ]
+
+
+def test_schema_accepts_groups_without_order() -> None:
+    doc = _scalar_series_doc(groups=[{"path": ["Baseline setup"]}])
+    bindings = validate_bindings_document(doc)
+    assert bindings["series"][0]["groups"] == [{"path": ["Baseline setup"]}]
+
+
+def test_schema_rejects_empty_group_path() -> None:
+    doc = _scalar_series_doc(groups=[{"path": []}])
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_group_without_path() -> None:
+    doc = _scalar_series_doc(groups=[{"order": 1}])
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_1_5_0_ignores_groups_when_omitted() -> None:
+    doc = _scalar_series_doc()
+    doc["schema_version"] = "1.5.0"
+    bindings = validate_bindings_document(doc)
+    assert "groups" not in bindings["series"][0]

--- a/tests/unit/series_bindings/test_versions.py
+++ b/tests/unit/series_bindings/test_versions.py
@@ -19,7 +19,7 @@ FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "series_bindings"
 
 
 def test_supported_schema_versions() -> None:
-    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"})
+    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"})
     assert expected == SUPPORTED_SCHEMA_VERSIONS
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #308

## Summary

Adds optional, view-level API grouping to series bindings so generated `set_*` / `compute_*` symbols can be organized into named, nestable groups for export sequencing and documentation tooling.

## Changes

- **Schema 1.6.0**: optional `groups` field on `SeriesBinding` with nested `path` (`list[str]`, outer→inner) and optional `order`
- **`groups.py`**: ordering logic and `api_manifest.json` builder
- **Export sequencing**: when any series declares groups, setter/compute emission, `list_setters`/`list_computes`, and modular `__all__` follow group order (path, then `order`, then manifest index)
- **Modular export**: emits `api_manifest.json` with flat symbol lists and nested `group_tree` when groups are present
- **Backward compatible**: bindings without `groups` keep today's alphabetical ordering for discovery helpers

## Example binding

```yaml
schema_version: "1.6.0"
series:
  - id: climate_debt_to_gdp_paris
    # ... existing fields ...
    groups:
      - path: ["Climate scenarios", "Paris"]
        order: 13
```

## Testing

- Unit tests for schema validation, ordering logic, and manifest shape
- Integration test verifying grouped export sequencing and `api_manifest.json` emission
- Existing ffv2 and series-bindings codegen tests pass unchanged

## Open questions (from #308, deferred)

- Multi-membership vs single path (schema supports list; ordering uses first entry)
- Sub-namespacing surface (`pkg.api.<group>`) — not implemented in this PR
- Label/slug constraints beyond `minLength: 1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a76404fe-1e6a-49d0-9dff-1dac19c7b653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a76404fe-1e6a-49d0-9dff-1dac19c7b653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

