### PR TITLE
feat(evaluator): implement EXP function

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -77,6 +77,19 @@ Prefer **live Excel** over cached workbook snapshots when validating against the
 
 Do **not** substitute alternative spreadsheet engines (for example LibreOffice Calc) as an “Excel”; they diverge semantically.
 
+### Per-function live Excel parity (precedent: `ABS`, `EXP`)
+
+When implementing or changing a worksheet function, add **two** integration tests:
+
+| File | Path | CI default | Checks |
+| ---- | ---- | ---------- | ------ |
+| Codegen parity | `tests/integration/evaluator/test_<fn>_parity.py` | runs | evaluator ↔ export (`assert_codegen_matches_evaluator`) |
+| Live Excel parity | `tests/integration/evaluator/test_<fn>_excel_parity.py` | skipped (`@pytest.mark.slow`) | evaluator ↔ live Excel (`assert_evaluator_matches_live_excel`) |
+
+Shared harness: `tests/utils/excel_live_parity.py` — writes a small workbook, recalculates via `modify_and_recalculate_workbook`, builds a graph, and compares numeric **and error-code** results.
+
+Run locally: `uv run pytest tests/integration/evaluator/test_abs_excel_parity.py tests/integration/evaluator/test_exp_excel_parity.py -m slow`
+
 ## How to add or change Excel behavior (TDD workflow)
 
 When adding a new function/operator or changing semantics:

--- a/excel_grapher/core/excel_function_meta.py
+++ b/excel_grapher/core/excel_function_meta.py
@@ -31,6 +31,7 @@ FUNCTION_META: dict[str, ExcelFunctionMeta] = {
     "MIN": ExcelFunctionMeta("MIN", ()),
     "MAX": ExcelFunctionMeta("MAX", ()),
     "ABS": ExcelFunctionMeta("ABS", ("value",)),
+    "EXP": ExcelFunctionMeta("EXP", ("value",)),
     "IF": ExcelFunctionMeta("IF", ("value", "value", "value")),
     "CONCAT": ExcelFunctionMeta("CONCAT", ()),
 }

--- a/excel_grapher/core/expr_eval.py
+++ b/excel_grapher/core/expr_eval.py
@@ -26,7 +26,7 @@ from .formula_ast import (
     StringNode,
     UnaryOpNode,
 )
-from .functions import xl_abs
+from .functions import xl_abs, xl_exp
 from .operators import (
     xl_add,
     xl_concat,
@@ -331,6 +331,10 @@ def _fn_abs(args: list[CellValue]) -> CellValue:
     return xl_abs(*args)
 
 
+def _fn_exp(args: list[CellValue]) -> CellValue:
+    return xl_exp(*args)
+
+
 def _fn_if(args: list[CellValue]) -> CellValue:
     if len(args) < 2:
         return XlError.VALUE
@@ -363,6 +367,7 @@ _DEFAULT_FUNCTIONS: dict[str, Callable[[list[CellValue]], CellValue]] = {
     "MIN": _fn_min,
     "MAX": _fn_max,
     "ABS": _fn_abs,
+    "EXP": _fn_exp,
     "IF": _fn_if,
     "CONCAT": _fn_concat,
 }

--- a/excel_grapher/core/functions.py
+++ b/excel_grapher/core/functions.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import math
+
 from .coercions import to_number
 from .types import CellValue, XlError
 
-__all__ = ["xl_abs"]
+__all__ = ["xl_abs", "xl_exp"]
 
 
 def xl_abs(*args: CellValue) -> float | XlError:
@@ -16,3 +18,16 @@ def xl_abs(*args: CellValue) -> float | XlError:
     if isinstance(n, XlError):
         return n
     return float(abs(n))
+
+
+def xl_exp(*args: CellValue) -> float | XlError:
+    """Return e raised to the power of a number (Excel ``EXP``)."""
+    if len(args) != 1:
+        return XlError.VALUE
+    n = to_number(args[0])
+    if isinstance(n, XlError):
+        return n
+    try:
+        return float(math.exp(n))
+    except OverflowError:
+        return XlError.NUM

--- a/excel_grapher/evaluator/functions/math.py
+++ b/excel_grapher/evaluator/functions/math.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from excel_grapher.runtime.math import (
     xl_abs,
+    xl_exp,
     xl_average,
     xl_averageif,
     xl_count,
@@ -27,6 +28,7 @@ from . import register
 register("SUM")(xl_sum)
 register("AVERAGE")(xl_average)
 register("ABS")(xl_abs)
+register("EXP")(xl_exp)
 register("MIN")(xl_min)
 register("MAX")(xl_max)
 register("COUNT")(xl_count)

--- a/excel_grapher/evaluator/functions/math.py
+++ b/excel_grapher/evaluator/functions/math.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from excel_grapher.runtime.math import (
     xl_abs,
-    xl_exp,
     xl_average,
     xl_averageif,
     xl_count,
     xl_counta,
     xl_countif,
+    xl_exp,
     xl_large,
     xl_max,
     xl_min,

--- a/excel_grapher/grapher/dynamic_refs.py
+++ b/excel_grapher/grapher/dynamic_refs.py
@@ -1912,6 +1912,32 @@ def _abs_numeric_domain(
     return _IntBounds(0, max(-lo, hi))
 
 
+def _exp_numeric_domain(
+    d: _FiniteInts | _IntBounds | None,
+) -> _FiniteInts | _IntBounds | None:
+    """Map an integer numeric domain through ``EXP`` as conservative ``_IntBounds``."""
+    if d is None:
+        return None
+    if isinstance(d, _FiniteInts):
+        exp_lo = math.inf
+        exp_hi = -math.inf
+        for value in d.values:
+            try:
+                ev = math.exp(value)
+            except OverflowError:
+                return None
+            exp_lo = min(exp_lo, ev)
+            exp_hi = max(exp_hi, ev)
+        return _IntBounds(int(math.floor(exp_lo)), int(math.ceil(exp_hi)))
+    lo, hi = d.lo, d.hi
+    try:
+        exp_lo = math.exp(lo)
+        exp_hi = math.exp(hi)
+    except OverflowError:
+        return None
+    return _IntBounds(int(math.floor(exp_lo)), int(math.ceil(exp_hi)))
+
+
 def _min_numeric_domains(
     a: _FiniteInts | _IntBounds,
     b: _FiniteInts | _IntBounds,
@@ -2201,6 +2227,7 @@ def _describe_unsupported_numeric_construct(node: AstNode | None) -> str | None:
             "MIN",
             "MAX",
             "ABS",
+            "EXP",
         }:
             for arg in node.args:
                 reason = _describe_unsupported_numeric_construct(arg)
@@ -2665,6 +2692,17 @@ def _infer_numeric_domain_result(
             if inner.domain is None:
                 return _domain_result(None)
             return _domain_result(_abs_numeric_domain(inner.domain))
+        if name == "EXP":
+            if len(node.args) != 1:
+                return _domain_result(None)
+            inner = _infer_numeric_domain_result(
+                node.args[0], env, limits, context=ctx, current_sheet=current_sheet, depth=depth + 1
+            )
+            if inner.diagnostic is not None:
+                return inner
+            if inner.domain is None:
+                return _domain_result(None)
+            return _domain_result(_exp_numeric_domain(inner.domain))
         if name in {"MIN", "MAX"}:
             if len(node.args) < 1:
                 return _domain_result(None)

--- a/excel_grapher/runtime/math.py
+++ b/excel_grapher/runtime/math.py
@@ -16,13 +16,14 @@ from excel_grapher.core import (
     to_number,
     to_string,
 )
-from excel_grapher.core.functions import xl_abs
+from excel_grapher.core.functions import xl_abs, xl_exp
 from excel_grapher.core.sumproduct import xl_sumproduct
 
 T = TypeVar("T", str, float)
 
 __all__ = [
     "xl_abs",
+    "xl_exp",
     "xl_average",
     "xl_averageif",
     "xl_count",

--- a/tests/integration/evaluator/test_abs_excel_parity.py
+++ b/tests/integration/evaluator/test_abs_excel_parity.py
@@ -1,0 +1,67 @@
+"""ABS: evaluator matches live Excel on small synthetic workbooks (integration, slow).
+
+Complements `test_abs_parity.py` (evaluator ↔ codegen). Requires xlwings or WSL/COM;
+skips cleanly when Excel automation is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.utils.excel_live_parity import LiveExcelCell, assert_evaluator_matches_live_excel
+
+
+@pytest.mark.slow
+def test_abs_excel_parity_literal_nested_and_cell_ref(tmp_path: Path) -> None:
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", value=-4),
+            LiveExcelCell("B1", formula="=ABS(-3)"),
+            LiveExcelCell("B2", formula="=ABS(A1)"),
+            LiveExcelCell("B3", formula="=SUM(ABS(A1),10)"),
+        ),
+        targets=("S!B1", "S!B2", "S!B3"),
+        workbook_stem="abs_numeric",
+    )
+
+
+@pytest.mark.slow
+def test_abs_excel_parity_error_propagation_and_value_error(tmp_path: Path) -> None:
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", formula="=1/0"),
+            LiveExcelCell("B1", formula='=ABS("not a number")'),
+            LiveExcelCell("B2", formula="=ABS(A1)"),
+        ),
+        targets=("S!B1", "S!B2"),
+        workbook_stem="abs_errors",
+    )
+
+
+@pytest.mark.slow
+def test_abs_excel_parity_sigma_band_pattern(tmp_path: Path) -> None:
+    """Mirror ``normdist_sigma_band`` IF/ABS nesting from the sandbox workbook."""
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("J1", value=0.5),
+            LiveExcelCell(
+                "M1",
+                formula='=IF(ABS(J1)<=1,"Within 1σ",IF(ABS(J1)<=2,"Within 2σ","Outlier >2σ"))',
+            ),
+            LiveExcelCell("J2", value=2.5),
+            LiveExcelCell(
+                "M2",
+                formula='=IF(ABS(J2)<=1,"Within 1σ",IF(ABS(J2)<=2,"Within 2σ","Outlier >2σ"))',
+            ),
+        ),
+        targets=("S!M1", "S!M2"),
+        workbook_stem="abs_sigma_band",
+    )

--- a/tests/integration/evaluator/test_abs_parity.py
+++ b/tests/integration/evaluator/test_abs_parity.py
@@ -1,4 +1,7 @@
-"""ABS: evaluator and generated export runtime agree on synthetic graphs (integration)."""
+"""ABS: evaluator and generated export runtime agree on synthetic graphs (integration).
+
+Live Excel parity for ``ABS`` lives in ``test_abs_excel_parity.py`` (slow, run-if-available).
+"""
 
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core.address_keys import parse_address

--- a/tests/integration/evaluator/test_exp_excel_parity.py
+++ b/tests/integration/evaluator/test_exp_excel_parity.py
@@ -1,0 +1,65 @@
+"""EXP: evaluator matches live Excel on small synthetic workbooks (integration, slow).
+
+Complements `test_exp_parity.py` (evaluator ↔ codegen). Requires xlwings or WSL/COM;
+skips cleanly when Excel automation is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.utils.excel_live_parity import LiveExcelCell, assert_evaluator_matches_live_excel
+
+
+@pytest.mark.slow
+def test_exp_excel_parity_scalar_and_cell_ref(tmp_path: Path) -> None:
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", value=1.0),
+            LiveExcelCell("B1", formula="=EXP(1)"),
+            LiveExcelCell("B2", formula="=EXP(A1)"),
+        ),
+        targets=("S!B1", "S!B2"),
+        workbook_stem="exp_numeric",
+    )
+
+
+@pytest.mark.slow
+def test_exp_excel_parity_error_propagation_value_error_and_overflow(tmp_path: Path) -> None:
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", formula="=1/0"),
+            LiveExcelCell("B1", formula='=EXP("not a number")'),
+            LiveExcelCell("B2", formula="=EXP(A1)"),
+            LiveExcelCell("A2", value=709.782),
+            LiveExcelCell("B3", formula="=EXP(A2)"),
+            LiveExcelCell("A3", value=710),
+            LiveExcelCell("B4", formula="=EXP(A3)"),
+        ),
+        targets=("S!B1", "S!B2", "S!B3", "S!B4"),
+        workbook_stem="exp_errors",
+    )
+
+
+@pytest.mark.slow
+def test_exp_excel_parity_logistic_convergence_pattern(tmp_path: Path) -> None:
+    """Mirror Q-CRAFT logistic convergence with a computed year column (issue #333 MCVE)."""
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", value=1.0),
+            LiveExcelCell("B1", formula="=EXP(A1)"),
+            LiveExcelCell("A2", value=0.5),
+            LiveExcelCell("A3", value=15.0),
+            LiveExcelCell("B2", formula="=1/(1+EXP(-A2*(B1-A3)))"),
+        ),
+        targets=("S!B1", "S!B2"),
+        workbook_stem="exp_logistic",
+    )

--- a/tests/integration/evaluator/test_exp_parity.py
+++ b/tests/integration/evaluator/test_exp_parity.py
@@ -47,13 +47,16 @@ def test_exp_parity_scalar_and_cell_ref() -> None:
 
 
 def test_exp_parity_logistic_convergence_pattern() -> None:
-    """Mirror Q-CRAFT logistic convergence: ``1/(1+EXP(-rate*(x-pivot)))``."""
+    """Mirror Q-CRAFT logistic convergence with a computed year column (issue #333 MCVE)."""
     graph = _make_graph(
+        _make_node("S!A1", None, 1.0),
+        _make_node("S!B1", "=EXP(S!A1)", None),
         _make_node("S!A2", None, 0.5),
-        _make_node("S!B1", None, 15.0),
         _make_node("S!A3", None, 15.0),
         _make_node("S!B2", "=1/(1+EXP(-S!A2*(S!B1-S!A3)))", None),
     )
 
-    result = assert_codegen_matches_evaluator(graph, ["S!B2"])
-    assert result.generated_results["S!B2"] == 0.5
+    expected = 1.0 / (1.0 + math.exp(-0.5 * (math.e - 15.0)))
+    result = assert_codegen_matches_evaluator(graph, ["S!B1", "S!B2"])
+    assert result.generated_results["S!B1"] == pytest.approx(math.e)
+    assert result.generated_results["S!B2"] == pytest.approx(expected)

--- a/tests/integration/evaluator/test_exp_parity.py
+++ b/tests/integration/evaluator/test_exp_parity.py
@@ -1,4 +1,7 @@
-"""EXP: evaluator and generated export runtime agree on synthetic graphs (integration)."""
+"""EXP: evaluator and generated export runtime agree on synthetic graphs (integration).
+
+Live Excel parity for ``EXP`` lives in ``test_exp_excel_parity.py`` (slow, run-if-available).
+"""
 
 from __future__ import annotations
 

--- a/tests/integration/evaluator/test_exp_parity.py
+++ b/tests/integration/evaluator/test_exp_parity.py
@@ -1,0 +1,59 @@
+"""EXP: evaluator and generated export runtime agree on synthetic graphs (integration)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from excel_grapher import DependencyGraph, Node
+from excel_grapher.core.address_keys import parse_address
+from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
+
+
+def _make_node(address: str, formula: str | None, value: object) -> Node:
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=formula,
+        value=value,
+        is_leaf=formula is None,
+    )
+
+
+def _make_graph(*nodes: Node) -> DependencyGraph:
+    graph = DependencyGraph()
+    for node in nodes:
+        graph.add_node(node)
+    return graph
+
+
+def test_exp_parity_scalar_and_cell_ref() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", None, 1.0),
+        _make_node("S!B1", "=EXP(1)", None),
+        _make_node("S!B2", "=EXP(S!A1)", None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!B1", "S!B2"])
+    assert result.generated_results["S!B1"] == pytest.approx(math.e)
+    assert result.generated_results["S!B2"] == pytest.approx(math.e)
+    assert "xl_exp" in result.generated_code
+
+
+def test_exp_parity_logistic_convergence_pattern() -> None:
+    """Mirror Q-CRAFT logistic convergence: ``1/(1+EXP(-rate*(x-pivot)))``."""
+    graph = _make_graph(
+        _make_node("S!A2", None, 0.5),
+        _make_node("S!B1", None, 15.0),
+        _make_node("S!A3", None, 15.0),
+        _make_node("S!B2", "=1/(1+EXP(-S!A2*(S!B1-S!A3)))", None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!B2"])
+    assert result.generated_results["S!B2"] == 0.5

--- a/tests/integration/exporter/test_codegen_export_modular.py
+++ b/tests/integration/exporter/test_codegen_export_modular.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from excel_grapher import DependencyGraph, FormulaEvaluator, Node
 from excel_grapher.core.address_keys import parse_address
 from excel_grapher.exporter.codegen import CodeGenerator
@@ -314,4 +316,35 @@ def test_codegen_generate_modules_embeds_xl_abs_in_runtime(tmp_path: Path) -> No
         sys.modules.pop("exported_abs", None)
         for name in list(sys.modules):
             if name.startswith("exported_abs."):
+                sys.modules.pop(name, None)
+
+
+def test_codegen_generate_modules_embeds_xl_exp_in_runtime(tmp_path: Path) -> None:
+    """Modular export embeds ``xl_exp`` when the graph uses ``EXP``."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1.0),
+        _make_node("S!B1", "=EXP(S!A1)", None),
+    )
+    files = CodeGenerator(graph).generate_modules(["S!B1"])
+
+    runtime = files["runtime.py"]
+    internals = files["internals.py"]
+    assert "def xl_exp" in runtime
+    assert "xl_exp" in internals
+
+    pkg_dir = tmp_path / "exported_exp"
+    for filename, content in files.items():
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        pkg = importlib.import_module("exported_exp")
+        results = pkg.compute_all()
+        assert results["S!B1"] == pytest.approx(2.718281828459045)
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("exported_exp", None)
+        for name in list(sys.modules):
+            if name.startswith("exported_exp."):
                 sys.modules.pop(name, None)

--- a/tests/unit/core/test_formula_ast_and_expr_eval.py
+++ b/tests/unit/core/test_formula_ast_and_expr_eval.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
+
+import pytest
 
 from excel_grapher.core.expr_eval import Unsupported, evaluate_expr
 from excel_grapher.core.formula_ast import (
@@ -66,6 +69,10 @@ def test_core_expr_eval_basic_functions_over_integers() -> None:
     # ABS over a single cell reference.
     ast = parse("=ABS(Sheet1!B1)")
     assert evaluate_expr(ast, get_cell_value=get_cell_value) == 5.0
+
+    # EXP over a single cell reference.
+    ast = parse("=EXP(Sheet1!A1)")
+    assert evaluate_expr(ast, get_cell_value=get_cell_value) == pytest.approx(math.e)
 
     # IF over simple boolean conditions.
     ast = parse("=IF(TRUE, 1, 2)")

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -261,6 +261,11 @@ class TestEmitAstFunctions:
         node = FunctionCallNode("ABS", [NumberNode(-5.0)])
         assert gen._emit_ast(node) == "xl_abs(-5.0)"
 
+    def test_emit_function_exp(self, gen):
+        """EXP emits the shared runtime helper."""
+        node = FunctionCallNode("EXP", [NumberNode(1.0)])
+        assert gen._emit_ast(node) == "xl_exp(1.0)"
+
     def test_emit_function_multiple_args(self, gen):
         """Function with multiple arguments."""
         node = FunctionCallNode("SUM", [NumberNode(1.0), NumberNode(2.0), NumberNode(3.0)])

--- a/tests/unit/exporter/test_emit_runtime.py
+++ b/tests/unit/exporter/test_emit_runtime.py
@@ -17,6 +17,12 @@ def test_emit_runtime_includes_xl_abs_definition() -> None:
     assert "xl_abs" in code
 
 
+def test_emit_runtime_includes_xl_exp_definition() -> None:
+    code = emit_runtime({"xl_exp"}, include_offset_table=False)
+    assert "def xl_exp" in code
+    assert "xl_exp" in code
+
+
 def test_emit_runtime_includes_smoke_blocker_symbols() -> None:
     code = emit_runtime(
         {

--- a/tests/unit/grapher/test_dynamic_refs.py
+++ b/tests/unit/grapher/test_dynamic_refs.py
@@ -2108,6 +2108,7 @@ def test_infer_numeric_domain_parity_never_raises() -> None:
         "MIN(Sheet1!A1)",
         "MAX(Sheet1!A1)",
         "ABS(-1)",
+        "EXP(1)",
         "ROW()",
         "COLUMN()",
         "ROW(Sheet1!A5)",
@@ -2989,6 +2990,18 @@ class TestAbstractPathCharacterization:
         result = dynamic_refs_mod._infer_numeric_domain_result(ast, env, self._limits())
         assert result.domain is not None, "ABS should now produce an abstract domain"
 
+    def test_exp_stays_abstract_after_phase1(self) -> None:
+        """EXP(A1) stays on the abstract path after Phase 1 (regression guard)."""
+        ast = _parse_selector("EXP(Sheet1!A1)")
+        env = _make_env(
+            {"Sheet1!A1": CellType(kind=CellKind.NUMBER, interval=IntervalDomain(min=1, max=5))}
+        )
+        result = dynamic_refs_mod._infer_numeric_domain_result(ast, env, self._limits())
+        assert result.domain is not None, "EXP should now produce an abstract domain"
+        bounds = dynamic_refs_mod._normalize_to_bounds(result.domain)
+        assert bounds.lo == 2
+        assert bounds.hi == 149
+
     def test_min_stays_abstract_after_phase1(self) -> None:
         """MIN(A1, B1) stays on the abstract path after Phase 1 (regression guard)."""
         ast = _parse_selector("MIN(Sheet1!A1, Sheet1!B1)")
@@ -3106,6 +3119,18 @@ class TestAbstractMinMaxAbsTransferRules:
         b = dynamic_refs_mod._normalize_to_bounds(result.domain)
         assert b.lo == 0
         assert b.hi == 700
+
+    def test_exp_finite_enum_returns_conservative_bounds(self) -> None:
+        """EXP with a small enum domain maps to a conservative integer hull."""
+        ast = _parse_selector("EXP(Sheet1!A1)")
+        env = _make_env(
+            {"Sheet1!A1": CellType(kind=CellKind.NUMBER, enum=EnumDomain(values=frozenset({0, 1})))}
+        )
+        result = dynamic_refs_mod._infer_numeric_domain_result(ast, env, self._limits())
+        assert result.domain is not None
+        b = dynamic_refs_mod._normalize_to_bounds(result.domain)
+        assert b.lo == 1
+        assert b.hi == 3
 
     def test_abs_unsupported_returns_none(self) -> None:
         """ABS with no domain info (e.g. unknown cell) still returns None."""

--- a/tests/unit/runtime/test_math_exp.py
+++ b/tests/unit/runtime/test_math_exp.py
@@ -42,3 +42,18 @@ def test_xl_exp_wrong_arity_returns_value_error() -> None:
 
 def test_xl_exp_overflow_returns_num_error() -> None:
     assert xl_exp(1000) == XlError.NUM
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (709.782, 1.7964120280206387e308),
+        (710, XlError.NUM),
+    ],
+)
+def test_xl_exp_overflow_boundary(raw: CellValue, expected: float | XlError) -> None:
+    result = xl_exp(raw)
+    if isinstance(expected, XlError):
+        assert result == expected
+    else:
+        assert result == pytest.approx(expected)

--- a/tests/unit/runtime/test_math_exp.py
+++ b/tests/unit/runtime/test_math_exp.py
@@ -1,0 +1,44 @@
+"""Unit tests for ``xl_exp`` export runtime semantics."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from excel_grapher.core.types import CellValue, XlError
+from excel_grapher.runtime.math import xl_exp
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0, 1.0),
+        (1, math.e),
+        (-1, math.exp(-1)),
+        (True, math.e),
+        (False, 1.0),
+        ("1", math.e),
+        ("-2", math.exp(-2)),
+    ],
+)
+def test_xl_exp_numeric(raw: CellValue, expected: float) -> None:
+    assert xl_exp(raw) == pytest.approx(expected)
+
+
+def test_xl_exp_text_returns_value_error() -> None:
+    assert xl_exp("not a number") == XlError.VALUE
+
+
+def test_xl_exp_propagates_xl_error() -> None:
+    assert xl_exp(XlError.DIV) == XlError.DIV
+    assert xl_exp(XlError.NA) == XlError.NA
+
+
+def test_xl_exp_wrong_arity_returns_value_error() -> None:
+    assert xl_exp() == XlError.VALUE
+    assert xl_exp(1, 2) == XlError.VALUE
+
+
+def test_xl_exp_overflow_returns_num_error() -> None:
+    assert xl_exp(1000) == XlError.NUM

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,10 +1,18 @@
 """Utilities for golden master testing with Excel automation."""
 
 from tests.utils._helpers import is_wsl, wsl_path_to_windows_unc
+from tests.utils.excel_live_parity import (
+    LiveExcelCell,
+    assert_evaluator_matches_live_excel,
+    compare_cached_to_evaluator,
+)
 from tests.utils.modify_and_recalculate import modify_and_recalculate_workbook
 from tests.utils.read_cell import read_cell_value, read_range_values
 
 __all__ = [
+    "LiveExcelCell",
+    "assert_evaluator_matches_live_excel",
+    "compare_cached_to_evaluator",
     "is_wsl",
     "wsl_path_to_windows_unc",
     "read_cell_value",

--- a/tests/utils/excel_live_parity.py
+++ b/tests/utils/excel_live_parity.py
@@ -1,0 +1,295 @@
+"""Build small workbooks, recalculate through Excel, assert evaluator ↔ live Excel parity.
+
+Per-function live Excel tests should call `assert_evaluator_matches_live_excel` from
+`tests/integration/evaluator/test_<fn>_excel_parity.py` modules (slow, run-if-available).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import fastpyxl.utils.cell
+import pytest
+import xlsxwriter
+
+from excel_grapher import FormulaEvaluator, XlError, create_dependency_graph
+from excel_grapher.core.address_keys import normalize_key
+from tests.utils.modify_and_recalculate import (
+    ExcelRecalculationError,
+    modify_and_recalculate_workbook,
+)
+
+if TYPE_CHECKING:
+    from excel_grapher import DependencyGraph
+
+
+class LiveExcelParityMismatchKind(Enum):
+    """Classification for live-Excel vs evaluator differences."""
+
+    NUMERIC_DRIFT = "numeric_drift"
+    XL_ERROR_CODE_MISMATCH = "xl_error_code_mismatch"
+    XL_ERROR_VS_NUMBER = "xl_error_vs_number"
+    NUMBER_VS_XL_ERROR = "number_vs_xl_error"
+    EXCEPTION = "exception"
+    NOT_IMPLEMENTED = "not_implemented"
+    NONE_RESULT = "none_result"
+    TYPE_MISMATCH = "type_mismatch"
+    MISSING_TARGET = "missing_target"
+
+
+@dataclass(frozen=True, slots=True)
+class LiveExcelCell:
+    """One worksheet cell to populate before live recalculation."""
+
+    address: str
+    formula: str | None = None
+    value: str | float | int | bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LiveExcelParityMismatch:
+    address: str
+    kind: LiveExcelParityMismatchKind
+    excel_cached: object
+    evaluator_result: object | None
+    formula: str | None = None
+    exception: BaseException | None = None
+
+    def format_line(self) -> str:
+        parts = [
+            self.address,
+            f"kind={self.kind.value}",
+            f"excel_cached={self.excel_cached!r}",
+            f"evaluator={self.evaluator_result!r}",
+        ]
+        if self.formula:
+            parts.append(f"formula={self.formula[:120]}{'...' if len(self.formula) > 120 else ''}")
+        if self.exception is not None:
+            parts.append(f"exception={type(self.exception).__name__}: {self.exception}")
+        return " | ".join(parts)
+
+
+def _a1_to_row_col(a1: str) -> tuple[int, int]:
+    col, row = fastpyxl.utils.cell.coordinate_from_string(a1.replace("$", ""))
+    col_idx = fastpyxl.utils.cell.column_index_from_string(col) - 1
+    return int(row) - 1, col_idx
+
+
+def write_live_excel_workbook(
+    path: Path,
+    *,
+    sheet: str,
+    cells: tuple[LiveExcelCell, ...],
+) -> None:
+    """Write a one-sheet workbook with literals and formulas for live recalculation."""
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet(sheet)
+    for cell in cells:
+        row, col = _a1_to_row_col(cell.address)
+        if cell.formula is not None:
+            ws.write_formula(row, col, cell.formula)
+        elif cell.value is not None:
+            if isinstance(cell.value, str):
+                ws.write_string(row, col, cell.value)
+            elif isinstance(cell.value, bool):
+                ws.write_boolean(row, col, cell.value)
+            else:
+                ws.write_number(row, col, float(cell.value))
+    wb.close()
+
+
+def _normalize_cached_excel_value(raw: object) -> object:
+    if isinstance(raw, str):
+        err = XlError.from_text(raw)
+        if err is not None:
+            return err
+    return raw
+
+
+def _numeric_close(a: float, b: float, *, rtol: float, atol: float) -> bool:
+    if a == b:
+        return True
+    scale = max(abs(a), abs(b), 1.0)
+    return abs(a - b) <= max(atol, rtol * scale)
+
+
+def compare_cached_to_evaluator(
+    excel_cached: object,
+    evaluator_result: object,
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-9,
+) -> LiveExcelParityMismatchKind | None:
+    """Return a mismatch kind when Excel cached value differs from evaluator output."""
+    cached = _normalize_cached_excel_value(excel_cached)
+
+    if isinstance(cached, XlError):
+        if isinstance(evaluator_result, XlError):
+            if cached == evaluator_result:
+                return None
+            return LiveExcelParityMismatchKind.XL_ERROR_CODE_MISMATCH
+        return LiveExcelParityMismatchKind.XL_ERROR_VS_NUMBER
+
+    if isinstance(evaluator_result, XlError):
+        return LiveExcelParityMismatchKind.NUMBER_VS_XL_ERROR
+
+    if (
+        isinstance(cached, (int, float))
+        and not isinstance(cached, bool)
+        and isinstance(evaluator_result, (int, float))
+        and not isinstance(evaluator_result, bool)
+    ):
+        if _numeric_close(float(cached), float(evaluator_result), rtol=rtol, atol=atol):
+            return None
+        return LiveExcelParityMismatchKind.NUMERIC_DRIFT
+
+    if cached == evaluator_result:
+        return None
+    return LiveExcelParityMismatchKind.TYPE_MISMATCH
+
+
+def format_live_excel_parity_report(mismatches: list[LiveExcelParityMismatch]) -> str:
+    if not mismatches:
+        return ""
+    lines = ["Live Excel vs evaluator mismatches:"]
+    for mismatch in mismatches:
+        lines.append(f"  - {mismatch.format_line()}")
+    return "\n".join(lines)
+
+
+def compare_evaluator_to_live_excel(
+    graph: DependencyGraph,
+    addresses: list[str],
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-9,
+    fail_fast: bool = False,
+) -> list[LiveExcelParityMismatch]:
+    """Compare evaluator output to cached values on a post-recalc dependency graph."""
+    mismatches: list[LiveExcelParityMismatch] = []
+
+    def _formula_for(addr: str) -> str | None:
+        node = graph.get_node(addr)
+        if node is None or node.formula is None:
+            return None
+        nf = node.normalized_formula
+        if isinstance(nf, str) and nf.strip():
+            return nf.strip()
+        return node.formula
+
+    with FormulaEvaluator(graph) as ev:
+        for addr in addresses:
+            node = graph.get_node(addr)
+            if node is None:
+                mismatches.append(
+                    LiveExcelParityMismatch(
+                        address=addr,
+                        kind=LiveExcelParityMismatchKind.MISSING_TARGET,
+                        excel_cached=None,
+                        evaluator_result=None,
+                    )
+                )
+                if fail_fast:
+                    return mismatches
+                continue
+
+            formula = _formula_for(addr)
+            try:
+                computed = ev._evaluate_cell(addr)  # noqa: SLF001
+            except NotImplementedError as exc:
+                mismatches.append(
+                    LiveExcelParityMismatch(
+                        address=addr,
+                        kind=LiveExcelParityMismatchKind.NOT_IMPLEMENTED,
+                        excel_cached=node.value,
+                        evaluator_result=None,
+                        formula=formula,
+                        exception=exc,
+                    )
+                )
+                if fail_fast:
+                    return mismatches
+                continue
+            except Exception as exc:
+                mismatches.append(
+                    LiveExcelParityMismatch(
+                        address=addr,
+                        kind=LiveExcelParityMismatchKind.EXCEPTION,
+                        excel_cached=node.value,
+                        evaluator_result=None,
+                        formula=formula,
+                        exception=exc,
+                    )
+                )
+                if fail_fast:
+                    return mismatches
+                continue
+
+            if computed is None and node.value is None:
+                continue
+
+            kind = compare_cached_to_evaluator(
+                node.value,
+                computed,
+                rtol=rtol,
+                atol=atol,
+            )
+            if kind is None:
+                continue
+            mismatches.append(
+                LiveExcelParityMismatch(
+                    address=addr,
+                    kind=kind,
+                    excel_cached=node.value,
+                    evaluator_result=computed,
+                    formula=formula,
+                )
+            )
+            if fail_fast:
+                return mismatches
+
+    return mismatches
+
+
+def assert_evaluator_matches_live_excel(
+    *,
+    tmp_path: Path,
+    sheet: str,
+    cells: tuple[LiveExcelCell, ...],
+    targets: tuple[str, ...],
+    rtol: float = 1e-5,
+    atol: float = 1e-9,
+    workbook_stem: str = "live_parity",
+    fail_fast: bool = True,
+) -> DependencyGraph:
+    """Write a workbook, recalculate through Excel, and assert evaluator parity."""
+    input_path = tmp_path / f"{workbook_stem}.xlsx"
+    output_path = tmp_path / f"{workbook_stem}_recalc.xlsx"
+    write_live_excel_workbook(input_path, sheet=sheet, cells=cells)
+
+    try:
+        modify_and_recalculate_workbook(input_path, output_path, {})
+    except (ExcelRecalculationError, RuntimeError, ImportError) as exc:
+        pytest.skip(f"Excel recalculation not available: {exc}")
+
+    target_keys = [normalize_key(target) for target in targets]
+    graph = create_dependency_graph(
+        output_path,
+        target_keys,
+        load_values=True,
+        use_cached_dynamic_refs=True,
+    )
+
+    mismatches = compare_evaluator_to_live_excel(
+        graph,
+        target_keys,
+        rtol=rtol,
+        atol=atol,
+        fail_fast=fail_fast,
+    )
+    if mismatches:
+        raise AssertionError(format_live_excel_parity_report(mismatches))
+    return graph

--- a/tests/utils/test_excel_live_parity.py
+++ b/tests/utils/test_excel_live_parity.py
@@ -1,0 +1,49 @@
+"""Unit tests for live Excel parity helpers (comparison logic; no automation required)."""
+
+from __future__ import annotations
+
+from excel_grapher.core.types import XlError
+from tests.utils.excel_live_parity import (
+    LiveExcelParityMismatchKind,
+    compare_cached_to_evaluator,
+)
+
+
+def test_compare_cached_numeric_match() -> None:
+    assert compare_cached_to_evaluator(3.0, 3.0, rtol=1e-5, atol=1e-9) is None
+
+
+def test_compare_cached_numeric_drift() -> None:
+    assert (
+        compare_cached_to_evaluator(3.0, 4.0, rtol=1e-5, atol=1e-9)
+        == LiveExcelParityMismatchKind.NUMERIC_DRIFT
+    )
+
+
+def test_compare_cached_error_string_matches_xl_error() -> None:
+    assert compare_cached_to_evaluator("#NUM!", XlError.NUM, rtol=1e-5, atol=1e-9) is None
+
+
+def test_compare_cached_error_code_mismatch() -> None:
+    assert (
+        compare_cached_to_evaluator("#NUM!", XlError.DIV, rtol=1e-5, atol=1e-9)
+        == LiveExcelParityMismatchKind.XL_ERROR_CODE_MISMATCH
+    )
+
+
+def test_compare_cached_number_vs_evaluator_error() -> None:
+    assert (
+        compare_cached_to_evaluator(1.0, XlError.NUM, rtol=1e-5, atol=1e-9)
+        == LiveExcelParityMismatchKind.NUMBER_VS_XL_ERROR
+    )
+
+
+def test_compare_cached_error_vs_evaluator_number() -> None:
+    assert (
+        compare_cached_to_evaluator("#NUM!", 1.0, rtol=1e-5, atol=1e-9)
+        == LiveExcelParityMismatchKind.XL_ERROR_VS_NUMBER
+    )
+
+
+def test_compare_cached_string_result() -> None:
+    assert compare_cached_to_evaluator("Within 1σ", "Within 1σ", rtol=1e-5, atol=1e-9) is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Excel `EXP` in the shared runtime so `FormulaEvaluator` and exported code can evaluate exponential formulas, including Q-CRAFT logistic convergence patterns.

Fixes #333.

## Changes

- Add `xl_exp` to `excel_grapher/core/functions.py` (`math.exp`, with `OverflowError` mapped to `#NUM!`)
- Register `EXP` in the evaluator and re-export from `runtime/math.py`
- Wire `expr_eval` and `excel_function_meta` for static evaluation and domain inference metadata

## Tests

- `tests/unit/runtime/test_math_exp.py` — scalars, coercion, error propagation, arity, overflow
- `tests/integration/evaluator/test_exp_parity.py` — evaluator ↔ codegen parity for scalar refs and nested logistic form

Verified the issue MCVE: `EXP(A1)` and nested `1/(1+EXP(...))` evaluate to finite numeric results.

## Parity

Follows the existing `ABS` pattern: shared `core`/`runtime` semantics, no separate `export_runtime` module. Codegen emits `xl_exp(...)` automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df7e5efa-00a5-4f48-8a97-dfc6e3ee4768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df7e5efa-00a5-4f48-8a97-dfc6e3ee4768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

