### PR TITLE
feat(evaluator): cache parsed formula ASTs keyed by normalized_formula

### DIFF
--- a/excel_grapher/evaluator/ast_cache.py
+++ b/excel_grapher/evaluator/ast_cache.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from excel_grapher.evaluator.parser import AstNode
 
@@ -42,7 +42,7 @@ class AstCache:
         return len(self._cache)
 
     def get(self, normalized_formula: str, *, parse_fn: _ParseFn) -> AstNode:
-        """Return a cached AST or parse and store ``normalized_formula``."""
+        """Return a cached AST or parse and store `normalized_formula`."""
         if normalized_formula in self._cache:
             self._hits += 1
             self._cache.move_to_end(normalized_formula)

--- a/excel_grapher/evaluator/ast_cache.py
+++ b/excel_grapher/evaluator/ast_cache.py
@@ -1,0 +1,71 @@
+"""Bounded LRU cache for parsed formula ASTs."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Callable
+
+from excel_grapher.evaluator.parser import AstNode
+
+DEFAULT_AST_CACHE_MAXSIZE = 4096
+
+_ParseFn = Callable[[str], AstNode]
+
+
+@dataclass(frozen=True, slots=True)
+class AstCacheInfo:
+    """Statistics for an `AstCache` instance."""
+
+    hits: int
+    misses: int
+    maxsize: int
+    currsize: int
+
+
+class AstCache:
+    """LRU cache mapping normalized formula strings to parsed AST nodes."""
+
+    def __init__(self, maxsize: int = DEFAULT_AST_CACHE_MAXSIZE) -> None:
+        if maxsize < 1:
+            raise ValueError("maxsize must be at least 1")
+        self._maxsize = maxsize
+        self._cache: OrderedDict[str, AstNode] = OrderedDict()
+        self._hits = 0
+        self._misses = 0
+
+    @property
+    def maxsize(self) -> int:
+        return self._maxsize
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def get(self, normalized_formula: str, *, parse_fn: _ParseFn) -> AstNode:
+        """Return a cached AST or parse and store ``normalized_formula``."""
+        if normalized_formula in self._cache:
+            self._hits += 1
+            self._cache.move_to_end(normalized_formula)
+            return self._cache[normalized_formula]
+
+        self._misses += 1
+        ast = parse_fn(normalized_formula)
+        self._cache[normalized_formula] = ast
+        if len(self._cache) > self._maxsize:
+            self._cache.popitem(last=False)
+        return ast
+
+    def clear(self) -> None:
+        """Remove all cached ASTs and reset statistics."""
+        self._cache.clear()
+        self._hits = 0
+        self._misses = 0
+
+    def cache_info(self) -> AstCacheInfo:
+        """Return hit/miss and size statistics."""
+        return AstCacheInfo(
+            hits=self._hits,
+            misses=self._misses,
+            maxsize=self._maxsize,
+            currsize=len(self._cache),
+        )

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -26,7 +26,7 @@ from excel_grapher.grapher.blank_ranges import (
 )
 from excel_grapher.runtime.cache import EvalContext, xl_circular_reference, xl_iterative_compute
 
-from .ast_cache import AstCache, AstCacheInfo, DEFAULT_AST_CACHE_MAXSIZE
+from .ast_cache import DEFAULT_AST_CACHE_MAXSIZE, AstCache, AstCacheInfo
 from .errors import MissingNormalizedFormulaError, ParseError
 from .functions import FUNCTIONS
 from .functions.info import xl_isblank

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -26,6 +26,7 @@ from excel_grapher.grapher.blank_ranges import (
 )
 from excel_grapher.runtime.cache import EvalContext, xl_circular_reference, xl_iterative_compute
 
+from .ast_cache import AstCache, AstCacheInfo, DEFAULT_AST_CACHE_MAXSIZE
 from .errors import MissingNormalizedFormulaError, ParseError
 from .functions import FUNCTIONS
 from .functions.info import xl_isblank
@@ -94,9 +95,11 @@ class FormulaEvaluator:
     iterate_count: int = 100
     iterate_delta: float = 0.001
     blank_ranges: tuple[str, ...] | None = None
+    ast_cache_maxsize: int = DEFAULT_AST_CACHE_MAXSIZE
 
     def __post_init__(self) -> None:
         self._cache: dict[str, CellValue] = {}
+        self._ast_cache = AstCache(maxsize=self.ast_cache_maxsize)
         self._call_stack: list[str] = []
         self._leaf_values: dict[str, CellValue] = {}  # For auto-detection
         self._iteration_values: dict[str, CellValue] = {}
@@ -115,6 +118,18 @@ class FormulaEvaluator:
 
     def __exit__(self, *args: object) -> None:
         return None
+
+    def clear_caches(self) -> None:
+        """Clear cached cell values and parsed formula ASTs."""
+        self._cache.clear()
+        self._ast_cache.clear()
+
+    def ast_cache_info(self) -> AstCacheInfo:
+        """Return hit/miss statistics for the AST parse cache."""
+        return self._ast_cache.cache_info()
+
+    def _parse_cached(self, normalized_formula: str) -> AstNode:
+        return self._ast_cache.get(normalized_formula, parse_fn=parse)
 
     def _record_runtime_dependency(self, parent: str, child: str) -> None:
         """Record that `parent` read `child` during the current evaluation."""
@@ -296,7 +311,7 @@ class FormulaEvaluator:
 
         self._call_stack.append(norm)
         try:
-            ast = parse(formula)
+            ast = self._parse_cached(formula)
             result = self._evaluate_ast(ast)
             # Auto-resolve 1x1 ExcelRange to single value
             result = self._auto_resolve_single_cell(result)

--- a/tests/unit/evaluator/test_ast_cache.py
+++ b/tests/unit/evaluator/test_ast_cache.py
@@ -6,13 +6,13 @@ from unittest.mock import patch
 
 import pytest
 
+import excel_grapher.evaluator.evaluator as evaluator_module
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core.address_keys import parse_address
+from excel_grapher.evaluator import parser as evaluator_parser
 from excel_grapher.evaluator.ast_cache import DEFAULT_AST_CACHE_MAXSIZE, AstCache
 from excel_grapher.evaluator.errors import ParseError
 from excel_grapher.evaluator.evaluator import FormulaEvaluator
-from excel_grapher.evaluator import parser as evaluator_parser
-import excel_grapher.evaluator.evaluator as evaluator_module
 
 
 def _make_node(
@@ -58,16 +58,18 @@ def test_second_eval_after_invalidation_reuses_ast() -> None:
         parse_calls += 1
         return original_parse(formula)
 
-    with FormulaEvaluator(graph, auto_detect_changes=True) as ev:
-        with patch.object(evaluator_module, "parse", counting_parse):
-            ev.evaluate(["S!B1"])
-            assert parse_calls == 1
+    with (
+        FormulaEvaluator(graph, auto_detect_changes=True) as ev,
+        patch.object(evaluator_module, "parse", counting_parse),
+    ):
+        ev.evaluate(["S!B1"])
+        assert parse_calls == 1
 
-            graph.set_node_value("S!A1", 5)
+        graph.set_node_value("S!A1", 5)
 
-            ev.evaluate(["S!B1"])
-            assert parse_calls == 1
-            assert ev.evaluate(["S!B1"])["S!B1"] == 10.0
+        ev.evaluate(["S!B1"])
+        assert parse_calls == 1
+        assert ev.evaluate(["S!B1"])["S!B1"] == 10.0
 
 
 def test_distinct_cells_same_normalized_formula_share_ast() -> None:
@@ -88,10 +90,9 @@ def test_distinct_cells_same_normalized_formula_share_ast() -> None:
         parse_calls += 1
         return original_parse(formula)
 
-    with FormulaEvaluator(graph) as ev:
-        with patch.object(evaluator_module, "parse", counting_parse):
-            ev.evaluate(["S!B1", "S!B2"])
-            assert parse_calls == 1
+    with FormulaEvaluator(graph) as ev, patch.object(evaluator_module, "parse", counting_parse):
+        ev.evaluate(["S!B1", "S!B2"])
+        assert parse_calls == 1
 
 
 def test_different_formulas_distinct_ast_entries() -> None:
@@ -108,10 +109,9 @@ def test_different_formulas_distinct_ast_entries() -> None:
         parse_calls += 1
         return original_parse(formula)
 
-    with FormulaEvaluator(graph) as ev:
-        with patch.object(evaluator_module, "parse", counting_parse):
-            ev.evaluate(["S!A1", "S!A2"])
-            assert parse_calls == 2
+    with FormulaEvaluator(graph) as ev, patch.object(evaluator_module, "parse", counting_parse):
+        ev.evaluate(["S!A1", "S!A2"])
+        assert parse_calls == 2
 
 
 def test_ast_cache_is_bounded() -> None:

--- a/tests/unit/evaluator/test_ast_cache.py
+++ b/tests/unit/evaluator/test_ast_cache.py
@@ -1,0 +1,183 @@
+"""Tests for FormulaEvaluator AST parse cache."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from excel_grapher import DependencyGraph, Node
+from excel_grapher.core.address_keys import parse_address
+from excel_grapher.evaluator.ast_cache import DEFAULT_AST_CACHE_MAXSIZE, AstCache
+from excel_grapher.evaluator.errors import ParseError
+from excel_grapher.evaluator.evaluator import FormulaEvaluator
+from excel_grapher.evaluator import parser as evaluator_parser
+import excel_grapher.evaluator.evaluator as evaluator_module
+
+
+def _make_node(
+    address: str,
+    formula: str | None,
+    value: object,
+    *,
+    normalized_formula: str | None = None,
+) -> Node:
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=normalized_formula if normalized_formula is not None else formula,
+        value=value,
+        is_leaf=formula is None,
+    )
+
+
+def _make_graph(*nodes: Node) -> DependencyGraph:
+    graph = DependencyGraph()
+    for node in nodes:
+        graph.add_node(node)
+    return graph
+
+
+def test_second_eval_after_invalidation_reuses_ast() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", None, 10),
+        _make_node("S!B1", "=S!A1*2", None),
+    )
+    graph.add_edge("S!B1", "S!A1")
+
+    parse_calls = 0
+    original_parse = evaluator_module.parse
+
+    def counting_parse(formula: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(formula)
+
+    with FormulaEvaluator(graph, auto_detect_changes=True) as ev:
+        with patch.object(evaluator_module, "parse", counting_parse):
+            ev.evaluate(["S!B1"])
+            assert parse_calls == 1
+
+            graph.set_node_value("S!A1", 5)
+
+            ev.evaluate(["S!B1"])
+            assert parse_calls == 1
+            assert ev.evaluate(["S!B1"])["S!B1"] == 10.0
+
+
+def test_distinct_cells_same_normalized_formula_share_ast() -> None:
+    shared = "=S!A1*2"
+    graph = _make_graph(
+        _make_node("S!A1", None, 10),
+        _make_node("S!B1", "=S!A1*2", None, normalized_formula=shared),
+        _make_node("S!B2", "=S!A2*2", None, normalized_formula=shared),
+    )
+    graph.add_edge("S!B1", "S!A1")
+    graph.add_edge("S!B2", "S!A1")
+
+    parse_calls = 0
+    original_parse = evaluator_module.parse
+
+    def counting_parse(formula: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(formula)
+
+    with FormulaEvaluator(graph) as ev:
+        with patch.object(evaluator_module, "parse", counting_parse):
+            ev.evaluate(["S!B1", "S!B2"])
+            assert parse_calls == 1
+
+
+def test_different_formulas_distinct_ast_entries() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", "=1+1", None),
+        _make_node("S!A2", "=2+2", None),
+    )
+
+    parse_calls = 0
+    original_parse = evaluator_module.parse
+
+    def counting_parse(formula: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(formula)
+
+    with FormulaEvaluator(graph) as ev:
+        with patch.object(evaluator_module, "parse", counting_parse):
+            ev.evaluate(["S!A1", "S!A2"])
+            assert parse_calls == 2
+
+
+def test_ast_cache_is_bounded() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", "=1", None),
+        _make_node("S!A2", "=2", None),
+        _make_node("S!A3", "=3", None),
+    )
+
+    with FormulaEvaluator(graph, ast_cache_maxsize=2) as ev:
+        ev.evaluate(["S!A1", "S!A2", "S!A3"])
+        assert len(ev._ast_cache) == 2  # noqa: SLF001
+
+        info_before = ev.ast_cache_info()
+        assert info_before.currsize == 2
+        assert info_before.maxsize == 2
+
+        ev._cache.pop("S!A1")  # noqa: SLF001 — force re-evaluation past value cache
+        ev.evaluate(["S!A1"])
+        info_after = ev.ast_cache_info()
+        assert info_after.misses == info_before.misses + 1
+
+
+def test_parse_error_not_cached() -> None:
+    graph = _make_graph(_make_node("S!A1", "=1+", None))
+
+    with FormulaEvaluator(graph) as ev:
+        with pytest.raises(ParseError):
+            ev.evaluate(["S!A1"])
+        assert len(ev._ast_cache) == 0  # noqa: SLF001
+
+        with pytest.raises(ParseError):
+            ev.evaluate(["S!A1"])
+        info = ev.ast_cache_info()
+        assert info.misses == 2
+        assert info.hits == 0
+
+
+def test_clear_caches_clears_ast_and_value_caches() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!B1", "=S!A1+1", None),
+    )
+
+    with FormulaEvaluator(graph) as ev:
+        ev.evaluate(["S!B1"])
+        assert ev._cache  # noqa: SLF001
+        assert len(ev._ast_cache) == 1  # noqa: SLF001
+
+        ev.clear_caches()
+        assert ev._cache == {}  # noqa: SLF001
+        assert len(ev._ast_cache) == 0  # noqa: SLF001
+
+
+def test_ast_cache_default_maxsize() -> None:
+    cache = AstCache()
+    assert cache.maxsize == DEFAULT_AST_CACHE_MAXSIZE
+
+
+def test_ast_cache_info_tracks_hits_and_misses() -> None:
+    cache = AstCache(maxsize=8)
+    cache.get("=1", parse_fn=evaluator_parser.parse)
+    cache.get("=1", parse_fn=evaluator_parser.parse)
+    cache.get("=2", parse_fn=evaluator_parser.parse)
+
+    info = cache.cache_info()
+    assert info.hits == 1
+    assert info.misses == 2
+    assert info.currsize == 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #337 by adding a bounded LRU AST parse cache to `FormulaEvaluator`. Parsed formula trees are keyed by `normalized_formula` so they can be reused across cells with identical formula text and across re-evaluations after value-cache invalidation.

## Changes

- **`AstCache` helper** (`excel_grapher/evaluator/ast_cache.py`): instance-scoped LRU cache (default `maxsize=4096`) with `cache_info()` statistics.
- **`FormulaEvaluator` wiring**:
  - New `ast_cache_maxsize` parameter (default 4096).
  - `_parse_cached()` replaces direct `parse()` calls in `_evaluate_cell`.
  - `clear_caches()` clears both value and AST caches.
  - `ast_cache_info()` exposes hit/miss stats for debugging/benchmarks.
- **Unit tests** (`tests/unit/evaluator/test_ast_cache.py`): covers cross-cell sharing, post-invalidation reuse, bounded eviction, parse-error non-caching, and cache clearing.

## Testing

- `uv run pytest tests/unit/evaluator/test_ast_cache.py -v`
- `uv run pytest tests/unit/evaluator/ -v` (217 passed)

Closes #337
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6915144-6b95-435f-b16c-01e9e6387258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6915144-6b95-435f-b16c-01e9e6387258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

