### PR TITLE
fix: preserve quoted apostrophe sheet refs in formula normalization

### DIFF
--- a/excel_grapher/core/address_keys.py
+++ b/excel_grapher/core/address_keys.py
@@ -37,6 +37,25 @@ def quote_sheet_if_needed(sheet: str) -> str:
     return "'" + _escape_sheet_for_formula(sheet) + "'"
 
 
+# Regex fragment for the inner part of a quoted Excel sheet name in formulas.
+_QUOTED_SHEET_NAME_INNER = r"(?:[^']|'')+"
+
+
+def quoted_sheet_name_regex(*, capture_group: str = "sheet") -> str:
+    """Return a regex fragment matching a quoted Excel sheet name (no trailing ``!``)."""
+    return rf"'(?P<{capture_group}>{_QUOTED_SHEET_NAME_INNER})'"
+
+
+def quoted_sheet_prefix_regex(*, capture_group: str = "sheet") -> str:
+    """Return a regex fragment matching ``'Sheet Name'!`` with Excel ``''`` escape."""
+    return quoted_sheet_name_regex(capture_group=capture_group) + "!"
+
+
+def unescape_formula_sheet_name(escaped: str) -> str:
+    """Unescape a sheet name captured from a quoted formula reference."""
+    return escaped.replace("''", "'")
+
+
 def parse_address(address: str) -> tuple[str, str]:
     """Parse a sheet-qualified address into `(sheet, cell_coord)`.
 

--- a/excel_grapher/core/formula_normalization.py
+++ b/excel_grapher/core/formula_normalization.py
@@ -10,7 +10,14 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from excel_grapher.core.address_keys import format_cell_key, quote_sheet_if_needed
+from excel_grapher.core.address_keys import (
+    format_cell_key,
+    quote_sheet_if_needed,
+    quoted_sheet_prefix_regex,
+    unescape_formula_sheet_name,
+)
+
+_QUOTED_SHEET_PREFIX = quoted_sheet_prefix_regex()
 
 _FUNC_LIKE = frozenset({"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"})
 _STRING_LITERAL_RE = re.compile(r'"(?:[^"]|"")*"')
@@ -94,10 +101,11 @@ def _normalize_whole_column_row_shorthand(formula: str, current_sheet: str) -> s
     result = formula
 
     def quoted_whole_col(m: re.Match[str]) -> str:
-        return _format_whole_column_ref(m.group("sheet"), m.group("col"))
+        sheet = unescape_formula_sheet_name(m.group("sheet"))
+        return _format_whole_column_ref(sheet, m.group("col"))
 
     result = re.sub(
-        r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
+        _QUOTED_SHEET_PREFIX + r"\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
         quoted_whole_col,
         result,
         flags=re.IGNORECASE,
@@ -127,10 +135,11 @@ def _normalize_whole_column_row_shorthand(formula: str, current_sheet: str) -> s
     )
 
     def quoted_whole_row(m: re.Match[str]) -> str:
-        return _format_whole_row_ref(m.group("sheet"), int(m.group("row")))
+        sheet = unescape_formula_sheet_name(m.group("sheet"))
+        return _format_whole_row_ref(sheet, int(m.group("row")))
 
     result = re.sub(
-        r"'(?P<sheet>[^']+)'!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b",
+        _QUOTED_SHEET_PREFIX + r"\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b",
         quoted_whole_row,
         result,
     )
@@ -206,14 +215,15 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
     result = _normalize_whole_column_row_shorthand(formula, current_sheet)
 
     def replace_quoted_range(m: re.Match[str]) -> str:
-        sheet = m.group("sheet")
+        sheet = unescape_formula_sheet_name(m.group("sheet"))
         c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
         a = format_cell_key(sheet, c1, int(r1))
         b = format_cell_key(sheet, c2, int(r2))
         return f"{a}:{b}"
 
     result = re.sub(
-        r"'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
+        _QUOTED_SHEET_PREFIX
+        + r"\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
         replace_quoted_range,
         result,
     )
@@ -242,11 +252,12 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
     )
 
     def replace_quoted_cell(m: re.Match[str]) -> str:
-        sheet, col, row = m.group("sheet"), m.group("col"), m.group("row")
+        sheet = unescape_formula_sheet_name(m.group("sheet"))
+        col, row = m.group("col"), m.group("row")
         return format_cell_key(sheet, col, int(row))
 
     result = re.sub(
-        r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
+        _QUOTED_SHEET_PREFIX + r"\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)",
         replace_quoted_cell,
         result,
     )

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -13,6 +13,9 @@ from excel_grapher.core import address_keys as _address_keys
 from excel_grapher.core.address_keys import (
     format_cell_key,
     needs_quoting,
+    quoted_sheet_name_regex,
+    quoted_sheet_prefix_regex,
+    unescape_formula_sheet_name,
 )
 from excel_grapher.core.excel_function_names import excel_function_call_prefixes
 from excel_grapher.core.formula_normalization import (
@@ -46,24 +49,45 @@ class CellRef:
     range_kind: TypingLiteral["cell", "whole_column", "whole_row"] = "cell"
 
 
+_FUNC_LIKE = {"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"}
+
+_QUOTED_SHEET = quoted_sheet_name_regex(capture_group="sheet")
+_QUOTED_SHEET_QS = quoted_sheet_name_regex(capture_group="qs")
+_QUOTED_SHEET_PREFIX = quoted_sheet_prefix_regex()
+
+
+def _sheet_from_cell_match(m: re.Match[str]) -> str:
+    qs = m.group("qs")
+    if qs is not None:
+        return unescape_formula_sheet_name(qs)
+    us = m.group("us")
+    assert us is not None
+    return us
+
+
+def _sheet_from_quoted_group(m: re.Match[str], *, group: str = "sheet") -> str:
+    return unescape_formula_sheet_name(m.group(group))
+
+
 _SHEET_CELL_RE = re.compile(
-    r"(?:'(?P<qs>[^']+)'|(?P<us>[A-Za-z][A-Za-z0-9_]*))!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)"
+    rf"(?:{_QUOTED_SHEET_QS}|(?P<us>[A-Za-z][A-Za-z0-9_]*))!\$?(?P<col>[A-Z]{{1,3}})\$?(?P<row>\d+)"
 )
 # Do not treat `Col` in `Sheet!$Col$Row` as a local ref: the column letter can follow `!$`.
 # Sheet tokens may look like A1 (e.g. `S2` / `'S2'`); do not match those as local refs.
 _LOCAL_CELL_RE = re.compile(
     r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])"
 )
-_FUNC_LIKE = {"IF", "OR", "AND", "NOT", "SUM", "MAX", "MIN", "AVG"}
 
 _RANGE_QUOTED_RE = re.compile(
-    r"'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
+    _QUOTED_SHEET_PREFIX
+    + r"\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
 )
 _RANGE_UNQUOTED_RE = re.compile(
     r"(?<![A-Za-z_])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
 )
 _RANGE_QUOTED_BOTH_ENDPOINTS_RE = re.compile(
-    r"'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*'(?P=sheet)'!\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
+    _QUOTED_SHEET_PREFIX
+    + r"\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*'(?P=sheet)'!\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
 )
 _RANGE_UNQUOTED_BOTH_ENDPOINTS_RE = re.compile(
     r"(?<![A-Za-z_])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*(?P=sheet)!\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)"
@@ -72,7 +96,7 @@ _RANGE_LOCAL_RE = re.compile(
     r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])"
 )
 _RANGE_WHOLE_COL_QUOTED_RE = re.compile(
-    r"'(?P<sheet>[^']+)'!\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
+    _QUOTED_SHEET_PREFIX + r"\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b",
     re.IGNORECASE,
 )
 _RANGE_WHOLE_COL_UNQUOTED_RE = re.compile(
@@ -83,7 +107,9 @@ _RANGE_WHOLE_COL_LOCAL_RE = re.compile(
     r"(?<![!A-Za-z0-9_'])(?<!\$)\$?(?P<col>[A-Z]{1,3})\s*:\s*\$?(?P=col)\b(?![A-Za-z0-9_])",
     re.IGNORECASE,
 )
-_RANGE_WHOLE_ROW_QUOTED_RE = re.compile(r"'(?P<sheet>[^']+)'!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b")
+_RANGE_WHOLE_ROW_QUOTED_RE = re.compile(
+    _QUOTED_SHEET_PREFIX + r"\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b"
+)
 _RANGE_WHOLE_ROW_UNQUOTED_RE = re.compile(
     r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<row>\d+)\s*:\s*\$?(?P=row)\b"
 )
@@ -103,7 +129,7 @@ def parse_cell_refs(formula: str) -> list[CellRef]:
     out: list[CellRef] = []
 
     for m in _SHEET_CELL_RE.finditer(formula):
-        sheet = m.group("qs") or m.group("us")
+        sheet = _sheet_from_cell_match(m)
         out.append(CellRef(sheet=sheet, column=m.group("col"), row=int(m.group("row"))))
 
     for m in _LOCAL_CELL_RE.finditer(formula):
@@ -123,7 +149,7 @@ def parse_cell_refs_with_spans(formula: str) -> list[tuple[CellRef, tuple[int, i
     out: list[tuple[CellRef, tuple[int, int]]] = []
 
     for m in _SHEET_CELL_RE.finditer(formula):
-        sheet = m.group("qs") or m.group("us")
+        sheet = _sheet_from_cell_match(m)
         ref = CellRef(sheet=sheet, column=m.group("col"), row=int(m.group("row")))
         out.append((ref, m.span()))
 
@@ -145,7 +171,7 @@ def parse_range_refs(formula: str) -> list[tuple[CellRef, CellRef]]:
     out: list[tuple[CellRef, CellRef]] = []
 
     for m in _RANGE_WHOLE_COL_QUOTED_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         col = m.group("col").upper()
         ref = CellRef(sheet=sheet, column=col, row=0, range_kind="whole_column")
         out.append((ref, ref))
@@ -162,7 +188,7 @@ def parse_range_refs(formula: str) -> list[tuple[CellRef, CellRef]]:
         out.append((ref, ref))
 
     for m in _RANGE_WHOLE_ROW_QUOTED_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         row = int(m.group("row"))
         ref = CellRef(sheet=sheet, column="", row=row, range_kind="whole_row")
         out.append((ref, ref))
@@ -179,7 +205,7 @@ def parse_range_refs(formula: str) -> list[tuple[CellRef, CellRef]]:
         out.append((ref, ref))
 
     for m in _RANGE_QUOTED_BOTH_ENDPOINTS_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         out.append(
             (
                 CellRef(sheet=sheet, column=m.group("c1"), row=int(m.group("r1"))),
@@ -197,7 +223,7 @@ def parse_range_refs(formula: str) -> list[tuple[CellRef, CellRef]]:
         )
 
     for m in _RANGE_QUOTED_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         out.append(
             (
                 CellRef(sheet=sheet, column=m.group("c1"), row=int(m.group("r1"))),
@@ -237,7 +263,7 @@ def parse_range_refs_with_spans(formula: str) -> list[tuple[CellRef, CellRef, tu
     out: list[tuple[CellRef, CellRef, tuple[int, int]]] = []
 
     for m in _RANGE_WHOLE_COL_QUOTED_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         col = m.group("col").upper()
         ref = CellRef(sheet=sheet, column=col, row=0, range_kind="whole_column")
         out.append((ref, ref, m.span()))
@@ -254,7 +280,7 @@ def parse_range_refs_with_spans(formula: str) -> list[tuple[CellRef, CellRef, tu
         out.append((ref, ref, m.span()))
 
     for m in _RANGE_WHOLE_ROW_QUOTED_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         row = int(m.group("row"))
         ref = CellRef(sheet=sheet, column="", row=row, range_kind="whole_row")
         out.append((ref, ref, m.span()))
@@ -271,7 +297,7 @@ def parse_range_refs_with_spans(formula: str) -> list[tuple[CellRef, CellRef, tu
         out.append((ref, ref, m.span()))
 
     for m in _RANGE_QUOTED_BOTH_ENDPOINTS_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         out.append(
             (
                 CellRef(sheet=sheet, column=m.group("c1"), row=int(m.group("r1"))),
@@ -291,7 +317,7 @@ def parse_range_refs_with_spans(formula: str) -> list[tuple[CellRef, CellRef, tu
         )
 
     for m in _RANGE_QUOTED_RE.finditer(formula):
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         out.append(
             (
                 CellRef(sheet=sheet, column=m.group("c1"), row=int(m.group("r1"))),
@@ -574,13 +600,15 @@ def split_top_level_switch(formula: str) -> list[str] | None:
 
 
 _CELL_TOKEN_RE = re.compile(
-    r"^(?:(?:'(?P<qs>[^']+)')|(?P<us>[A-Za-z][A-Za-z0-9_]*))!\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)$"
+    rf"^(?:{_QUOTED_SHEET_QS}|(?P<us>[A-Za-z][A-Za-z0-9_]*))!\$?(?P<col>[A-Z]{{1,3}})\$?(?P<row>\d+)$"
 )
 _LOCAL_CELL_TOKEN_RE = re.compile(r"^\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)$")
 _NUMBER_TOKEN_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
 _INT_TOKEN_RE = re.compile(r"^[+-]?\d+$")
 _RANGE_TOKEN_QUOTED_RE = re.compile(
-    r"^'(?P<sheet>[^']+)'!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)$"
+    "^"
+    + _QUOTED_SHEET_PREFIX
+    + r"\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)$"
 )
 _RANGE_TOKEN_UNQUOTED_RE = re.compile(
     r"^(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)$"
@@ -868,7 +896,7 @@ def _parse_ref_or_range_token(
     # Quoted sheet range
     m = _RANGE_TOKEN_QUOTED_RE.match(tok)
     if m:
-        sheet = m.group("sheet")
+        sheet = _sheet_from_quoted_group(m)
         return (
             CellRef(sheet=sheet, column=m.group("c1"), row=int(m.group("r1"))),
             CellRef(sheet=sheet, column=m.group("c2"), row=int(m.group("r2"))),
@@ -894,7 +922,7 @@ def _parse_ref_or_range_token(
     # Sheet-qualified cell
     m = _CELL_TOKEN_RE.match(tok)
     if m:
-        sheet = m.group("qs") or m.group("us")
+        sheet = _sheet_from_cell_match(m)
         ref = CellRef(sheet=sheet, column=m.group("col"), row=int(m.group("row")))
         return ref, ref
 
@@ -1360,7 +1388,7 @@ def _parse_guard_atom(
     # Sheet-qualified cell
     m = _CELL_TOKEN_RE.match(s)
     if m:
-        sheet = m.group("qs") or m.group("us")
+        sheet = _sheet_from_cell_match(m)
         return GuardCellRef(_to_node_key(str(sheet), m.group("col"), int(m.group("row"))))
 
     # Local cell

--- a/tests/integration/grapher/test_address_parsing.py
+++ b/tests/integration/grapher/test_address_parsing.py
@@ -6,7 +6,6 @@ import re
 import zipfile
 from pathlib import Path
 
-import pytest
 import xlsxwriter
 
 from excel_grapher import create_dependency_graph, validate_graph
@@ -39,10 +38,6 @@ def _with_calcchain(src_xlsx: Path, dst_xlsx: Path, *, sheet_id: str, cell_refs:
         zout.writestr("xl/calcChain.xml", calc_xml)
 
 
-@pytest.mark.xfail(
-    reason="Formula normalization corrupts quoted apostrophe sheet refs ('O''Neil' -> 'O'Neil')",
-    strict=True,
-)
 def test_create_dependency_graph_handles_apostrophe_sheet_names(tmp_path: Path) -> None:
     sheet_name = "O'Neil"
     excel_path = tmp_path / "apostrophe_sheet.xlsx"

--- a/tests/unit/core/test_address_keys.py
+++ b/tests/unit/core/test_address_keys.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import typing
 
 from excel_grapher.core.address_keys import (
@@ -8,7 +9,9 @@ from excel_grapher.core.address_keys import (
     format_key,
     make_node_key_sort_key,
     normalize_key,
+    quoted_sheet_prefix_regex,
     sort_node_keys,
+    unescape_formula_sheet_name,
 )
 from excel_grapher.grapher.node import NodeKey
 
@@ -74,3 +77,15 @@ def test_make_node_key_sort_key_places_unknown_sheets_after_known() -> None:
     keys = ["Known!A1", "Other!A1", "Another!A1"]
 
     assert sorted(keys, key=key_fn) == ["Known!A1", "Another!A1", "Other!A1"]
+
+
+def test_quoted_sheet_prefix_regex_matches_doubled_apostrophe_escape() -> None:
+    pattern = quoted_sheet_prefix_regex()
+    match = re.match(pattern + r"A1", "'O''Neil'!A1")
+    assert match is not None
+    assert unescape_formula_sheet_name(match.group("sheet")) == "O'Neil"
+
+
+def test_unescape_formula_sheet_name() -> None:
+    assert unescape_formula_sheet_name("O''Neil") == "O'Neil"
+    assert unescape_formula_sheet_name("It''s Data") == "It's Data"

--- a/tests/unit/core/test_formula_normalization.py
+++ b/tests/unit/core/test_formula_normalization.py
@@ -36,3 +36,21 @@ def test_normalize_excel_formula_preserves_cell_like_text_in_string_literals() -
     ]
     for formula, expected in cases:
         assert normalize_excel_formula(formula, "Sheet1") == expected
+
+
+def test_normalize_excel_formula_preserves_quoted_apostrophe_sheet_refs() -> None:
+    """Quoted sheet names with escaped apostrophes must not be corrupted."""
+    sheet = "O'Neil"
+    cases = [
+        ("='O''Neil'!A1*2", "='O''Neil'!A1*2"),
+        ("='O''Neil'!A1:'O''Neil'!B2", "='O''Neil'!A1:'O''Neil'!B2"),
+        ("=SUM('O''Neil'!A:A)", "=SUM('O''Neil'!A:A)"),
+        ("=SUM('O''Neil'!1:1)", "=SUM('O''Neil'!1:1)"),
+    ]
+    for formula, expected in cases:
+        assert normalize_excel_formula(formula, sheet) == expected
+
+
+def test_formula_normalizer_preserves_quoted_apostrophe_sheet_refs() -> None:
+    n = FormulaNormalizer({}, {})
+    assert n.normalize("='O''Neil'!A1*2", "O'Neil") == "='O''Neil'!A1*2"

--- a/tests/unit/grapher/test_address_parsing.py
+++ b/tests/unit/grapher/test_address_parsing.py
@@ -13,6 +13,7 @@ from excel_grapher.grapher.dynamic_refs import (
     _split_qualified_to_sheet_a1,
     expand_leaf_env_to_argument_env,
 )
+from excel_grapher.grapher.parser import parse_cell_refs
 from excel_grapher.grapher.validation import _sheet_name_from_key
 
 _APOSTROPHE_SHEET = "O'Neil"
@@ -99,3 +100,11 @@ def test_expand_leaf_env_passes_correct_sheet_for_apostrophe_sheet_names() -> No
     )
     assert seen_sheets == [_APOSTROPHE_SHEET]
     assert formula_cell in env
+
+
+def test_parse_cell_refs_handles_apostrophe_sheet_names() -> None:
+    refs = parse_cell_refs("='O''Neil'!A1*2")
+    assert len(refs) == 1
+    assert refs[0].sheet == _APOSTROPHE_SHEET
+    assert refs[0].column == "A"
+    assert refs[0].row == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #344

## Problem

`FormulaNormalizer` and dependency ref parsing used regex patterns like `'(?P<sheet>[^']+)'` that stop at the first apostrophe. Formulas such as `='O''Neil'!A1*2` were corrupted to `='O'Neil!A1*2`, and graph build recorded dependencies like `Neil!A1` instead of `'O''Neil'!A1`.

## Solution

- Add shared quoted-sheet regex helpers in `excel_grapher.core.address_keys` (`quoted_sheet_name_regex`, `quoted_sheet_prefix_regex`, `unescape_formula_sheet_name`).
- Route formula normalization and grapher ref parsing through those helpers so Excel's `''` escape inside quoted sheet names is preserved end-to-end.
- Remove the strict xfail on `test_create_dependency_graph_handles_apostrophe_sheet_names` and add unit coverage for normalization and `parse_cell_refs`.

## Testing

- `uv run pytest tests/unit/core/test_formula_normalization.py tests/unit/core/test_address_keys.py tests/unit/grapher/test_address_parsing.py tests/integration/grapher/test_address_parsing.py`
- Full CI suite: ruff, format, ty, pytest (1799 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8cdfa60-9984-4545-9ea1-3f118b076dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8cdfa60-9984-4545-9ea1-3f118b076dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

