### PR TITLE
refactor: minor grapher cleanup (dead code, sha256, version, viz API)

### DIFF
--- a/excel_grapher/__init__.py
+++ b/excel_grapher/__init__.py
@@ -64,7 +64,6 @@ from .grapher import (
     try_load_graph_cache,
     validate_graph,
     write_lightweight_viz_data,
-    write_lightweight_viz_html,
     write_web_viz_html,
 )
 from .series_bindings import (
@@ -130,7 +129,6 @@ __all__ = [
     "to_mermaid",
     "to_networkx",
     "write_lightweight_viz_data",
-    "write_lightweight_viz_html",
     "write_web_viz_html",
     "validate_graph",
     "save_graph_cache",

--- a/excel_grapher/grapher/__init__.py
+++ b/excel_grapher/grapher/__init__.py
@@ -45,7 +45,6 @@ from .export import (
     to_mermaid,
     to_networkx,
     write_lightweight_viz_data,
-    write_lightweight_viz_html,
     write_web_viz_html,
 )
 from .graph import CycleError, CycleReport, DependencyGraph, GraphReadView, NodeHook
@@ -114,7 +113,6 @@ __all__ = [
     "to_networkx",
     "write_web_viz_html",
     "write_lightweight_viz_data",
-    "write_lightweight_viz_html",
     "validate_graph",
     "ValidationResult",
     "get_calc_settings",

--- a/excel_grapher/grapher/cache.py
+++ b/excel_grapher/grapher/cache.py
@@ -47,11 +47,8 @@ def _package_version() -> str:
 
 
 def sha256_file(path: Path) -> str:
-    h = hashlib.sha256()
     with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
+        return hashlib.file_digest(f, "sha256").hexdigest()
 
 
 def sha256_lines(lines: list[str]) -> str:

--- a/excel_grapher/grapher/export.py
+++ b/excel_grapher/grapher/export.py
@@ -15,7 +15,6 @@ from .lightweight_viz import (
     LightweightVizPayload,
     LightweightVizStats,
     write_lightweight_viz_data,
-    write_lightweight_viz_html,
     write_web_viz_html,
 )
 from .node import Node, NodeKey, NodeView
@@ -243,5 +242,4 @@ __all__ = [
     "to_networkx",
     "write_web_viz_html",
     "write_lightweight_viz_data",
-    "write_lightweight_viz_html",
 ]

--- a/excel_grapher/grapher/lightweight_viz.py
+++ b/excel_grapher/grapher/lightweight_viz.py
@@ -1308,7 +1308,7 @@ def write_lightweight_viz_data(payload: LightweightVizPayload, path: Path | str)
     p.write_text(serialize_lightweight_viz_json(payload), encoding="utf-8")
 
 
-def write_lightweight_viz_html(
+def write_web_viz_html(
     payload: LightweightVizPayload,
     path: Path | str,
     *,
@@ -1318,6 +1318,7 @@ def write_lightweight_viz_html(
     inline_size_budget_mb: int = 50,
     template_path: Path | str | None = None,
 ) -> None:
+    """Write a web visualization HTML bundle from a web-viz payload."""
     from importlib import resources
 
     if payload.version != VIZ_PAYLOAD_VERSION:
@@ -1381,25 +1382,3 @@ def write_lightweight_viz_html(
         .replace("/*__SIDECAR__*/", sidecar_js)
     )
     out.write_text(html, encoding="utf-8")
-
-
-def write_web_viz_html(
-    payload: LightweightVizPayload,
-    path: Path | str,
-    *,
-    title: str = "Workbook dependency graph",
-    data_mode: Literal["inline", "sidecar", "auto"] = "auto",
-    data_path: Path | str | None = None,
-    inline_size_budget_mb: int = 50,
-    template_path: Path | str | None = None,
-) -> None:
-    """Write a web visualization HTML bundle from a web-viz payload."""
-    write_lightweight_viz_html(
-        payload,
-        path,
-        title=title,
-        data_mode=data_mode,
-        data_path=data_path,
-        inline_size_budget_mb=inline_size_budget_mb,
-        template_path=template_path,
-    )

--- a/excel_grapher/grapher/resolver.py
+++ b/excel_grapher/grapher/resolver.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Protocol
 
 import fastpyxl
 from fastpyxl.utils.cell import (
@@ -29,19 +28,6 @@ from excel_grapher.core.formula_normalization import expand_whole_column_row_for
 from excel_grapher.core.types import CellValue, ExcelRange, XlError
 
 from .parser import CellRef
-
-
-class NameResolver(Protocol):
-    def resolve(self, name: str) -> tuple[str, str] | None:
-        """Return (sheet, A1) for a defined name, or None if unknown/unsupported."""
-
-
-class DictNameResolver:
-    def __init__(self, mapping: dict[str, tuple[str, str]]):
-        self._mapping = mapping
-
-    def resolve(self, name: str) -> tuple[str, str] | None:
-        return self._mapping.get(name)
 
 
 @dataclass(frozen=True)

--- a/excel_grapher/grapher/type_analysis_cache.py
+++ b/excel_grapher/grapher/type_analysis_cache.py
@@ -13,7 +13,6 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +27,7 @@ from excel_grapher.core.cell_types import (
     NotEqualCell,
     RealIntervalDomain,
 )
+from excel_grapher.grapher.cache import _package_version
 from excel_grapher.grapher.dynamic_refs import DynamicRefLimits
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # Bump this when the analysis logic changes in a way that affects cached results.
 ANALYSIS_SCHEMA_VERSION: int = 2
 
-_EXCEL_GRAPHER_VERSION: str = _pkg_version("excel_grapher")
+_EXCEL_GRAPHER_VERSION: str = _package_version()
 
 # ---------------------------------------------------------------------------
 # CellType JSON serialization

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -343,7 +343,6 @@ reference:
       - validate_graph
       - validate_series_bindings
       - write_lightweight_viz_data
-      - write_lightweight_viz_html
       - write_web_viz_html
 
   - title: Constants

--- a/tests/integration/grapher/test_export_lightweight_viz_html.py
+++ b/tests/integration/grapher/test_export_lightweight_viz_html.py
@@ -9,7 +9,7 @@ import pytest
 
 import excel_grapher.grapher.lightweight_viz as lightweight_viz_mod
 from excel_grapher.exporter import to_web_viz_payload
-from excel_grapher.grapher import write_lightweight_viz_data, write_lightweight_viz_html
+from excel_grapher.grapher import write_lightweight_viz_data, write_web_viz_html
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.grapher.lightweight_viz import (
     VIZ_PAYLOAD_VERSION,
@@ -67,7 +67,7 @@ def test_write_html_core_only_no_overlays(tmp_path: Path) -> None:
     assert payload.version == VIZ_PAYLOAD_VERSION
     assert payload.overlays == ()
     out = tmp_path / "core_only.html"
-    write_lightweight_viz_html(payload, out, title="Core only", data_mode="inline")
+    write_web_viz_html(payload, out, title="Core only", data_mode="inline")
     assert out.is_file()
     text = out.read_text(encoding="utf-8")
     ver = str(VIZ_PAYLOAD_VERSION)
@@ -87,7 +87,7 @@ def test_build_core_uses_graph_sheet_order_for_sheet_indices() -> None:
 def test_write_html_creates_file(tmp_path: Path) -> None:
     p = _payload()
     out = tmp_path / "v.html"
-    write_lightweight_viz_html(p, out, title="T", data_mode="inline")
+    write_web_viz_html(p, out, title="T", data_mode="inline")
     assert out.is_file()
     text = out.read_text(encoding="utf-8")
     assert "T" in text
@@ -99,7 +99,7 @@ def test_write_html_creates_file(tmp_path: Path) -> None:
 def test_inline_embeds_payload_under_budget(tmp_path: Path) -> None:
     p = _payload()
     out = tmp_path / "v.html"
-    write_lightweight_viz_html(p, out, data_mode="inline", inline_size_budget_mb=50)
+    write_web_viz_html(p, out, data_mode="inline", inline_size_budget_mb=50)
     text = out.read_text(encoding="utf-8")
     assert "window.__VIZ_DATA__" in text
     ver = str(VIZ_PAYLOAD_VERSION)
@@ -110,7 +110,7 @@ def test_inline_embeds_payload_under_budget(tmp_path: Path) -> None:
 def test_sidecar_writes_sibling_json(tmp_path: Path) -> None:
     p = _payload()
     out = tmp_path / "v.html"
-    write_lightweight_viz_html(p, out, data_mode="sidecar", data_path=tmp_path / "data.viz.json")
+    write_web_viz_html(p, out, data_mode="sidecar", data_path=tmp_path / "data.viz.json")
     data = tmp_path / "data.viz.json"
     assert data.is_file()
     assert "window.__VIZ_DATA_URL__" in out.read_text(encoding="utf-8")
@@ -124,7 +124,7 @@ def test_auto_sidecar_when_estimate_large(tmp_path: Path, monkeypatch: pytest.Mo
         lambda _payload: 100 * 1024 * 1024,
     )
     out = tmp_path / "v.html"
-    write_lightweight_viz_html(p, out, data_mode="auto", inline_size_budget_mb=50)
+    write_web_viz_html(p, out, data_mode="auto", inline_size_budget_mb=50)
     sidecar = tmp_path / "v.viz.json"
     assert sidecar.is_file()
     html = out.read_text(encoding="utf-8")
@@ -134,7 +134,7 @@ def test_auto_sidecar_when_estimate_large(tmp_path: Path, monkeypatch: pytest.Mo
 def test_invalid_payload_version_raises(tmp_path: Path) -> None:
     p = replace(_payload(), version=99)
     with pytest.raises(ValueError, match="Unsupported"):
-        write_lightweight_viz_html(p, tmp_path / "x.html", data_mode="inline")
+        write_web_viz_html(p, tmp_path / "x.html", data_mode="inline")
 
 
 def test_write_data_roundtrip(tmp_path: Path) -> None:
@@ -156,5 +156,5 @@ def test_write_data_roundtrip(tmp_path: Path) -> None:
 def test_overview_viewer_contract(tmp_path: Path, needle: str) -> None:
     p = _payload()
     out = tmp_path / "v.html"
-    write_lightweight_viz_html(p, out, data_mode="inline")
+    write_web_viz_html(p, out, data_mode="inline")
     assert needle.lower() in out.read_text(encoding="utf-8").lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements four low-risk cleanup items from the minor-code review:

1. **Remove dead resolver types** — delete unused `NameResolver` protocol and `DictNameResolver` from `resolver.py`.
2. **Use stdlib file hashing** — replace hand-rolled chunked `sha256_file` with `hashlib.file_digest` in `cache.py` (already used elsewhere in the builder).
3. **Unify package version lookup** — route `type_analysis_cache` through `cache._package_version()` so both sites use `importlib.metadata.version("excel-grapher")` with a `PackageNotFoundError` fallback.
4. **Consolidate web viz HTML API** — keep `write_web_viz_html` as the single public writer; remove the `write_lightweight_viz_html` alias from exports and docs.

## Breaking changes

- `write_lightweight_viz_html` is no longer exported. Callers should use `write_web_viz_html` instead (same signature and behavior).

## Test plan

- [x] `uv run ruff check` / `ruff format --check` on touched files
- [x] Targeted pytest: web viz, type analysis cache, resolver (74 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1bcf3d9-e7aa-4fb4-ae51-39ea7ee939be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1bcf3d9-e7aa-4fb4-ae51-39ea7ee939be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

