### PR TITLE
feat(grapher): opt-in AST pre-parsing during graph extraction

### DIFF
--- a/excel_grapher/evaluator/ast_cache.py
+++ b/excel_grapher/evaluator/ast_cache.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
 from excel_grapher.evaluator.parser import AstNode
@@ -54,6 +54,15 @@ class AstCache:
         if len(self._cache) > self._maxsize:
             self._cache.popitem(last=False)
         return ast
+
+    def seed(self, entries: Mapping[str, AstNode]) -> None:
+        """Insert pre-parsed ASTs without affecting hit/miss statistics."""
+        for normalized_formula, ast in entries.items():
+            if normalized_formula in self._cache:
+                continue
+            self._cache[normalized_formula] = ast
+            if len(self._cache) > self._maxsize:
+                self._cache.popitem(last=False)
 
     def clear(self) -> None:
         """Remove all cached ASTs and reset statistics."""

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -100,6 +100,9 @@ class FormulaEvaluator:
     def __post_init__(self) -> None:
         self._cache: dict[str, CellValue] = {}
         self._ast_cache = AstCache(maxsize=self.ast_cache_maxsize)
+        preparsed = self.graph.preparsed_formulas
+        if preparsed:
+            self._ast_cache.seed(preparsed)
         self._call_stack: list[str] = []
         self._leaf_values: dict[str, CellValue] = {}  # For auto-detection
         self._iteration_values: dict[str, CellValue] = {}

--- a/excel_grapher/grapher/__init__.py
+++ b/excel_grapher/grapher/__init__.py
@@ -55,6 +55,7 @@ from .guard import And, Compare, GuardExpr, Literal, Not, Or
 from .guard import CellRef as GuardCellRef
 from .node import Node, NodeKey
 from .parser import format_cell_key, format_key, needs_quoting
+from .preparsed_formulas import warm_preparsed_formulas
 from .range_compression import TacoBuildConfig, TacoIndex, build_taco_index, input_keys_from_graph
 from .validation import ValidationResult, WorkbookCalcSettings, get_calc_settings, validate_graph
 
@@ -72,6 +73,7 @@ __all__ = [
     "CacheValidationPolicy",
     "save_graph_cache",
     "try_load_graph_cache",
+    "warm_preparsed_formulas",
     "DependencyCause",
     "DependencyGraph",
     "GraphReadView",

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -296,7 +296,11 @@ def create_dependency_graph(
     When `warm_ast_cache` is True, each distinct `normalized_formula` in the
     built graph is parsed once and stored on `DependencyGraph.preparsed_formulas`.
     `FormulaEvaluator` seeds its AST cache from that mapping so first evaluation
-    does not re-parse unless formulas change after extraction.
+    does not re-parse unless formulas change after extraction. Seeding is
+    best-effort when distinct formulas exceed `FormulaEvaluator.ast_cache_maxsize`
+    (oldest warmed entries may be evicted). `preparsed_formulas` is not stored
+    in JSON graph caches; call `warm_preparsed_formulas` after cache load or
+    formula mutation.
 
     **Cost model**: constraint-based dynamic-ref expansion (`dynamic_refs` set,
     `use_cached_dynamic_refs=False`) runs `expand_leaf_env_to_argument_env`

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -248,6 +248,7 @@ def create_dependency_graph(
     capture_dependency_provenance: bool = False,
     blank_ranges: Iterable[str] | None = None,
     type_analysis_cache: TypeAnalysisCache | None = None,
+    warm_ast_cache: bool = False,
 ) -> DependencyGraph:
     r"""Build a dependency graph starting from target cells.
 
@@ -291,6 +292,11 @@ def create_dependency_graph(
     same declarations on `excel_grapher.FormulaEvaluator` and
     `excel_grapher.exporter.codegen.CodeGenerator.generate` for **evaluator
     <-> export** parity (consistent behavior between evaluation and generated code).
+
+    When `warm_ast_cache` is True, each distinct `normalized_formula` in the
+    built graph is parsed once and stored on `DependencyGraph.preparsed_formulas`.
+    `FormulaEvaluator` seeds its AST cache from that mapping so first evaluation
+    does not re-parse unless formulas change after extraction.
 
     **Cost model**: constraint-based dynamic-ref expansion (`dynamic_refs` set,
     `use_cached_dynamic_refs=False`) runs `expand_leaf_env_to_argument_env`
@@ -1279,6 +1285,10 @@ def create_dependency_graph(
     graph.named_ranges = dict(named_ranges)
     graph.named_range_ranges = dict(named_range_ranges)
     graph.sheet_bounds = dict(sheet_bounds)
+    if warm_ast_cache:
+        from .preparsed_formulas import warm_preparsed_formulas
+
+        graph.preparsed_formulas = warm_preparsed_formulas(graph)
     return graph
 
 

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from .compression import IdentityTransitCompressionRecord, OptimalCompressionRecord
 
 from excel_grapher.core.address_keys import normalize_key, sort_node_keys
+from excel_grapher.core.formula_ast import AstNode
 
 from .dependency_provenance import DependencyCause, EdgeProvenance, merge_edge_provenance
 from .guard import And, CellRef, Compare, GuardConstraints, GuardExpr, Not, Or, or_guard
@@ -122,6 +123,7 @@ class DependencyGraph:
     sheet_bounds: dict[str, tuple[int, int]] | None = None
     named_ranges: dict[str, tuple[str, str]] | None = None
     named_range_ranges: dict[str, tuple[str, str, str]] | None = None
+    preparsed_formulas: dict[str, AstNode] | None = None
 
     def copy(self) -> DependencyGraph:
         """Return a deep copy of this graph (node hooks are not copied)."""

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -123,6 +123,7 @@ class DependencyGraph:
     sheet_bounds: dict[str, tuple[int, int]] | None = None
     named_ranges: dict[str, tuple[str, str]] | None = None
     named_range_ranges: dict[str, tuple[str, str, str]] | None = None
+    # Opt-in AST cache from warm_ast_cache; not JSON-serialized; re-warm after load.
     preparsed_formulas: dict[str, AstNode] | None = None
 
     def copy(self) -> DependencyGraph:

--- a/excel_grapher/grapher/preparsed_formulas.py
+++ b/excel_grapher/grapher/preparsed_formulas.py
@@ -1,0 +1,25 @@
+"""Pre-parse formula ASTs during graph extraction for evaluator reuse."""
+
+from __future__ import annotations
+
+from excel_grapher.core.formula_ast import AstNode, parse
+
+from .graph import DependencyGraph
+
+
+def warm_preparsed_formulas(graph: DependencyGraph) -> dict[str, AstNode]:
+    """Parse each distinct `normalized_formula` in `graph`.
+
+    Returns a mapping from stripped normalized formula strings to AST roots.
+    Duplicate formulas across cells share one entry.
+    """
+    warmed: dict[str, AstNode] = {}
+    for _, node in graph.formula_nodes():
+        nf = node.normalized_formula
+        if nf is None or not isinstance(nf, str):
+            continue
+        stripped = nf.strip()
+        if not stripped or stripped in warmed:
+            continue
+        warmed[stripped] = parse(stripped)
+    return warmed

--- a/excel_grapher/grapher/preparsed_formulas.py
+++ b/excel_grapher/grapher/preparsed_formulas.py
@@ -12,6 +12,15 @@ def warm_preparsed_formulas(graph: DependencyGraph) -> dict[str, AstNode]:
 
     Returns a mapping from stripped normalized formula strings to AST roots.
     Duplicate formulas across cells share one entry.
+
+    Re-call after loading a graph from JSON cache or mutating node formulas
+    post-extraction so `DependencyGraph.preparsed_formulas` stays aligned.
+
+    Raises:
+        FormulaParseError: If any distinct normalized formula is syntactically
+            invalid. Warming fails fast on the first bad formula (unlike
+            `FormulaEvaluator`, which raises `ParseError` per cell at evaluate
+            time).
     """
     warmed: dict[str, AstNode] = {}
     for _, node in graph.formula_nodes():

--- a/tests/integration/grapher/test_graph_cache_json.py
+++ b/tests/integration/grapher/test_graph_cache_json.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import xlsxwriter
 
+import excel_grapher.evaluator.evaluator as evaluator_module
 from excel_grapher import FormulaEvaluator, create_dependency_graph
 from excel_grapher.grapher.cache import (
     GRAPH_CACHE_SCHEMA_VERSION,
@@ -21,6 +23,7 @@ from excel_grapher.grapher.cache import (
     save_graph_cache,
     try_load_graph_cache,
 )
+from excel_grapher.grapher.preparsed_formulas import warm_preparsed_formulas
 
 
 def _make_simple_workbook(path: Path) -> None:
@@ -53,6 +56,39 @@ def test_cache_roundtrip_strict_hit(tmp_path: Path) -> None:
 
     with FormulaEvaluator(loaded) as ev:
         assert ev.evaluate(["Sheet1!A3"])["Sheet1!A3"] == 5
+
+
+def test_cache_load_rewarm_avoids_evaluator_parse_on_first_pass(tmp_path: Path) -> None:
+    workbook = tmp_path / "book.xlsx"
+    _make_simple_workbook(workbook)
+
+    targets = ["Sheet1!A3"]
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+    meta = build_graph_cache_meta(workbook, targets, extraction_params={"load_values": True})
+
+    cache_path = tmp_path / "graph.json"
+    save_graph_cache(cache_path, graph, meta)
+
+    loaded = try_load_graph_cache(cache_path, expected_meta=meta)
+    assert loaded is not None
+    assert loaded.preparsed_formulas is None
+
+    loaded.preparsed_formulas = warm_preparsed_formulas(loaded)
+
+    parse_calls = 0
+    original_parse = evaluator_module.parse
+
+    def counting_parse(formula: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(formula)
+
+    with (
+        FormulaEvaluator(loaded) as ev,
+        patch.object(evaluator_module, "parse", counting_parse),
+    ):
+        assert ev.evaluate(["Sheet1!A3"])["Sheet1!A3"] == 5
+        assert parse_calls == 0
 
 
 def test_cache_miss_when_targets_differ(tmp_path: Path) -> None:

--- a/tests/unit/evaluator/test_ast_cache.py
+++ b/tests/unit/evaluator/test_ast_cache.py
@@ -181,3 +181,44 @@ def test_ast_cache_info_tracks_hits_and_misses() -> None:
     assert info.hits == 1
     assert info.misses == 2
     assert info.currsize == 2
+
+
+def test_ast_cache_seed_does_not_affect_hit_miss_stats() -> None:
+    cache = AstCache(maxsize=8)
+    cache.seed({"=1": evaluator_parser.parse("=1")})
+
+    info = cache.cache_info()
+    assert info.hits == 0
+    assert info.misses == 0
+    assert info.currsize == 1
+
+
+def test_ast_cache_seed_skips_existing_keys() -> None:
+    cache = AstCache(maxsize=8)
+    original = cache.get("=1", parse_fn=evaluator_parser.parse)
+    info_before = cache.cache_info()
+
+    replacement = evaluator_parser.parse("=2")
+    cache.seed({"=1": replacement, "=2": replacement})
+
+    assert cache.get("=1", parse_fn=evaluator_parser.parse) is original
+    info_after = cache.cache_info()
+    assert info_after.hits == info_before.hits + 1
+    assert info_after.misses == info_before.misses
+    assert info_after.currsize == 2
+
+
+def test_ast_cache_seed_respects_maxsize() -> None:
+    cache = AstCache(maxsize=2)
+    cache.seed(
+        {
+            "=1": evaluator_parser.parse("=1"),
+            "=2": evaluator_parser.parse("=2"),
+            "=3": evaluator_parser.parse("=3"),
+        }
+    )
+
+    assert len(cache) == 2
+    assert "=1" not in cache._cache  # noqa: SLF001
+    assert "=2" in cache._cache  # noqa: SLF001
+    assert "=3" in cache._cache  # noqa: SLF001

--- a/tests/unit/evaluator/test_preparsed_formulas.py
+++ b/tests/unit/evaluator/test_preparsed_formulas.py
@@ -1,0 +1,45 @@
+"""Tests for seeding FormulaEvaluator AST cache from graph pre-parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import fastpyxl
+
+import excel_grapher.evaluator.evaluator as evaluator_module
+from excel_grapher import FormulaEvaluator, create_dependency_graph
+
+
+def test_evaluator_seeds_ast_cache_from_graph_preparsed_formulas(tmp_path: Path) -> None:
+    excel_path = tmp_path / "seed_eval.xlsx"
+    wb = fastpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"].value = 10
+    ws["B1"].value = "=A1*2"
+    wb.save(excel_path)
+    wb.close()
+
+    graph = create_dependency_graph(
+        excel_path,
+        ["Sheet1!B1"],
+        load_values=True,
+        warm_ast_cache=True,
+    )
+
+    parse_calls = 0
+    original_parse = evaluator_module.parse
+
+    def counting_parse(formula: str):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(formula)
+
+    with (
+        FormulaEvaluator(graph) as ev,
+        patch.object(evaluator_module, "parse", counting_parse),
+    ):
+        ev.evaluate(["Sheet1!B1"])
+        assert parse_calls == 0
+        assert ev.ast_cache_info().currsize >= 1

--- a/tests/unit/grapher/test_preparsed_formulas.py
+++ b/tests/unit/grapher/test_preparsed_formulas.py
@@ -1,0 +1,67 @@
+"""Tests for optional formula AST pre-parsing during graph extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import fastpyxl
+
+from excel_grapher import create_dependency_graph
+from excel_grapher.core.formula_ast import AstNode
+from excel_grapher.grapher.preparsed_formulas import warm_preparsed_formulas
+
+
+def test_warm_preparsed_formulas_deduplicates_by_normalized_formula(tmp_path: Path) -> None:
+    excel_path = tmp_path / "dup_formulas.xlsx"
+    wb = fastpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"].value = 1
+    ws["B1"].value = "=A1*2"
+    ws["B2"].value = "=A1*2"
+    wb.save(excel_path)
+    wb.close()
+
+    graph = create_dependency_graph(excel_path, ["Sheet1!B1", "Sheet1!B2"], load_values=False)
+    parse_calls = 0
+    original_parse = warm_preparsed_formulas.__globals__["parse"]
+
+    def counting_parse(formula: str) -> AstNode:
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(formula)
+
+    with patch("excel_grapher.grapher.preparsed_formulas.parse", counting_parse):
+        warmed = warm_preparsed_formulas(graph)
+
+    assert parse_calls == 1
+    assert len(warmed) == 1
+    nf = graph.get_node("Sheet1!B1")
+    assert nf is not None
+    assert nf.normalized_formula in warmed
+
+
+def test_create_dependency_graph_warm_ast_cache_opt_in(tmp_path: Path) -> None:
+    excel_path = tmp_path / "warm_flag.xlsx"
+    wb = fastpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"].value = 1
+    ws["A2"].value = "=A1+1"
+    wb.save(excel_path)
+    wb.close()
+
+    graph_default = create_dependency_graph(excel_path, ["Sheet1!A2"], load_values=False)
+    assert graph_default.preparsed_formulas is None
+
+    graph_warm = create_dependency_graph(
+        excel_path,
+        ["Sheet1!A2"],
+        load_values=False,
+        warm_ast_cache=True,
+    )
+    assert graph_warm.preparsed_formulas is not None
+    node = graph_warm.get_node("Sheet1!A2")
+    assert node is not None
+    assert node.normalized_formula in graph_warm.preparsed_formulas

--- a/tests/unit/grapher/test_preparsed_formulas.py
+++ b/tests/unit/grapher/test_preparsed_formulas.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import fastpyxl
+import pytest
 
-from excel_grapher import create_dependency_graph
-from excel_grapher.core.formula_ast import AstNode
+from excel_grapher import DependencyGraph, Node, create_dependency_graph
+from excel_grapher.core.address_keys import parse_address
+from excel_grapher.core.formula_ast import AstNode, FormulaParseError, parse
 from excel_grapher.grapher.preparsed_formulas import warm_preparsed_formulas
 
 
@@ -25,12 +27,11 @@ def test_warm_preparsed_formulas_deduplicates_by_normalized_formula(tmp_path: Pa
 
     graph = create_dependency_graph(excel_path, ["Sheet1!B1", "Sheet1!B2"], load_values=False)
     parse_calls = 0
-    original_parse = warm_preparsed_formulas.__globals__["parse"]
 
     def counting_parse(formula: str) -> AstNode:
         nonlocal parse_calls
         parse_calls += 1
-        return original_parse(formula)
+        return parse(formula)
 
     with patch("excel_grapher.grapher.preparsed_formulas.parse", counting_parse):
         warmed = warm_preparsed_formulas(graph)
@@ -65,3 +66,24 @@ def test_create_dependency_graph_warm_ast_cache_opt_in(tmp_path: Path) -> None:
     node = graph_warm.get_node("Sheet1!A2")
     assert node is not None
     assert node.normalized_formula in graph_warm.preparsed_formulas
+
+
+def test_warm_preparsed_formulas_raises_on_invalid_formula() -> None:
+    sheet, coord = parse_address("S!A1")
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    graph = DependencyGraph()
+    graph.add_node(
+        Node(
+            sheet=sheet,
+            column=col,
+            row=row,
+            formula="=1+",
+            normalized_formula="=1+",
+            value=None,
+            is_leaf=False,
+        )
+    )
+
+    with pytest.raises(FormulaParseError):
+        warm_preparsed_formulas(graph)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an opt-in `warm_ast_cache` flag to `create_dependency_graph` that pre-parses each distinct `normalized_formula` at extraction time. Parsed ASTs are stored on `DependencyGraph.preparsed_formulas`, and `FormulaEvaluator` seeds its existing LRU cache from that mapping so first evaluation does not re-parse.

## Changes

- `create_dependency_graph(..., warm_ast_cache=False)` — when enabled, populates `graph.preparsed_formulas`
- `warm_preparsed_formulas(graph)` — standalone helper (also useful after loading a graph from JSON cache)
- `AstCache.seed()` — bulk insert pre-parsed ASTs without affecting hit/miss stats
- `FormulaEvaluator` automatically seeds from `graph.preparsed_formulas` when present

## Design notes

- Respects grapher/evaluator import boundary: warming uses `core.formula_ast.parse` in grapher; evaluator only reads the stored mapping
- ASTs are keyed by `normalized_formula` (same as evaluator cache), deduplicating array-fill patterns
- Not persisted in JSON graph cache; callers can re-warm after load via `warm_preparsed_formulas(graph)`
- Value invalidation behavior unchanged — only formula changes require re-parsing

## Usage

```python
graph = create_dependency_graph(workbook, targets, warm_ast_cache=True)
with FormulaEvaluator(graph) as ev:
    ev.evaluate(targets)  # no parse misses on first pass
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-806f87f8-412e-4b25-bac9-2d069319e728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-806f87f8-412e-4b25-bac9-2d069319e728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

