### PR TITLE
perf: speed up optimal projection manifests

### DIFF
--- a/excel_grapher/exporter/projection.py
+++ b/excel_grapher/exporter/projection.py
@@ -292,22 +292,38 @@ def _external_dependencies(
 
 
 def _statement_order(
-    graph: DependencyGraph, collapsed_sources: Iterable[NodeKey]
+    graph: DependencyGraph,
+    collapsed_sources: Iterable[NodeKey],
+    *,
+    order_index: Mapping[NodeKey, int] | None = None,
 ) -> tuple[str, ...]:
     """Return dependency-first statement order for collapsed source nodes."""
     sources = {normalize_key(key) for key in collapsed_sources}
     if not sources:
         return ()
-    try:
-        ordered = [key for key in graph.evaluation_order(strict=False) if key in sources]
-    except CycleError:
-        ordered = []
+    if order_index is None:
+        try:
+            ordered = [key for key in graph.evaluation_order(strict=False) if key in sources]
+        except CycleError:
+            ordered = []
+    else:
+        ordered = sorted(
+            (key for key in sources if key in order_index), key=order_index.__getitem__
+        )
     seen = set(ordered)
     for key in graph.keys(order="workbook", source=sources):
         if key not in seen:
             ordered.append(key)
             seen.add(key)
     return tuple(ordered)
+
+
+def _statement_order_index(graph: DependencyGraph) -> dict[NodeKey, int]:
+    """Return one graph-wide dependency order index for collapsed group ordering."""
+    try:
+        return {key: index for index, key in enumerate(graph.evaluation_order(strict=False))}
+    except CycleError:
+        return {}
 
 
 def build_forwarding_projection_manifest(
@@ -333,12 +349,13 @@ def build_forwarding_projection_manifest(
     }
 
     removed_node_snapshots = dict(record.snapshots_by_removed)
+    order_index = _statement_order_index(original_graph)
 
     collapsed_groups = tuple(
         CollapsedGroup(
             retained=retained,
             collapsed_sources=tuple(sources),
-            statement_order=_statement_order(original_graph, sources),
+            statement_order=_statement_order(original_graph, sources, order_index=order_index),
             external_dependencies=_external_dependencies(
                 original_graph,
                 retained=retained,
@@ -362,7 +379,7 @@ def project_identity_transits(
     graph: DependencyGraph,
 ) -> tuple[DependencyGraph, BaseProjectionManifest]:
     """Return a projected copy of `graph` with identity transit nodes collapsed."""
-    projected = graph.copy()
+    projected = graph._copy_for_projection()
     record = IdentityTransitCompressionRecord()
     projected.compress_identity_transits(record=record)
     return projected, build_forwarding_projection_manifest(graph, record, kind="identity_transit")
@@ -400,12 +417,13 @@ def build_optimal_projection_manifest(
     }
 
     removed_node_snapshots = dict(record.snapshots_by_removed)
+    order_index = _statement_order_index(original_graph)
 
     collapsed_groups = tuple(
         CollapsedGroup(
             retained=retained,
             collapsed_sources=tuple(sources),
-            statement_order=_statement_order(original_graph, sources),
+            statement_order=_statement_order(original_graph, sources, order_index=order_index),
             external_dependencies=_external_dependencies(
                 original_graph,
                 retained=retained,
@@ -431,7 +449,7 @@ def project_optimal(
     preserve: set[str] | None = None,
 ) -> tuple[DependencyGraph, BaseProjectionManifest]:
     """Return a projected copy of `graph` with optimal compression applied."""
-    projected = graph.copy()
+    projected = graph._copy_for_projection()
     record = OptimalCompressionRecord()
     projected.compress_optimal(preserve=preserve, record=record)
     return projected, build_optimal_projection_manifest(graph, record)
@@ -594,7 +612,7 @@ def apply_projection(
     if not manifests:
         return ProjectionResult(
             original_graph=graph,
-            projected_graph=graph.copy(),
+            projected_graph=graph._copy_for_projection(),
             manifest=BaseProjectionManifest.empty(kind="empty"),
         )
     if len(manifests) == 1:

--- a/excel_grapher/grapher/graph.py
+++ b/excel_grapher/grapher/graph.py
@@ -132,6 +132,43 @@ class DependencyGraph:
         cloned._hooks = []
         return cloned
 
+    def _copy_for_projection(self) -> DependencyGraph:
+        """Return an isolated mutable graph clone for projection rewrites."""
+        cloned = DependencyGraph()
+        cloned._nodes = {
+            key: Node(
+                sheet=node.sheet,
+                column=node.column,
+                row=node.row,
+                formula=node.formula,
+                normalized_formula=node.normalized_formula,
+                value=node.value,
+                is_leaf=node.is_leaf,
+                is_target=node.is_target,
+                metadata=dict(node.metadata),
+            )
+            for key, node in self._nodes.items()
+        }
+        cloned._edges = {key: set(deps) for key, deps in self._edges.items()}
+        cloned._reverse_edges = {
+            key: set(dependents) for key, dependents in self._reverse_edges.items()
+        }
+        cloned._guards = dict(self._guards)
+        cloned._edge_extra = {edge: dict(extra) for edge, extra in self._edge_extra.items()}
+        cloned.leaf_classification = (
+            dict(self.leaf_classification) if self.leaf_classification is not None else None
+        )
+        cloned.sheet_order = list(self.sheet_order) if self.sheet_order is not None else None
+        cloned.sheet_bounds = dict(self.sheet_bounds) if self.sheet_bounds is not None else None
+        cloned.named_ranges = dict(self.named_ranges) if self.named_ranges is not None else None
+        cloned.named_range_ranges = (
+            dict(self.named_range_ranges) if self.named_range_ranges is not None else None
+        )
+        cloned.preparsed_formulas = (
+            dict(self.preparsed_formulas) if self.preparsed_formulas is not None else None
+        )
+        return cloned
+
     # ---- node insertion and iteration ---------------------------------------
 
     def add_node(self, node: Node) -> None:

--- a/tests/unit/exporter/test_optimal_projection.py
+++ b/tests/unit/exporter/test_optimal_projection.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import pytest
+
+from excel_grapher.core.formula_ast import parse
 from excel_grapher.exporter.projection import (
     BaseProjectionManifest,
     OptimalCompression,
+    _statement_order,
+    _statement_order_index,
+    build_forwarding_projection_manifest,
     build_optimal_projection_manifest,
     resolve_projection_manifest,
 )
-from excel_grapher.grapher.compression import OptimalCompressionRecord
+from excel_grapher.grapher.compression import (
+    IdentityTransitCompressionRecord,
+    OptimalCompressionRecord,
+)
 from excel_grapher.grapher.dependency_provenance import DependencyCause, EdgeProvenance
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.grapher.guard import CellRef, Compare, Literal
 from excel_grapher.grapher.node import Node
 
 
@@ -67,6 +77,9 @@ def test_optimal_projection_does_not_mutate_original_graph() -> None:
         graph.add_node(n)
     _direct_edge(graph, "Sheet1!B1", "Sheet1!D1")
     _direct_edge(graph, "Sheet1!A1", "Sheet1!B1")
+    graph.set_node_metadata("Sheet1!B1", {"label": "source"})
+    ast = parse("=Sheet1!D1*2")
+    graph.preparsed_formulas = {"=Sheet1!D1*2": ast}
 
     original_keys = set(graph)
     projection = OptimalCompression().project(graph)
@@ -74,6 +87,20 @@ def test_optimal_projection_does_not_mutate_original_graph() -> None:
     assert set(graph) == original_keys
     assert "Sheet1!B1" in graph
     assert "Sheet1!B1" not in projection
+    original_a = graph.get_node("Sheet1!A1")
+    original_b = graph.get_node("Sheet1!B1")
+    projected_a = projection.get_node("Sheet1!A1")
+    assert original_a is not None
+    assert original_b is not None
+    assert projected_a is not None
+    assert original_a.normalized_formula == "=Sheet1!B1+1"
+    assert original_b.normalized_formula == "=Sheet1!D1*2"
+    assert original_b.metadata["label"] == "source"
+    assert graph.get_dependencies("Sheet1!A1") == frozenset({"Sheet1!B1"})
+    assert graph.get_dependencies("Sheet1!B1") == frozenset({"Sheet1!D1"})
+    assert graph.preparsed_formulas == {"=Sheet1!D1*2": ast}
+    assert projected_a.normalized_formula == "=(Sheet1!D1*2)+1"
+    assert projection.get_dependencies("Sheet1!A1") == frozenset({"Sheet1!D1"})
 
 
 def test_optimal_projection_manifest_kind_and_forwarding() -> None:
@@ -129,7 +156,9 @@ def test_optimal_projection_resolves_chained_inline_to_final_retained() -> None:
     assert collapsed == {"Sheet1!B1", "Sheet1!C1"}
 
 
-def test_optimal_manifest_reuses_statement_order_across_groups() -> None:
+def test_optimal_manifest_reuses_statement_order_across_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     graph = DependencyGraph()
     record = OptimalCompressionRecord()
     group_count = 8
@@ -154,12 +183,73 @@ def test_optimal_manifest_reuses_statement_order_across_groups() -> None:
         calls += 1
         return original_evaluation_order(strict=strict, iterate_enabled=iterate_enabled)
 
-    object.__setattr__(graph, "evaluation_order", counted_evaluation_order)
+    monkeypatch.setattr(graph, "evaluation_order", counted_evaluation_order)
 
     manifest = build_optimal_projection_manifest(graph, record)
 
     assert len(manifest.collapsed_groups) == group_count
     assert calls == 1
+
+
+def test_forwarding_manifest_reuses_statement_order_across_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = DependencyGraph()
+    record = IdentityTransitCompressionRecord()
+    group_count = 8
+    for row in range(1, group_count + 1):
+        dependent = f"Sheet1!A{row}"
+        source = f"Sheet1!B{row}"
+        retained = f"Sheet1!C{row}"
+        graph.add_node(_make_node(retained, None, None, is_leaf=True))
+        graph.add_node(_make_node(source, f"={retained}", f"={retained}"))
+        graph.add_node(_make_node(dependent, f"={source}", f"={source}"))
+        _direct_edge(graph, source, retained)
+        _direct_edge(graph, dependent, source)
+        record.immediate_removed[source] = retained
+        record.removal_order.append(source)
+
+    calls = 0
+    original_evaluation_order = graph.evaluation_order
+
+    def counted_evaluation_order(
+        *, strict: bool = True, iterate_enabled: bool | None = None
+    ) -> list[str]:
+        nonlocal calls
+        calls += 1
+        return original_evaluation_order(strict=strict, iterate_enabled=iterate_enabled)
+
+    monkeypatch.setattr(graph, "evaluation_order", counted_evaluation_order)
+
+    manifest = build_forwarding_projection_manifest(graph, record, kind="identity_transit")
+
+    assert len(manifest.collapsed_groups) == group_count
+    assert calls == 1
+
+
+def test_statement_order_cached_matches_uncached_may_cycle_fallback() -> None:
+    graph = DependencyGraph()
+    a = _make_node("Sheet1!A1", "=Sheet1!B1+1", "=Sheet1!B1+1")
+    b = _make_node("Sheet1!B1", "=Sheet1!A1+1", "=Sheet1!A1+1")
+    c = _make_node("Sheet1!C1", None, None, is_leaf=True)
+    for n in (a, b, c):
+        graph.add_node(n)
+    provenance = EdgeProvenance(causes=frozenset({DependencyCause.direct_ref}))
+    guard = Compare(left=CellRef(key="Sheet1!C1"), op="=", right=Literal(value=True))
+    graph.add_edge("Sheet1!A1", "Sheet1!B1", guard=guard, provenance=provenance)
+    graph.add_edge("Sheet1!B1", "Sheet1!A1", guard=guard, provenance=provenance)
+
+    with pytest.warns(UserWarning, match="May-cycles detected"):
+        uncached = _statement_order(graph, ("Sheet1!B1", "Sheet1!A1"))
+    with pytest.warns(UserWarning, match="May-cycles detected"):
+        order_index = _statement_order_index(graph)
+    cached = _statement_order(
+        graph,
+        ("Sheet1!B1", "Sheet1!A1"),
+        order_index=order_index,
+    )
+
+    assert cached == uncached == ("Sheet1!A1", "Sheet1!B1")
 
 
 def test_optimal_projection_manifest_round_trips() -> None:

--- a/tests/unit/exporter/test_optimal_projection.py
+++ b/tests/unit/exporter/test_optimal_projection.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from excel_grapher.exporter.projection import (
     BaseProjectionManifest,
     OptimalCompression,
+    build_optimal_projection_manifest,
     resolve_projection_manifest,
 )
+from excel_grapher.grapher.compression import OptimalCompressionRecord
 from excel_grapher.grapher.dependency_provenance import DependencyCause, EdgeProvenance
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.grapher.node import Node
@@ -125,6 +127,39 @@ def test_optimal_projection_resolves_chained_inline_to_final_retained() -> None:
     assert isinstance(manifest, BaseProjectionManifest)
     collapsed = set(manifest.retained_to_collapsed_sources["Sheet1!A1"])
     assert collapsed == {"Sheet1!B1", "Sheet1!C1"}
+
+
+def test_optimal_manifest_reuses_statement_order_across_groups() -> None:
+    graph = DependencyGraph()
+    record = OptimalCompressionRecord()
+    group_count = 8
+    for row in range(1, group_count + 1):
+        retained = f"Sheet1!A{row}"
+        source = f"Sheet1!B{row}"
+        leaf = f"Sheet1!C{row}"
+        graph.add_node(_make_node(leaf, None, None, is_leaf=True))
+        graph.add_node(_make_node(source, f"={leaf}+1", f"={leaf}+1"))
+        graph.add_node(_make_node(retained, f"={source}+1", f"={source}+1"))
+        _direct_edge(graph, source, leaf)
+        _direct_edge(graph, retained, source)
+        record.inlined_to[source] = retained
+
+    calls = 0
+    original_evaluation_order = graph.evaluation_order
+
+    def counted_evaluation_order(
+        *, strict: bool = True, iterate_enabled: bool | None = None
+    ) -> list[str]:
+        nonlocal calls
+        calls += 1
+        return original_evaluation_order(strict=strict, iterate_enabled=iterate_enabled)
+
+    object.__setattr__(graph, "evaluation_order", counted_evaluation_order)
+
+    manifest = build_optimal_projection_manifest(graph, record)
+
+    assert len(manifest.collapsed_groups) == group_count
+    assert calls == 1
 
 
 def test_optimal_projection_manifest_round_trips() -> None:

--- a/tests/unit/grapher/test_graph_projection.py
+++ b/tests/unit/grapher/test_graph_projection.py
@@ -9,10 +9,12 @@ from typing import Any, cast
 import pytest
 import xlsxwriter
 
+from excel_grapher.core.formula_ast import FunctionCallNode, parse
 from excel_grapher.exporter.projection import (
     BaseProjectionManifest,
     CompositeProjectionManifest,
     IdentityTransitCompression,
+    OptimalCompression,
     ProjectedNodeSnapshot,
     ProjectionResult,
     apply_projection,
@@ -618,6 +620,50 @@ def test_projection_copy_preserves_graph_metadata_fields() -> None:
         projected_value = getattr(projected, field_name)
         assert projected_value == original_value
         assert projected_value is not original_value
+
+
+def test_optimal_projection_does_not_mutate_shared_preparsed_ast() -> None:
+    from excel_grapher.grapher.graph import DependencyGraph
+
+    graph = DependencyGraph()
+    c = _make_node("Sheet1!C1", None, None, is_leaf=True)
+    b = _make_node("Sheet1!B1", "=SUM(Sheet1!C1,1)", "=SUM(Sheet1!C1,1)")
+    a = _make_node("Sheet1!A1", "=Sheet1!B1+1", "=Sheet1!B1+1")
+    for n in (c, b, a):
+        graph.add_node(n)
+    dr = DependencyCause.direct_ref
+    graph.add_edge(
+        "Sheet1!B1",
+        "Sheet1!C1",
+        provenance=EdgeProvenance(causes=frozenset({dr})),
+    )
+    ref = "Sheet1!B1"
+    formula = "=Sheet1!B1+1"
+    span = ((formula.index(ref), formula.index(ref) + len(ref)),)
+    graph.add_edge(
+        "Sheet1!A1",
+        "Sheet1!B1",
+        provenance=EdgeProvenance(
+            causes=frozenset({dr}),
+            direct_sites_formula=span,
+            direct_sites_normalized=span,
+        ),
+    )
+    ast = parse("=SUM(Sheet1!C1,1)")
+    assert isinstance(ast, FunctionCallNode)
+    original_args = tuple(ast.args)
+    graph.preparsed_formulas = {"=SUM(Sheet1!C1,1)": ast}
+
+    projection = OptimalCompression().project(graph)
+
+    assert "Sheet1!B1" not in projection
+    assert graph.preparsed_formulas is not None
+    projected_cache = projection.projected_graph.preparsed_formulas
+    assert projected_cache is not None
+    assert projected_cache is not graph.preparsed_formulas
+    assert projected_cache["=SUM(Sheet1!C1,1)"] is ast
+    assert graph.preparsed_formulas["=SUM(Sheet1!C1,1)"] is ast
+    assert ast.args == list(original_args)
 
 
 def test_projection_snapshot_and_rewrite_types_are_shared_across_layers() -> None:

--- a/tests/unit/grapher/test_graph_projection.py
+++ b/tests/unit/grapher/test_graph_projection.py
@@ -552,6 +552,34 @@ def test_custom_collapse_projection_uses_public_primitives_without_forwarding() 
     assert condensed.metadata["collapsed_from"] == ["Sheet1!B1"]
 
 
+def test_projection_copy_isolates_projection_mutations() -> None:
+    from excel_grapher.grapher.graph import DependencyGraph
+
+    graph = DependencyGraph()
+    c = _make_node("Sheet1!C1", None, None, is_leaf=True)
+    b = _make_node("Sheet1!B1", "=Sheet1!C1", "=Sheet1!C1")
+    for n in (c, b):
+        graph.add_node(n)
+    graph.add_edge(
+        "Sheet1!B1",
+        "Sheet1!C1",
+        provenance=EdgeProvenance(causes=frozenset({DependencyCause.direct_ref})),
+    )
+    graph.set_node_metadata("Sheet1!B1", {"label": "source"})
+
+    projected = graph._copy_for_projection()
+    projected.set_node_formula("Sheet1!B1", "=1", "=1")
+    projected.set_node_metadata("Sheet1!B1", {"label": "projected"})
+    projected.remove_node("Sheet1!C1")
+
+    original = graph.get_node("Sheet1!B1")
+    assert original is not None
+    assert original.normalized_formula == "=Sheet1!C1"
+    assert original.metadata["label"] == "source"
+    assert graph.get_dependencies("Sheet1!B1") == frozenset({"Sheet1!C1"})
+    assert "Sheet1!C1" in graph
+
+
 def test_projection_snapshot_and_rewrite_types_are_shared_across_layers() -> None:
     from excel_grapher.grapher import compression as grapher_compression
 

--- a/tests/unit/grapher/test_graph_projection.py
+++ b/tests/unit/grapher/test_graph_projection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from pathlib import Path
 from typing import Any, cast
 
@@ -578,6 +579,45 @@ def test_projection_copy_isolates_projection_mutations() -> None:
     assert original.metadata["label"] == "source"
     assert graph.get_dependencies("Sheet1!B1") == frozenset({"Sheet1!C1"})
     assert "Sheet1!C1" in graph
+
+
+def test_projection_copy_preserves_graph_metadata_fields() -> None:
+    from excel_grapher.grapher.graph import DependencyGraph
+
+    graph = DependencyGraph()
+    graph.leaf_classification = {"Sheet1!A1": "input"}
+    graph.sheet_order = ["Sheet1", "Sheet2"]
+    graph.sheet_bounds = {"Sheet1": (1, 10)}
+    graph.named_ranges = {"Rate": ("Sheet1", "A1")}
+    graph.named_range_ranges = {"Table": ("Sheet1", "A1", "B2")}
+    graph.preparsed_formulas = cast(Any, {"Sheet1!A1": object()})
+
+    graph_structure_fields = {
+        "_nodes",
+        "_edges",
+        "_reverse_edges",
+        "_guards",
+        "_edge_extra",
+        "_hooks",
+    }
+    metadata_field_names = tuple(
+        field.name for field in fields(DependencyGraph) if field.name not in graph_structure_fields
+    )
+    assert metadata_field_names == (
+        "leaf_classification",
+        "sheet_order",
+        "sheet_bounds",
+        "named_ranges",
+        "named_range_ranges",
+        "preparsed_formulas",
+    )
+
+    projected = graph._copy_for_projection()
+    for field_name in metadata_field_names:
+        original_value = getattr(graph, field_name)
+        projected_value = getattr(projected, field_name)
+        assert projected_value == original_value
+        assert projected_value is not original_value
 
 
 def test_projection_snapshot_and_rewrite_types_are_shared_across_layers() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #351.

### Summary
- Cache graph-wide statement ordering once per projection manifest so collapsed groups no longer rerun full `evaluation_order` / cycle analysis.
- Use a projection-specific graph clone for projection rewrites instead of full `copy.deepcopy`, while preserving mutation isolation for formulas, metadata, and edges.
- Add regression coverage for one-time optimal and forwarding manifest ordering, projection-clone isolation, full optimal projection immutability, dataclass-driven metadata field preservation, may-cycle statement-order fallback parity, and safe shallow sharing of preparsed AST cache entries.

### Validation
- `uv run pytest tests/unit/exporter/test_optimal_projection.py::test_optimal_manifest_reuses_statement_order_across_groups` initially failed before the ordering cache (`8 == 1`), then passed after the fix.
- Synthetic manifest benchmark: `groups=400 nodes=1200 old_style_ordering=1.639s new_manifest=0.004s speedup=373.9x`.
- Synthetic projection copy benchmark: `nodes=12000 edges=11999 graph_copy=0.411s projection_copy=0.059s speedup=6.9x`.
- `uv run pytest tests/unit/exporter/test_optimal_projection.py`
- `uv run pytest tests/unit/exporter/test_optimal_projection.py tests/unit/grapher/test_graph_projection.py tests/unit/grapher/test_graph_optimal_compression.py`
- `uv run pytest tests/unit/grapher/test_graph_projection.py::test_optimal_projection_does_not_mutate_shared_preparsed_ast tests/unit/grapher/test_graph_projection.py::test_projection_copy_preserves_graph_metadata_fields tests/unit/grapher/test_graph_projection.py::test_projection_copy_isolates_projection_mutations`
- `uv run pytest tests/unit/grapher/test_graph_projection.py`
- `uv run pytest tests/unit/grapher/test_graph_projection.py::test_projection_copy_preserves_graph_metadata_fields tests/unit/grapher/test_graph_projection.py::test_projection_copy_isolates_projection_mutations`
- `uv run pytest tests/unit/grapher/test_graph_projection.py::test_projection_copy_isolates_projection_mutations tests/unit/exporter/test_optimal_projection.py::test_optimal_manifest_reuses_statement_order_across_groups`
- `uv run pytest tests/unit/exporter/test_optimal_projection.py tests/unit/grapher/test_graph_optimal_compression.py tests/unit/grapher/test_graph_projection.py`
- `uv run ruff check .`
- `uv run ruff check tests/unit/exporter/test_optimal_projection.py`
- `uv run ruff check tests/unit/grapher/test_graph_projection.py`
- `uv run ruff format --check .`
- `uv run ruff format --check tests/unit/exporter/test_optimal_projection.py`
- `uv run ruff format --check tests/unit/grapher/test_graph_projection.py`
- `uv run ty check`
- `uv run pytest`
- `uv run excel-grapher bindings validate examples/micro_workbooks/ffv2.xlsx --bindings examples/micro_workbooks/ff.bindings.yaml --smoke-test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43b4e7b3-a745-4da4-b798-b6a341be35f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43b4e7b3-a745-4da4-b798-b6a341be35f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

