### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,13 @@ also patches `post-render.py` for Quarto's subprocess.
 The project aims for **behavioral parity** across **Excel** (reference), **`FormulaEvaluator`**, and **exported standalone code**. Semantics are centralized in `excel_grapher/exporter/export_runtime/`; the evaluator and codegen must both use that runtime so **evaluator ↔ export** stays aligned.
 
 **Excel-facing tests:** Prefer validating against **live Excel** (xlwings on Windows/macOS, or Excel via COM from WSL) when comparing to the real engine. **Run-if-available:** if automation is missing, **`pytest.skip`** with a clear reason—do not fail CI. Cache-based comparisons (`excel_workbook_parity`) remain useful for environments without Excel. See `.cursor/rules/parity.mdc` for the full contract.
+
+## Cursor Cloud specific instructions
+
+This is a pure Python **library + CLI** (`excel-grapher`) managed with `uv`; there are no runtime services (no DB/web/queue). "End-to-end" runs entirely in-process against `.xlsx` fixtures in `examples/` and `tests/fixtures/`. Dependencies are installed by the startup update script (`uv sync --all-extras --dev`), which also provisions the pinned Python (3.13). Run everything through `uv run`.
+
+- Standard lint/format/type/test commands live in `.github/workflows/ci.yml`: `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run pytest`.
+- `pytest` deselects the `slow` marker by default (see `[tool.pytest.ini_options]`); opt in with `uv run pytest -m slow`.
+- Live-Excel parity tests (`xlwings`) `pytest.skip` on this Linux VM since Excel automation is unavailable — this is expected, not a failure.
+- The `graphviz` Python package is installed, but the system Graphviz binary is not; rendering visualizations to images needs `apt-get install -y graphviz` (only for viz/docs, not for tests or core use).
+- CLI smoke check: `uv run excel-grapher bindings validate examples/micro_workbooks/ffv2.xlsx --bindings examples/micro_workbooks/ff.bindings.yaml --smoke-test` (note the colocated sidecar declares `workbook: ff.xlsx`, so pass the workbook explicitly as shown).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for `excel-grapher` and documents non-obvious startup/run caveats for future agents.

This is a pure Python **library + CLI** managed with `uv` — there are no runtime services. Environment setup is just installing `uv` (if missing) and running `uv sync --all-extras --dev` (provisions pinned Python 3.13 + all deps including the git-based `fastpyxl`).

### Changes
- Add `## Cursor Cloud specific instructions` to `AGENTS.md` describing the library/CLI nature, where standard commands live (CI/README), the `slow`-marker default, expected `xlwings` parity skips on Linux, the missing system Graphviz binary, and the CLI smoke-check invocation.

### Verification (all via `uv run`)
- `ruff check .` — passed
- `ruff format --check .` — 337 files formatted
- `ty check` — passed
- `pytest` — 1749 passed, 1 skipped, 30 deselected, 4 xfailed
- End-to-end library pipeline (build graph → evaluate → export standalone code → run generated code) produced `42.0` from overridden input
- CLI `excel-grapher bindings validate ... --smoke-test` — `ok=True`, all setter/compute smoke checks passed

The update script (uv install + `uv sync --all-extras --dev`) is registered separately via the environment setup tool, not committed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c915d230-e1e5-42b2-a23c-365617a856f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c915d230-e1e5-42b2-a23c-365617a856f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

