### PR TITLE
feat(series_bindings): add view-level groups for export sequencing (#308)

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast as py_ast
+import json
 import re
 from collections.abc import Iterable, Mapping, Sequence, Set
 from pathlib import Path
@@ -549,18 +550,42 @@ class CodeGenerator:
     def _series_binding_public_names(
         bindings: WorkbookSeriesBindings,
     ) -> tuple[list[str], list[str]]:
-        """Return declared public setter and compute function names."""
+        """Return declared public setter and compute function names.
+
+        Without groups the names sort alphabetically (flat export); with
+        view-level groups they follow the grouped export order.
+        """
+        from excel_grapher.series_bindings.groups import (
+            bindings_have_groups,
+            grouped_public_names,
+        )
         from excel_grapher.series_bindings.workflow import compute_names, setter_names
 
+        if bindings_have_groups(bindings):
+            return grouped_public_names(bindings)
         return setter_names(bindings), compute_names(bindings)
+
+    @staticmethod
+    def _series_binding_groups_manifest(
+        bindings: WorkbookSeriesBindings | None,
+    ) -> dict[str, Any] | None:
+        """Return the group manifest when any binding declares groups."""
+        if bindings is None:
+            return None
+        from excel_grapher.series_bindings.groups import bindings_have_groups, group_manifest
+
+        if not bindings_have_groups(bindings):
+            return None
+        return dict(group_manifest(bindings))
 
     @staticmethod
     def _emit_series_binding_discovery_lines(
         setter_names: Sequence[str],
         compute_names: Sequence[str],
+        groups_manifest: Mapping[str, Any] | None = None,
     ) -> list[str]:
         """Emit generated-code helpers that list public series-binding functions."""
-        return [
+        lines = [
             "def list_setters() -> list[str]:",
             '    """Return generated series-binding setter function names."""',
             f"    return {list(setter_names)!r}",
@@ -570,6 +595,17 @@ class CodeGenerator:
             '    """Return generated series-binding compute function names."""',
             f"    return {list(compute_names)!r}",
         ]
+        if groups_manifest is not None:
+            lines.extend(
+                [
+                    "",
+                    "",
+                    "def list_groups() -> dict[str, object]:",
+                    '    """Return the view-level group manifest for the generated API."""',
+                    f"    return {dict(groups_manifest)!r}",
+                ]
+            )
+        return lines
 
     def _range_addresses_2d(self, start: str, end: str) -> list[list[str]]:
         """Generate all cell addresses in a range as a 2D list (rows x cols)."""
@@ -2125,6 +2161,7 @@ class CodeGenerator:
             self._emit_series_binding_discovery_lines(
                 series_setter_names,
                 series_compute_names,
+                self._series_binding_groups_manifest(series_bindings),
             )
         )
         lines.append("")
@@ -2304,10 +2341,12 @@ class CodeGenerator:
                 series_bindings
             )
             api_lines.append("")
+        groups_manifest = self._series_binding_groups_manifest(series_bindings)
         api_lines.extend(
             self._emit_series_binding_discovery_lines(
                 series_setter_names,
                 series_compute_names,
+                groups_manifest,
             )
         )
         api_lines.append("")
@@ -2342,6 +2381,8 @@ class CodeGenerator:
         api_py = "\n".join(api_lines)
 
         api_exports = ["compute_all", "make_context", "list_setters", "list_computes"]
+        if groups_manifest is not None:
+            api_exports.append("list_groups")
         api_exports.extend(series_setter_names)
         api_exports.extend(series_compute_names)
         api_imports = ", ".join(api_exports)
@@ -2367,6 +2408,8 @@ class CodeGenerator:
         }
         if api_helpers_py is not None:
             modules["_api_helpers.py"] = api_helpers_py
+        if groups_manifest is not None:
+            modules["groups.json"] = json.dumps(groups_manifest, indent=2) + "\n"
         return modules
 
     def _workbook_sort_addresses(self, addresses: Iterable[str]) -> list[str]:

--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -32,6 +32,16 @@ from excel_grapher.series_bindings.docstrings import (
     resolve_series_docstring_callback,
     unregister_series_docstring_callback,
 )
+from excel_grapher.series_bindings.groups import (
+    GroupMember,
+    GroupNode,
+    GroupsManifest,
+    bindings_export_order,
+    bindings_have_groups,
+    group_manifest,
+    group_slug,
+    grouped_public_names,
+)
 from excel_grapher.series_bindings.input_coerce import coerce_setter_input
 from excel_grapher.series_bindings.input_series import derive_input_series
 from excel_grapher.series_bindings.load import (
@@ -141,7 +151,15 @@ __all__ = [
     "ValidationReport",
     "WorkbookSeriesBindings",
     "BindingsCheckResult",
+    "GroupMember",
+    "GroupNode",
+    "GroupsManifest",
     "bindings_canonical_sha256",
+    "bindings_export_order",
+    "bindings_have_groups",
+    "group_manifest",
+    "group_slug",
+    "grouped_public_names",
     "Layout",
     "SeriesInput",
     "coerce_setter_input",

--- a/excel_grapher/series_bindings/bindings_codegen.py
+++ b/excel_grapher/series_bindings/bindings_codegen.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.series_bindings.compute_codegen import emit_computes_block
+from excel_grapher.series_bindings.groups import bindings_export_order
 from excel_grapher.series_bindings.normalize import has_input_direction, has_output_direction
 from excel_grapher.series_bindings.setter_codegen import emit_setters_block
 from excel_grapher.series_bindings.types import WorkbookSeriesBindings
@@ -34,11 +35,12 @@ def emit_series_bindings_block(
     emitted; the helpers and aliases are expected to be importable from a separate
     module (the multi-module export's `_api_helpers`).
     """
-    series_list = [s for s in bindings.get("series", []) if isinstance(s, dict)]
+    series_list = bindings_export_order(bindings)
     emit_input = any(has_input_direction(s) for s in series_list)
     emit_output = any(has_output_direction(s) for s in series_list)
     if not emit_input and not emit_output:
         return []
+    bindings = cast(WorkbookSeriesBindings, {**bindings, "series": series_list})
 
     lines: list[str] = []
     include_aliases = include_helpers

--- a/excel_grapher/series_bindings/groups.py
+++ b/excel_grapher/series_bindings/groups.py
@@ -1,0 +1,216 @@
+"""View-level series binding groups: export sequencing and group manifest.
+
+Groups are a presentation concern of the generated `set_*`/`compute_*` API.
+They sequence code export and feed documentation tooling; they never affect
+graph extraction, binding resolution, or record semantics.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, TypedDict
+
+from excel_grapher.series_bindings.normalize import normalize_series_entry
+from excel_grapher.series_bindings.types import WorkbookSeriesBindings
+
+
+class GroupMember(TypedDict):
+    """One binding's membership entry inside a group manifest node."""
+
+    id: str
+    setter: str | None
+    compute: str | None
+    order: int | None
+
+
+class GroupNode(TypedDict):
+    """One group in the nested manifest tree."""
+
+    label: str
+    path: list[str]
+    slug: str
+    members: list[GroupMember]
+    children: list[GroupNode]
+
+
+class GroupsManifest(TypedDict):
+    """Machine-readable group structure for documentation tooling."""
+
+    groups: list[GroupNode]
+    ungrouped: list[GroupMember]
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def group_slug(label: str) -> str:
+    """Derive a Python-identifier-safe slug from a human-readable group label."""
+    slug = _SLUG_RE.sub("_", label.lower()).strip("_")
+    if not slug:
+        slug = "group"
+    if slug[0].isdigit():
+        slug = f"g{slug}"
+    return slug
+
+
+def _group_refs(series: dict[str, Any]) -> list[dict[str, Any]]:
+    groups = series.get("groups")
+    if not isinstance(groups, list):
+        return []
+    return [ref for ref in groups if isinstance(ref, dict) and ref.get("path")]
+
+
+def bindings_have_groups(bindings: WorkbookSeriesBindings | dict[str, Any]) -> bool:
+    """Return True when any series declares at least one group ref."""
+    return any(
+        _group_refs(series) for series in bindings.get("series", []) if isinstance(series, dict)
+    )
+
+
+def _setter_name(series: dict[str, Any]) -> str | None:
+    normalized = normalize_series_entry(series)
+    setter = (normalized.get("input") or {}).get("setter")
+    if isinstance(setter, dict) and setter.get("name"):
+        return str(setter["name"])
+    return None
+
+
+def _compute_name(series: dict[str, Any]) -> str | None:
+    compute = (series.get("output") or {}).get("compute")
+    if isinstance(compute, dict) and compute.get("name"):
+        return str(compute["name"])
+    return None
+
+
+def _member(series: dict[str, Any], order: int | None) -> GroupMember:
+    return {
+        "id": str(series.get("id", "")),
+        "setter": _setter_name(series),
+        "compute": _compute_name(series),
+        "order": order,
+    }
+
+
+class _TreeNode:
+    """Mutable group tree node used while scanning bindings in declaration order."""
+
+    def __init__(self, label: str, path: tuple[str, ...]) -> None:
+        self.label = label
+        self.path = path
+        self.children: dict[str, _TreeNode] = {}
+        # (order-is-missing, order, declaration_index) sort key per member.
+        self.members: list[tuple[bool, int, int, dict[str, Any], int | None]] = []
+
+    def child(self, label: str) -> _TreeNode:
+        if label not in self.children:
+            self.children[label] = _TreeNode(label, self.path + (label,))
+        return self.children[label]
+
+    def sorted_members(self) -> list[tuple[dict[str, Any], int | None]]:
+        return [
+            (series, order)
+            for _, _, _, series, order in sorted(
+                self.members, key=lambda item: (item[0], item[1], item[2])
+            )
+        ]
+
+
+def _build_group_tree(
+    bindings: WorkbookSeriesBindings | dict[str, Any],
+    *,
+    placement_only: bool,
+) -> tuple[_TreeNode, list[tuple[dict[str, Any], int | None]]]:
+    """Scan series in declaration order into a group tree.
+
+    When `placement_only` is true each binding is attached to its first group
+    ref only (definition sequencing); otherwise every group ref contributes a
+    membership entry (manifest view). Returns the synthetic root node and the
+    ungrouped bindings in declaration order.
+    """
+    root = _TreeNode("", ())
+    ungrouped: list[tuple[dict[str, Any], int | None]] = []
+    for index, series in enumerate(bindings.get("series", [])):
+        if not isinstance(series, dict):
+            continue
+        refs = _group_refs(series)
+        if not refs:
+            ungrouped.append((series, None))
+            continue
+        if placement_only:
+            refs = refs[:1]
+        for ref in refs:
+            node = root
+            for label in ref["path"]:
+                node = node.child(str(label))
+            order = ref.get("order")
+            order = int(order) if isinstance(order, int) else None
+            node.members.append((order is None, order or 0, index, series, order))
+    return root, ungrouped
+
+
+def _flatten_tree(node: _TreeNode, out: list[dict[str, Any]]) -> None:
+    for series, _ in node.sorted_members():
+        out.append(series)
+    for child in node.children.values():
+        _flatten_tree(child, out)
+
+
+def bindings_export_order(
+    bindings: WorkbookSeriesBindings | dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Return series entries in grouped export order.
+
+    Sibling groups follow first-appearance order over the series list; members
+    within a leaf group sort by explicit `order` then declaration order; each
+    group's own members precede its nested children; ungrouped bindings trail
+    in declaration order. A multi-membership binding is placed by its first
+    group ref. Without any groups the declaration order is returned unchanged.
+    """
+    if not bindings_have_groups(bindings):
+        return [s for s in bindings.get("series", []) if isinstance(s, dict)]
+    root, ungrouped = _build_group_tree(bindings, placement_only=True)
+    ordered: list[dict[str, Any]] = []
+    _flatten_tree(root, ordered)
+    ordered.extend(series for series, _ in ungrouped)
+    return ordered
+
+
+def grouped_public_names(
+    bindings: WorkbookSeriesBindings | dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Return unique setter and compute names in grouped export order."""
+    setters: list[str] = []
+    computes: list[str] = []
+    for series in bindings_export_order(bindings):
+        setter = _setter_name(series)
+        if setter is not None and setter not in setters:
+            setters.append(setter)
+        compute = _compute_name(series)
+        if compute is not None and compute not in computes:
+            computes.append(compute)
+    return setters, computes
+
+
+def _manifest_node(node: _TreeNode) -> GroupNode:
+    return {
+        "label": node.label,
+        "path": list(node.path),
+        "slug": group_slug(node.label),
+        "members": [_member(series, order) for series, order in node.sorted_members()],
+        "children": [_manifest_node(child) for child in node.children.values()],
+    }
+
+
+def group_manifest(
+    bindings: WorkbookSeriesBindings | dict[str, Any],
+) -> GroupsManifest:
+    """Build the nested group manifest consumed by documentation tooling.
+
+    Unlike `bindings_export_order`, a multi-membership binding appears under
+    every group it references.
+    """
+    root, ungrouped = _build_group_tree(bindings, placement_only=False)
+    return {
+        "groups": [_manifest_node(child) for child in root.children.values()],
+        "ungrouped": [_member(series, order) for series, order in ungrouped],
+    }

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -13,6 +13,7 @@ _STRUCTURAL_FIELDS = frozenset(
         "layout",
         "structure",
         "key",
+        "groups",
         "series_context",
         "validation",
         "editable",

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -10,7 +10,7 @@
     "schema_version": {
       "type": "string",
       "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout and row_hierarchy bind (matrix supported with explicit binds; row_hierarchy schema-valid only). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry — skip/include/fill/missing on row_label and column_header binds, the value_map bind kind, and series-level exclude_rows."
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout and row_hierarchy bind (matrix supported with explicit binds; row_hierarchy schema-valid only). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping."
     },
     "workbook": {
       "type": "string",
@@ -281,6 +281,24 @@
         "value": { "$ref": "#/$defs/ScalarValue" }
       }
     },
+    "GroupRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "description": "View-level group membership for export sequencing and documentation. Affects only the generated API shape, never graph extraction or record semantics.",
+      "properties": {
+        "path": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Nested group labels, outermost to innermost (e.g. ['Climate scenarios', 'Paris'])."
+        },
+        "order": {
+          "type": ["integer", "null"],
+          "description": "Optional intra-group sequencing hint. Members without order fall back to binding declaration order."
+        }
+      }
+    },
     "DimensionScope": {
       "type": "string",
       "enum": ["series", "cell"],
@@ -464,6 +482,11 @@
         "setter": {
           "$ref": "#/$defs/Setter",
           "description": "Deprecated: use input.setter. Accepted for backward compatibility and normalized at load time."
+        },
+        "groups": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/GroupRef" },
+          "description": "Optional view-level groups sequencing the generated set_*/compute_* API. Omitted or empty reproduces the flat export."
         },
         "structure": {
           "type": "object",

--- a/tests/integration/user_flows/test_series_bindings_groups_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_groups_codegen.py
@@ -1,0 +1,162 @@
+"""Integration: view-level groups sequence the exported Records API without changing semantics."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from excel_grapher.exporter import CodeGenerator
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
+from tests.integration.user_flows.utils import write_series_bindings_workbook
+
+
+def _row_series(series_id: str, row: int, groups: list[dict[str, Any]] | None) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": series_id,
+        "sheet": "Sheet1",
+        "data_range": f"Sheet1!F{row}:J{row}",
+        "layout": "series",
+        "setter": {"name": f"set_{series_id}"},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                }
+            ],
+        },
+        "key": ["TIME_PERIOD"],
+    }
+    if groups is not None:
+        entry["groups"] = groups
+    return entry
+
+
+# Declaration order deliberately interleaves groups so grouped export must resequence:
+# primary_balance (Fiscal) is declared first but Macro/Growth groups appear first
+# in the group tree only if first-appearance ordering is honored.
+GROUPED_DOCUMENT: dict[str, Any] = {
+    "schema_version": "1.5.0",
+    "workbook": "series_bindings.xlsx",
+    "series": [
+        _row_series("primary_balance", 5, [{"path": ["Fiscal"], "order": 1}]),
+        _row_series("gdp_growth", 3, [{"path": ["Macro", "Growth"]}]),
+        _row_series("interest_rate", 4, None),
+    ],
+}
+
+
+@pytest.fixture
+def workbook(tmp_path: Path) -> Path:
+    path = tmp_path / "series_bindings.xlsx"
+    write_series_bindings_workbook(path)
+    return path
+
+
+def _generate_modules(workbook: Path) -> dict[str, str]:
+    bindings = validate_bindings_document(deepcopy(GROUPED_DOCUMENT))
+    targets: list[str] = []
+    for series in bindings["series"]:
+        targets.extend(expand_data_range(series["data_range"], workbook=workbook))
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+    with CodeGenerator(graph) as gen:
+        return gen.generate_modules(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+
+def test_grouped_export_sequences_definitions_and_all(workbook: Path) -> None:
+    modules = _generate_modules(workbook)
+    api = modules["api.py"]
+
+    # Grouped bindings first (Fiscal, then Macro/Growth), ungrouped trail.
+    assert (
+        api.index("def set_primary_balance(")
+        < api.index("def set_gdp_growth(")
+        < api.index("def set_interest_rate(")
+    )
+
+    init = modules["__init__.py"]
+    all_line = next(line for line in init.splitlines() if line.startswith("__all__"))
+    assert all_line.index("set_primary_balance") < all_line.index("set_gdp_growth")
+    assert all_line.index("set_gdp_growth") < all_line.index("set_interest_rate")
+
+
+def test_grouped_export_emits_manifest_file_and_discovery(workbook: Path) -> None:
+    modules = _generate_modules(workbook)
+
+    manifest = json.loads(modules["groups.json"])
+    assert [g["label"] for g in manifest["groups"]] == ["Fiscal", "Macro"]
+    macro = manifest["groups"][1]
+    assert [child["label"] for child in macro["children"]] == ["Growth"]
+    assert macro["children"][0]["members"][0]["setter"] == "set_gdp_growth"
+    assert [m["id"] for m in manifest["ungrouped"]] == ["interest_rate"]
+
+    assert "def list_groups(" in modules["api.py"]
+
+
+def test_grouped_export_preserves_setter_semantics(workbook: Path, tmp_path: Path) -> None:
+    modules = _generate_modules(workbook)
+    pkg_dir = tmp_path / "grouped_pkg"
+    pkg_dir.mkdir()
+    for filename, content in modules.items():
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
+
+    import importlib
+    import sys
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        pkg = importlib.import_module("grouped_pkg")
+        ctx = pkg.make_context()
+        pkg.set_primary_balance(ctx, [{"TIME_PERIOD": 4, "OBS_VALUE": 7.5}])
+        assert ctx.inputs["Sheet1!I5"] == 7.5
+
+        groups = cast(dict[str, Any], pkg.list_groups())
+        assert [g["label"] for g in groups["groups"]] == ["Fiscal", "Macro"]
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in list(sys.modules):
+            if name == "grouped_pkg" or name.startswith("grouped_pkg."):
+                del sys.modules[name]
+
+
+def test_ungrouped_bindings_export_is_unchanged(workbook: Path) -> None:
+    document = deepcopy(GROUPED_DOCUMENT)
+    for series in document["series"]:
+        series.pop("groups", None)
+    bindings = validate_bindings_document(document)
+    targets: list[str] = []
+    for series in bindings["series"]:
+        targets.extend(expand_data_range(series["data_range"], workbook=workbook))
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+    with CodeGenerator(graph) as gen:
+        modules = gen.generate_modules(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+    assert "groups.json" not in modules
+    assert "list_groups" not in modules["api.py"]
+    # Flat export keeps declaration order for definitions.
+    api = modules["api.py"]
+    assert (
+        api.index("def set_primary_balance(")
+        < api.index("def set_gdp_growth(")
+        < api.index("def set_interest_rate(")
+    )

--- a/tests/unit/series_bindings/test_groups.py
+++ b/tests/unit/series_bindings/test_groups.py
@@ -1,0 +1,210 @@
+"""Unit tests for view-level series binding groups (schema, ordering, manifest)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from excel_grapher.series_bindings.groups import (
+    bindings_export_order,
+    bindings_have_groups,
+    group_manifest,
+)
+from excel_grapher.series_bindings.schema import (
+    SeriesBindingsSchemaError,
+    validate_bindings_document,
+)
+
+
+def _series(series_id: str, **overrides: Any) -> dict[str, Any]:
+    """Minimal scalar binding entry with an input setter."""
+    entry: dict[str, Any] = {
+        "id": series_id,
+        "sheet": "Inputs",
+        "data_range": "Inputs!B2",
+        "layout": "scalar",
+        "setter": {"name": f"set_{series_id}"},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [],
+        },
+        "key": [],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _doc(*series: dict[str, Any]) -> dict[str, Any]:
+    return {"schema_version": "1.5.0", "series": list(series)}
+
+
+# --- Schema validation ---
+
+
+def test_schema_accepts_groups_with_nested_path_and_order() -> None:
+    doc = _doc(
+        _series(
+            "paris_debt",
+            groups=[{"path": ["Climate scenarios", "Paris"], "order": 1}],
+        )
+    )
+    validated = validate_bindings_document(doc)
+    assert validated["series"][0]["groups"] == [
+        {"path": ["Climate scenarios", "Paris"], "order": 1}
+    ]
+
+
+def test_schema_accepts_group_without_order() -> None:
+    doc = _doc(_series("baseline_gdp", groups=[{"path": ["Baseline setup"]}]))
+    validated = validate_bindings_document(doc)
+    assert validated["series"][0]["groups"][0]["path"] == ["Baseline setup"]
+
+
+def test_schema_rejects_empty_group_path() -> None:
+    doc = _doc(_series("bad", groups=[{"path": []}]))
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_group_without_path() -> None:
+    doc = _doc(_series("bad", groups=[{"order": 1}]))
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_non_string_path_segments() -> None:
+    doc = _doc(_series("bad", groups=[{"path": [1, 2]}]))
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_non_integer_order() -> None:
+    doc = _doc(_series("bad", groups=[{"path": ["G"], "order": "first"}]))
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_still_accepts_bindings_without_groups() -> None:
+    doc = _doc(_series("plain"))
+    validated = validate_bindings_document(doc)
+    assert "groups" not in validated["series"][0]
+
+
+# --- Ordering ---
+
+
+def test_have_groups_detects_any_group_declaration() -> None:
+    assert not bindings_have_groups(_doc(_series("a"), _series("b")))
+    assert bindings_have_groups(_doc(_series("a"), _series("b", groups=[{"path": ["G"]}])))
+
+
+def test_export_order_without_groups_preserves_declaration_order() -> None:
+    doc = _doc(_series("zulu"), _series("alpha"))
+    ordered = bindings_export_order(doc)
+    assert [s["id"] for s in ordered] == ["zulu", "alpha"]
+
+
+def test_export_order_sequences_by_group_first_appearance() -> None:
+    doc = _doc(
+        _series("c1", groups=[{"path": ["Climate"]}]),
+        _series("b1", groups=[{"path": ["Baseline"]}]),
+        _series("c2", groups=[{"path": ["Climate"]}]),
+        _series("b2", groups=[{"path": ["Baseline"]}]),
+    )
+    ordered = bindings_export_order(doc)
+    assert [s["id"] for s in ordered] == ["c1", "c2", "b1", "b2"]
+
+
+def test_export_order_respects_order_within_leaf_group() -> None:
+    doc = _doc(
+        _series("second", groups=[{"path": ["G"], "order": 2}]),
+        _series("first", groups=[{"path": ["G"], "order": 1}]),
+        _series("unordered", groups=[{"path": ["G"]}]),
+    )
+    ordered = bindings_export_order(doc)
+    # Explicit orders sort first; members without order fall back to declaration order.
+    assert [s["id"] for s in ordered] == ["first", "second", "unordered"]
+
+
+def test_export_order_emits_parent_members_before_nested_children() -> None:
+    doc = _doc(
+        _series("nested", groups=[{"path": ["Climate", "Paris"]}]),
+        _series("parent_level", groups=[{"path": ["Climate"]}]),
+    )
+    ordered = bindings_export_order(doc)
+    assert [s["id"] for s in ordered] == ["parent_level", "nested"]
+
+
+def test_export_order_places_ungrouped_bindings_last() -> None:
+    doc = _doc(
+        _series("loose_a"),
+        _series("grouped", groups=[{"path": ["G"]}]),
+        _series("loose_b"),
+    )
+    ordered = bindings_export_order(doc)
+    assert [s["id"] for s in ordered] == ["grouped", "loose_a", "loose_b"]
+
+
+def test_export_order_uses_first_group_ref_for_placement() -> None:
+    doc = _doc(
+        _series("multi", groups=[{"path": ["A"]}, {"path": ["B"]}]),
+        _series("b_only", groups=[{"path": ["B"]}]),
+    )
+    ordered = bindings_export_order(doc)
+    assert [s["id"] for s in ordered] == ["multi", "b_only"]
+
+
+# --- Manifest ---
+
+
+def test_group_manifest_nests_children_and_lists_members() -> None:
+    doc = _doc(
+        _series("paris", groups=[{"path": ["Climate scenarios", "Paris"], "order": 1}]),
+        _series("hot", groups=[{"path": ["Climate scenarios", "Hot"], "order": 2}]),
+        _series("baseline_gdp", groups=[{"path": ["Baseline setup"]}]),
+        _series("loose"),
+    )
+    manifest = group_manifest(doc)
+
+    assert [g["label"] for g in manifest["groups"]] == [
+        "Climate scenarios",
+        "Baseline setup",
+    ]
+    climate = manifest["groups"][0]
+    assert climate["path"] == ["Climate scenarios"]
+    assert climate["slug"] == "climate_scenarios"
+    assert climate["members"] == []
+    assert [child["label"] for child in climate["children"]] == ["Paris", "Hot"]
+    paris = climate["children"][0]
+    assert paris["path"] == ["Climate scenarios", "Paris"]
+    assert paris["members"] == [{"id": "paris", "setter": "set_paris", "compute": None, "order": 1}]
+    assert manifest["ungrouped"] == [
+        {"id": "loose", "setter": "set_loose", "compute": None, "order": None}
+    ]
+
+
+def test_group_manifest_records_multi_membership_in_every_group() -> None:
+    doc = _doc(
+        _series("multi", groups=[{"path": ["A"]}, {"path": ["B"], "order": 5}]),
+    )
+    manifest = group_manifest(doc)
+    group_a, group_b = manifest["groups"]
+    assert [m["id"] for m in group_a["members"]] == ["multi"]
+    assert group_b["members"] == [
+        {"id": "multi", "setter": "set_multi", "compute": None, "order": 5}
+    ]
+
+
+def test_group_manifest_includes_compute_names() -> None:
+    entry = _series("outputs_debt", groups=[{"path": ["Outputs"]}])
+    del entry["setter"]
+    entry["output"] = {"compute": {"name": "compute_outputs_debt"}}
+    manifest = group_manifest(_doc(entry))
+    assert manifest["groups"][0]["members"] == [
+        {"id": "outputs_debt", "setter": None, "compute": "compute_outputs_debt", "order": None}
+    ]


### PR DESCRIPTION
## Summary

- Adds optional `groups: list[GroupRef]` to series bindings (schema 1.5.0) so generated `set_*` / `compute_*` symbols can be organized into named, nestable workflow groups
- Sequences export definitions, `__all__`, and `list_setters` / `list_computes` by group; emits `groups.json` and generated `list_groups()` for documentation tooling
- Grouping is view-only: `data.py`, `internals.py`, and `runtime.py` are unchanged when groups are present or absent

Closes #308

## Schema

```yaml
series:
  - id: paris_carbon_price
    # ... existing fields ...
    groups:
      - path: ["Climate scenarios", "Paris"]
        order: 1   # optional; intra-group sequencing only
```

- `path`: required nested labels, outermost → innermost
- `order`: optional integer; omitted members fall back to binding declaration order
- Multi-membership supported; export placement uses the first ref, manifest lists every ref
- Omitted/empty `groups` reproduces today's flat export unchanged

## Export sequencing rules

- Sibling groups: first-appearance order over the series list
- Within a leaf group: explicit `order`, then declaration order
- Parent group members precede nested children
- Ungrouped bindings trail in declaration order

## Testing

- Unit tests: schema validation, ordering, manifest shape (`tests/unit/series_bindings/test_groups.py`)
- Integration: grouped codegen sequencing, `groups.json`, `list_groups()`, back-compat flat export (`tests/integration/user_flows/test_series_bindings_groups_codegen.py`)
- Validated against real Q-CRAFT bindings in [Teal-Insights/qcraft-extraction-pipeline](https://github.com/Teal-Insights/qcraft-extraction-pipeline) (consumed via local `[tool.uv.sources]` patch)

## Test plan

- [x] `uv run pytest tests/unit/series_bindings/test_groups.py tests/integration/user_flows/test_series_bindings_groups_codegen.py`
- [x] Full CI suite on PR
- [ ] Confirm Q-CRAFT extraction pipeline smoke tests pass against released excel-grapher once merged

## Notes

This branch implements the design agreed in #308 and validated on Q-CRAFT. It supersedes draft PR #331, which uses alphabetical path sorting for sibling groups (incorrect for workflow-ordered bindings like Q-CRAFT's `setup` → `climate` → `discrete_risks`).