### PR TITLE
refactor(export): move worksheet functions to core with thin wrappers

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -67,6 +67,22 @@ whose **error channel** differs, use a three-layer layout:
 Criteria helpers (e.g. `_value_matches_criteria`) live in `core/` alongside
 their implementations, not duplicated across layers.
 
+### Naming in `core/*_funcs`
+
+Core helpers use descriptive snake_case names — never `xl_*` (that prefix is
+reserved for `runtime/` and `export_runtime/` wrappers). Patterns:
+
+| Pattern | When | Examples |
+| --- | --- | --- |
+| `{verb}_cells` | Aggregates over flattened cell inputs | `sum_cells`, `average_cells`, `countif_cells` |
+| `{operation}_{detail}` | Scalar transforms on one or two values | `round_number`, `abs_number`, `left_chars` |
+| `{source}_from_{target}` or `{target}_parse` | Parsing / conversion | `value_from_text`, `numbervalue_parse` |
+| `{domain}_{property}` | Reference introspection | `row_number`, `columns_count`, `address_string` |
+| `logical_{op}` | Boolean combinators | `logical_and`, `logical_or` |
+
+Private helpers shared within a module stay `_`-prefixed (e.g.
+`_value_matches_criteria`).
+
 - **Export-owned semantics** (not just error-channel differences):
   `excel_grapher/exporter/export_runtime/*` also defines the exported error
   channel (`XlErrorException`, `xl_raise`, thunked error-consumers) and

--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -51,23 +51,36 @@ Export error-channel specifics:
   sentinel probe channel (`Range.value_at` / `Grid.at` convert raised errors
   back to sentinels for inspection without propagation).
 
-## Layered semantics: shared core vs export-owned runtime
+## Layered semantics: core, runtime, and export_runtime
 
-- **Shared semantics**: coercions, scalar operator semantics, and most
-  worksheet functions live in `excel_grapher/core/*` and
-  `excel_grapher/runtime/*`. The evaluator imports these directly.
-- **Export-owned semantics**: `excel_grapher/exporter/export_runtime/*` defines
-  the exported error channel (`XlErrorException`, `xl_raise`, thunked
-  error-consumers) and lazy-range consumers (operators, lookups, `SUMPRODUCT`,
-  `OFFSET`, `xl_range`). The operator/error/range layer is **not** a single
-  shared implementation anymore — divergence here is deliberate.
+Worksheet functions whose semantics are shared between evaluator and export, but
+whose **error channel** differs, use a three-layer layout:
+
+1. **`core/*_funcs.py`** — shared implementations (return `XlError` sentinels
+   internally where needed). Single source of truth for math, text, logic, and
+   reference helpers covered by this pattern.
+2. **`runtime/*`** — thin sentinel-returning wrappers (evaluator path). The
+   evaluator imports these directly.
+3. **`export_runtime/*`** — thin `raise_if_sentinel_*` wrappers (export path).
+   Delegates to the same `core/*_funcs` implementations.
+
+Criteria helpers (e.g. `_value_matches_criteria`) live in `core/` alongside
+their implementations, not duplicated across layers.
+
+- **Export-owned semantics** (not just error-channel differences):
+  `excel_grapher/exporter/export_runtime/*` also defines the exported error
+  channel (`XlErrorException`, `xl_raise`, thunked error-consumers) and
+  lazy-range consumers (operators, lookups, `SUMPRODUCT`, `OFFSET`, `xl_range`).
+  The operator/error/range layer is **not** a single shared implementation —
+  divergence here is deliberate.
 - **Embedding**: codegen embeds runtime code via
   `excel_grapher/exporter/embed.py::emit_runtime(...)`. Export-owned modules
-  register **last**, so their symbols override shared `core`/`runtime` symbols
-  in emitted code without changing what the evaluator imports.
+  register **last**, so their `xl_*` symbols override shared `runtime` wrappers
+  in emitted code without changing what the evaluator imports. Export wrappers
+  import shared logic from `core/*_funcs` directly.
 
 Do not introduce a *third* implementation of semantics elsewhere; put shared
-logic in `core`/`runtime` and export-specific behavior in `export_runtime`.
+logic in `core/*_funcs` and export-specific behavior in `export_runtime`.
 
 ## Tests that require Excel automation (run-if-available)
 

--- a/excel_grapher/core/expr_eval.py
+++ b/excel_grapher/core/expr_eval.py
@@ -26,7 +26,7 @@ from .formula_ast import (
     StringNode,
     UnaryOpNode,
 )
-from .functions import xl_abs, xl_exp
+from .math_funcs import abs_number, exp_number
 from .operators import (
     xl_add,
     xl_concat,
@@ -328,11 +328,11 @@ def _fn_max(args: list[CellValue]) -> CellValue:
 
 
 def _fn_abs(args: list[CellValue]) -> CellValue:
-    return xl_abs(*args)
+    return abs_number(*args)
 
 
 def _fn_exp(args: list[CellValue]) -> CellValue:
-    return xl_exp(*args)
+    return exp_number(*args)
 
 
 def _fn_if(args: list[CellValue]) -> CellValue:

--- a/excel_grapher/core/functions.py
+++ b/excel_grapher/core/functions.py
@@ -2,32 +2,7 @@
 
 from __future__ import annotations
 
-import math
-
-from .coercions import to_number
-from .types import CellValue, XlError
+from .math_funcs import abs_number as xl_abs
+from .math_funcs import exp_number as xl_exp
 
 __all__ = ["xl_abs", "xl_exp"]
-
-
-def xl_abs(*args: CellValue) -> float | XlError:
-    """Return the absolute value of a number (Excel ``ABS``)."""
-    if len(args) != 1:
-        return XlError.VALUE
-    n = to_number(args[0])
-    if isinstance(n, XlError):
-        return n
-    return float(abs(n))
-
-
-def xl_exp(*args: CellValue) -> float | XlError:
-    """Return e raised to the power of a number (Excel ``EXP``)."""
-    if len(args) != 1:
-        return XlError.VALUE
-    n = to_number(args[0])
-    if isinstance(n, XlError):
-        return n
-    try:
-        return float(math.exp(n))
-    except OverflowError:
-        return XlError.NUM

--- a/excel_grapher/core/functions.py
+++ b/excel_grapher/core/functions.py
@@ -1,8 +1,0 @@
-"""Excel function semantics shared by expr_eval, runtime, and export."""
-
-from __future__ import annotations
-
-from .math_funcs import abs_number as xl_abs
-from .math_funcs import exp_number as xl_exp
-
-__all__ = ["xl_abs", "xl_exp"]

--- a/excel_grapher/core/logic_funcs.py
+++ b/excel_grapher/core/logic_funcs.py
@@ -1,0 +1,44 @@
+"""Shared logical worksheet function implementations."""
+
+from __future__ import annotations
+
+from .coercions import get_error, to_bool
+from .types import CellValue, XlError
+
+__all__ = ["logical_and", "logical_not", "logical_or"]
+
+
+def logical_and(*args: CellValue) -> bool | XlError:
+    """Return logical AND across arguments."""
+    err = get_error(*args)
+    if err is not None:
+        return err
+    for a in args:
+        b = to_bool(a)
+        if isinstance(b, XlError):
+            return b
+        if not b:
+            return False
+    return True
+
+
+def logical_or(*args: CellValue) -> bool | XlError:
+    """Return logical OR across arguments."""
+    err = get_error(*args)
+    if err is not None:
+        return err
+    for a in args:
+        b = to_bool(a)
+        if isinstance(b, XlError):
+            return b
+        if b:
+            return True
+    return False
+
+
+def logical_not(arg: CellValue) -> bool | XlError:
+    """Return logical NOT of an argument."""
+    b = to_bool(arg)
+    if isinstance(b, XlError):
+        return b
+    return not b

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -1,0 +1,359 @@
+"""Shared math worksheet function implementations."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import TypeVar
+
+import numpy as np
+
+from .coercions import (
+    excel_casefold,
+    flatten,
+    numeric_values,
+    to_bool,
+    to_number,
+    to_string,
+)
+from .types import CellValue, XlError
+
+T = TypeVar("T", str, float)
+
+__all__ = [
+    "abs_number",
+    "average_cells",
+    "averageif_cells",
+    "countif_cells",
+    "exp_number",
+    "large_kth",
+    "max_cells",
+    "min_cells",
+    "normdist_value",
+    "npv_cells",
+    "rank_number",
+    "round_number",
+    "rounddown_number",
+    "stdev_cells",
+    "sum_cells",
+]
+
+
+def sum_cells(*args: CellValue) -> float | XlError:
+    """Return the sum of numeric cells."""
+    values = list(flatten(*args))
+    nums, err = numeric_values(values)
+    if err is not None:
+        return err
+    return float(sum(nums))
+
+
+def average_cells(*args: CellValue) -> float | XlError:
+    """Return the average of numeric cells."""
+    values = list(flatten(*args))
+    nums, err = numeric_values(values)
+    if err is not None:
+        return err
+    if len(nums) == 0:
+        return XlError.DIV
+    return float(sum(nums) / len(nums))
+
+
+def min_cells(*args: CellValue) -> float | XlError:
+    """Return the minimum of numeric cells."""
+    values = list(flatten(*args))
+    nums, err = numeric_values(values)
+    if err is not None:
+        return err
+    if len(nums) == 0:
+        return 0.0
+    return float(min(nums))
+
+
+def max_cells(*args: CellValue) -> float | XlError:
+    """Return the maximum of numeric cells."""
+    values = list(flatten(*args))
+    nums, err = numeric_values(values)
+    if err is not None:
+        return err
+    if len(nums) == 0:
+        return 0.0
+    return float(max(nums))
+
+
+def round_number(number: CellValue, num_digits: CellValue) -> float | XlError:
+    """Round a number to the given number of digits."""
+    n = to_number(number)
+    if isinstance(n, XlError):
+        return n
+    d = to_number(num_digits)
+    if isinstance(d, XlError):
+        return d
+    return float(round(n, int(d)))
+
+
+def rounddown_number(number: CellValue, num_digits: CellValue) -> float | XlError:
+    """Round a number down to the given number of digits."""
+    n = to_number(number)
+    if isinstance(n, XlError):
+        return n
+    d = to_number(num_digits)
+    if isinstance(d, XlError):
+        return d
+    digits = int(d)
+    factor = 10**digits
+    if n >= 0:
+        return float(math.floor(n * factor) / factor)
+    return float(math.ceil(n * factor) / factor)
+
+
+def npv_cells(rate: CellValue, *values: CellValue) -> float | XlError:
+    """Return net present value for a rate and cash flows."""
+    r = to_number(rate)
+    if isinstance(r, XlError):
+        return r
+    all_values = list(flatten(*values))
+    nums, err = numeric_values(all_values)
+    if err is not None:
+        return err
+    if len(nums) == 0:
+        return XlError.VALUE
+    result = 0.0
+    for i, val in enumerate(nums):
+        result += val / ((1 + r) ** (i + 1))
+    return result
+
+
+def stdev_cells(*args: CellValue) -> float | XlError:
+    """Return sample standard deviation of numeric cells."""
+    values = list(flatten(*args))
+    nums, err = numeric_values(values)
+    if err is not None:
+        return err
+    if len(nums) < 2:
+        return XlError.DIV
+    mean = sum(nums) / len(nums)
+    variance = sum((x - mean) ** 2 for x in nums) / (len(nums) - 1)
+    return float(variance**0.5)
+
+
+def _iter_numeric_cells(values: list[CellValue]) -> tuple[list[float], XlError | None]:
+    nums: list[float] = []
+    for v in values:
+        if isinstance(v, XlError):
+            return ([], v)
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            nums.append(float(v))
+            continue
+        if isinstance(v, (np.integer, np.floating)):
+            nums.append(float(v))
+            continue
+    return (nums, None)
+
+
+def _wildcard_to_regex(pattern: str) -> re.Pattern[str]:
+    out: list[str] = ["^"]
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "~" and i + 1 < len(pattern):
+            i += 1
+            out.append(re.escape(pattern[i]))
+        elif ch == "*":
+            out.append(".*")
+        elif ch == "?":
+            out.append(".")
+        else:
+            out.append(re.escape(ch))
+        i += 1
+    out.append("$")
+    return re.compile("".join(out), re.IGNORECASE)
+
+
+def _parse_countif_criteria(criteria: str) -> tuple[str | None, str]:
+    s = criteria.strip()
+    for op in (">=", "<=", "<>", ">", "<", "="):
+        if s.startswith(op):
+            return (op, s[len(op) :].strip())
+    return (None, s)
+
+
+def _criteria_compare(op: str, left: T, right: T) -> bool:
+    """Compare two values of the same type."""
+    if op == "=":
+        return left == right
+    if op == "<>":
+        return left != right
+    if op == ">":
+        return left > right  # type: ignore[operator]
+    if op == "<":
+        return left < right  # type: ignore[operator]
+    if op == ">=":
+        return left >= right  # type: ignore[operator]
+    if op == "<=":
+        return left <= right  # type: ignore[operator]
+    return False
+
+
+def _value_matches_criteria(cell_value: CellValue, criteria: CellValue) -> bool:
+    if isinstance(criteria, XlError):
+        return False
+    if not isinstance(criteria, str):
+        target = criteria
+        if isinstance(cell_value, XlError):
+            return False
+        if target is None:
+            return cell_value is None
+        if isinstance(target, bool):
+            b = to_bool(cell_value)
+            return (not isinstance(b, XlError)) and b == target
+        if isinstance(target, (int, float)) and not isinstance(target, bool):
+            vn = to_number(cell_value)
+            return (not isinstance(vn, XlError)) and vn == float(target)
+        return excel_casefold(to_string(cell_value)) == excel_casefold(to_string(target))
+
+    op, rhs = _parse_countif_criteria(criteria)
+    if isinstance(cell_value, XlError):
+        return False
+
+    if op is None:
+        if any(ch in rhs for ch in ("*", "?", "~")):
+            rx = _wildcard_to_regex(rhs)
+            return rx.match(to_string(cell_value)) is not None
+        return excel_casefold(to_string(cell_value)) == excel_casefold(rhs)
+
+    try:
+        rhs_num = float(rhs) if rhs != "" else 0.0
+    except ValueError:
+        rhs_num = None
+
+    if rhs_num is not None:
+        vn = to_number(cell_value)
+        if isinstance(vn, XlError):
+            return False
+        return _criteria_compare(op, vn, rhs_num)
+
+    return _criteria_compare(op, excel_casefold(to_string(cell_value)), excel_casefold(rhs))
+
+
+def countif_cells(range_values: CellValue, criteria: CellValue) -> int | XlError:
+    """Count cells matching criteria."""
+    if isinstance(criteria, XlError):
+        return criteria
+    values = list(flatten(range_values))
+    return sum(1 for v in values if _value_matches_criteria(v, criteria))
+
+
+def averageif_cells(
+    range_values: CellValue,
+    criteria: CellValue,
+    average_range: CellValue | None = None,
+) -> float | XlError:
+    """Return the average of cells matching criteria."""
+    if isinstance(criteria, XlError):
+        return criteria
+    crit_vals = list(flatten(range_values))
+    avg_vals = list(flatten(average_range if average_range is not None else range_values))
+    if len(crit_vals) != len(avg_vals):
+        return XlError.VALUE
+    matched: list[float] = []
+    for crit_val, avg_val in zip(crit_vals, avg_vals, strict=True):
+        if not _value_matches_criteria(crit_val, criteria):
+            continue
+        n = to_number(avg_val)
+        if isinstance(n, XlError):
+            return n
+        matched.append(float(n))
+    if not matched:
+        return XlError.DIV
+    return sum(matched) / len(matched)
+
+
+def large_kth(array: CellValue, k: CellValue) -> float | XlError:
+    """Return the k-th largest numeric value."""
+    kk = to_number(k)
+    if isinstance(kk, XlError):
+        return kk
+    kth = int(kk)
+    if kth < 1:
+        return XlError.NUM
+    values = list(flatten(array))
+    nums, err = _iter_numeric_cells(values)
+    if err is not None:
+        return err
+    if kth > len(nums):
+        return XlError.NUM
+    nums.sort(reverse=True)
+    return float(nums[kth - 1])
+
+
+def rank_number(number: CellValue, ref: CellValue, order: CellValue = 0) -> int | XlError:
+    """Return the rank of a number within a reference range."""
+    nn = to_number(number)
+    if isinstance(nn, XlError):
+        return nn
+    oo = to_number(order)
+    if isinstance(oo, XlError):
+        return oo
+    ascending = int(oo) != 0
+    values = list(flatten(ref))
+    nums, err = _iter_numeric_cells(values)
+    if err is not None:
+        return err
+    if ascending:
+        return 1 + sum(1 for v in nums if v < nn)
+    return 1 + sum(1 for v in nums if v > nn)
+
+
+def normdist_value(
+    x: CellValue,
+    mean: CellValue,
+    standard_dev: CellValue,
+    cumulative: CellValue,
+) -> float | XlError:
+    """Return the normal distribution value."""
+    xx = to_number(x)
+    if isinstance(xx, XlError):
+        return xx
+    mm = to_number(mean)
+    if isinstance(mm, XlError):
+        return mm
+    sd = to_number(standard_dev)
+    if isinstance(sd, XlError):
+        return sd
+    if sd <= 0:
+        return XlError.NUM
+    cc = to_bool(cumulative)
+    if isinstance(cc, XlError):
+        return cc
+    z = (xx - mm) / sd
+    if cc:
+        return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+    return (1.0 / (sd * math.sqrt(2.0 * math.pi))) * math.exp(-0.5 * z * z)
+
+
+def abs_number(*args: CellValue) -> float | XlError:
+    """Return the absolute value of a number (Excel ``ABS``)."""
+    if len(args) != 1:
+        return XlError.VALUE
+    n = to_number(args[0])
+    if isinstance(n, XlError):
+        return n
+    return float(abs(n))
+
+
+def exp_number(*args: CellValue) -> float | XlError:
+    """Return e raised to the power of a number (Excel ``EXP``)."""
+    if len(args) != 1:
+        return XlError.VALUE
+    n = to_number(args[0])
+    if isinstance(n, XlError):
+        return n
+    try:
+        return float(math.exp(n))
+    except OverflowError:
+        return XlError.NUM

--- a/excel_grapher/core/reference_funcs.py
+++ b/excel_grapher/core/reference_funcs.py
@@ -1,0 +1,88 @@
+"""Shared reference worksheet function implementations."""
+
+from __future__ import annotations
+
+import re
+
+import fastpyxl.utils.cell
+
+from .coercions import to_bool, to_number, to_string
+from .types import CellValue, ExcelRange, XlError
+
+__all__ = ["address_string", "column_number", "columns_count", "row_number"]
+
+
+def _quote_sheet_name(sheet: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_]+", sheet):
+        return sheet
+    escaped = sheet.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def address_string(
+    row_num: CellValue,
+    column_num: CellValue,
+    abs_num: CellValue = 1,
+    a1: CellValue = True,
+    sheet_text: CellValue = None,
+) -> str | XlError:
+    """Build an A1-style address string."""
+    rn = to_number(row_num)
+    if isinstance(rn, XlError):
+        return rn
+    cn = to_number(column_num)
+    if isinstance(cn, XlError):
+        return cn
+    an = to_number(abs_num)
+    if isinstance(an, XlError):
+        return an
+    a1_mode = to_bool(a1)
+    if isinstance(a1_mode, XlError):
+        return a1_mode
+    if not a1_mode:
+        return XlError.VALUE
+
+    r = int(rn)
+    c = int(cn)
+    if r < 1 or c < 1:
+        return XlError.VALUE
+
+    abs_flag = int(an)
+    if abs_flag not in (1, 2, 3, 4):
+        return XlError.VALUE
+
+    col_letters = fastpyxl.utils.cell.get_column_letter(c)
+
+    col_abs = abs_flag in (1, 2)
+    row_abs = abs_flag in (1, 3)
+    col_prefix = "$" if col_abs else ""
+    row_prefix = "$" if row_abs else ""
+
+    addr = f"{col_prefix}{col_letters}{row_prefix}{r}"
+
+    if sheet_text is None or sheet_text == "":
+        return addr
+
+    sheet = to_string(sheet_text)
+    return f"{_quote_sheet_name(sheet)}!{addr}"
+
+
+def row_number(ref: CellValue) -> int | XlError:
+    """Return the row number of a reference."""
+    if isinstance(ref, ExcelRange):
+        return ref.start_row
+    return XlError.VALUE
+
+
+def column_number(ref: CellValue) -> int | XlError:
+    """Return the column number of a reference."""
+    if isinstance(ref, ExcelRange):
+        return ref.start_col
+    return XlError.VALUE
+
+
+def columns_count(ref: CellValue) -> int | XlError:
+    """Return the column count of a reference."""
+    if isinstance(ref, ExcelRange):
+        return ref.end_col - ref.start_col + 1
+    return XlError.VALUE

--- a/excel_grapher/core/text_funcs.py
+++ b/excel_grapher/core/text_funcs.py
@@ -1,0 +1,182 @@
+"""Shared text worksheet function implementations."""
+
+from __future__ import annotations
+
+from .coercions import to_number, to_string
+from .types import CellValue, XlError
+
+__all__ = [
+    "concatenate_cells",
+    "left_chars",
+    "lower_text",
+    "mid_chars",
+    "numbervalue_parse",
+    "right_chars",
+    "text_format",
+    "value_from_text",
+]
+
+
+def left_chars(text: CellValue, num_chars: CellValue = 1) -> str | XlError:
+    """Return the leftmost characters of text."""
+    s = to_string(text)
+    n = to_number(num_chars)
+    if isinstance(n, XlError):
+        return n
+    chars = int(n)
+    if chars < 0:
+        return XlError.VALUE
+    return s[:chars]
+
+
+def right_chars(text: CellValue, num_chars: CellValue = 1) -> str | XlError:
+    """Return the rightmost characters of text."""
+    s = to_string(text)
+    n = to_number(num_chars)
+    if isinstance(n, XlError):
+        return n
+    chars = int(n)
+    if chars < 0:
+        return XlError.VALUE
+    if chars == 0:
+        return ""
+    return s[-chars:]
+
+
+def mid_chars(text: CellValue, start_num: CellValue, num_chars: CellValue) -> str | XlError:
+    """Return characters from the middle of text."""
+    s = to_string(text)
+    start = to_number(start_num)
+    if isinstance(start, XlError):
+        return start
+    num = to_number(num_chars)
+    if isinstance(num, XlError):
+        return num
+    start_idx = int(start) - 1
+    chars = int(num)
+    if start_idx < 0 or chars < 0:
+        return XlError.VALUE
+    return s[start_idx : start_idx + chars]
+
+
+def concatenate_cells(*args: CellValue) -> str | XlError:
+    """Concatenate text values."""
+    parts: list[str] = []
+    for a in args:
+        if isinstance(a, XlError):
+            return a
+        parts.append(to_string(a))
+    return "".join(parts)
+
+
+def text_format(value: CellValue, format_text: CellValue) -> str | XlError:
+    """Format a value as text using a format string."""
+    fmt = to_string(format_text)
+    n = to_number(value)
+    if isinstance(n, XlError):
+        return to_string(value)
+
+    if fmt == "0":
+        return str(int(round(n)))
+    if fmt == "0.0":
+        return f"{n:.1f}"
+    if fmt == "0.00":
+        return f"{n:.2f}"
+    if fmt == "0.000":
+        return f"{n:.3f}"
+    if fmt == "#,##0":
+        return f"{int(round(n)):,}"
+    if fmt == "#,##0.00":
+        return f"{n:,.2f}"
+    if fmt == "0%":
+        return f"{int(round(n * 100))}%"
+    if fmt == "0.0%":
+        return f"{n * 100:.1f}%"
+    if fmt == "0.00%":
+        return f"{n * 100:.2f}%"
+
+    if n == int(n):
+        return str(int(n))
+    return str(n)
+
+
+def numbervalue_parse(
+    text: CellValue,
+    decimal_separator: CellValue = ".",
+    group_separator: CellValue = ",",
+) -> float | XlError:
+    """Convert text to a number with explicit decimal and group separators."""
+    if isinstance(text, XlError):
+        return text
+    if isinstance(decimal_separator, XlError):
+        return decimal_separator
+    if isinstance(group_separator, XlError):
+        return group_separator
+
+    if not isinstance(text, str):
+        return to_number(text)
+
+    dec_sep = to_string(decimal_separator)
+    grp_sep = to_string(group_separator)
+    if dec_sep == "" or dec_sep == grp_sep:
+        return XlError.VALUE
+
+    s = text.replace("\u00a0", " ").strip()
+    if s == "":
+        return 0.0
+    currency_symbols = "$€£¥"
+    while s and (s[0] in currency_symbols or s[-1] in currency_symbols):
+        s = s.lstrip(currency_symbols).rstrip(currency_symbols).strip()
+        if s == "":
+            return XlError.VALUE
+    negative = False
+    if s.startswith("(") and s.endswith(")"):
+        negative = True
+        s = s[1:-1].strip()
+        if s == "":
+            return XlError.VALUE
+    percent = False
+    if s.endswith("%"):
+        percent = True
+        s = s[:-1].strip()
+        if s == "":
+            return XlError.VALUE
+    sign = 1.0
+    if s.startswith(("+", "-")):
+        if s[0] == "-":
+            sign = -1.0
+        s = s[1:].strip()
+        if s == "":
+            return XlError.VALUE
+    while s and (s[0] in currency_symbols or s[-1] in currency_symbols):
+        s = s.lstrip(currency_symbols).rstrip(currency_symbols).strip()
+        if s == "":
+            return XlError.VALUE
+    if grp_sep:
+        s = s.replace(grp_sep, "")
+    if dec_sep != ".":
+        s = s.replace(dec_sep, ".")
+    try:
+        value = float(s)
+    except ValueError:
+        return XlError.VALUE
+    if percent:
+        value /= 100.0
+    if negative:
+        value = -abs(value)
+    return value * sign
+
+
+def lower_text(text: CellValue) -> str | XlError:
+    """Return lowercase text."""
+    if isinstance(text, XlError):
+        return text
+    return to_string(text).lower()
+
+
+def value_from_text(text: CellValue) -> float | XlError:
+    """Convert locale-formatted text to a number (Excel VALUE)."""
+    parsed = numbervalue_parse(text)
+    if parsed is XlError.VALUE and isinstance(text, str):
+        return to_number(text)
+    return parsed

--- a/excel_grapher/exporter/embed.py
+++ b/excel_grapher/exporter/embed.py
@@ -31,6 +31,10 @@ def _core_modules(*, include_operators_fastpath: bool) -> list[tuple[str, Path]]
         ("core.sumproduct", _CORE_DIR / "sumproduct.py"),
         ("core.addressing", _CORE_DIR / "addressing.py"),
         ("core.functions", _CORE_DIR / "functions.py"),
+        ("core.logic_funcs", _CORE_DIR / "logic_funcs.py"),
+        ("core.math_funcs", _CORE_DIR / "math_funcs.py"),
+        ("core.text_funcs", _CORE_DIR / "text_funcs.py"),
+        ("core.reference_funcs", _CORE_DIR / "reference_funcs.py"),
     ]
 
 
@@ -396,9 +400,8 @@ def _register_runtime_symbol_maps(
     shared ``core``/``runtime`` symbols in emitted code while the evaluator
     keeps importing the shared versions directly.
 
-    When a symbol is overridden, the prior implementation is preserved under
-    ``_sentinel_{name}`` so export wrappers can delegate to sentinel-returning
-    shared logic and still expose a raise-based public API (#326).
+    Export-runtime wrappers override shared ``core``/``runtime`` symbols in emitted
+    code while delegating to ``core/*_funcs`` implementations for shared logic.
     """
     symbol_to_node: dict[str, ast.AST] = {}
     symbol_to_module: dict[str, str] = {}
@@ -413,11 +416,6 @@ def _register_runtime_symbol_maps(
                     continue
                 if mod == "cache_context" and name == _FULL_EVAL_CONTEXT_SYMBOL:
                     continue
-            if name in symbol_to_node:
-                # Keep the displaced implementation for wrapper delegation.
-                sentinel_name = f"_sentinel_{name}"
-                symbol_to_node[sentinel_name] = symbol_to_node[name]
-                symbol_to_module[sentinel_name] = symbol_to_module[name]
             symbol_to_node[name] = node
             symbol_to_module[name] = mod
 
@@ -425,23 +423,8 @@ def _register_runtime_symbol_maps(
 
 
 def _format_emitted_symbol_source(symbol: str, module_src: str, node: ast.AST) -> str:
-    """Extract runtime source for *symbol*, renaming shadowed sentinel implementations.
-
-    Invariants (see ``_register_runtime_symbol_maps``):
-
-    * Shadowed symbols use the ``_sentinel_{original}`` prefix assigned when an
-      export-runtime module overrides a shared definition.
-    * Shared implementations are plain top-level ``def {original}(...`` defs
-      without decorators. Renaming replaces only the first ``def {original}(``
-      occurrence so bodies extracted from shared modules keep calling the public
-      wrapper name where sibling delegation is intentional (for example
-      ``xl_value`` calling ``_sentinel_xl_numbervalue`` directly in source).
-    """
-    segment = _extract_source_segment(module_src, node)
-    if symbol.startswith("_sentinel_"):
-        original = symbol.removeprefix("_sentinel_")
-        segment = segment.replace(f"def {original}(", f"def {symbol}(", 1)
-    return segment
+    """Extract runtime source for *symbol*."""
+    return _extract_source_segment(module_src, node)
 
 
 def emit_runtime(

--- a/excel_grapher/exporter/embed.py
+++ b/excel_grapher/exporter/embed.py
@@ -30,7 +30,6 @@ def _core_modules(*, include_operators_fastpath: bool) -> list[tuple[str, Path]]
         ("core.operators", _CORE_DIR / "operators.py"),
         ("core.sumproduct", _CORE_DIR / "sumproduct.py"),
         ("core.addressing", _CORE_DIR / "addressing.py"),
-        ("core.functions", _CORE_DIR / "functions.py"),
         ("core.logic_funcs", _CORE_DIR / "logic_funcs.py"),
         ("core.math_funcs", _CORE_DIR / "math_funcs.py"),
         ("core.text_funcs", _CORE_DIR / "text_funcs.py"),

--- a/excel_grapher/exporter/export_runtime/logic.py
+++ b/excel_grapher/exporter/export_runtime/logic.py
@@ -1,12 +1,9 @@
-"""Raise-only boundary wrappers for logic runtime helpers.
-
-``_sentinel_xl_*`` names are bound at embed time; ``# noqa: F821`` marks those
-intentional forward references in wrapper source.
-"""
+"""Raise-only boundary wrappers for logic worksheet functions."""
 
 from __future__ import annotations
 
 from excel_grapher.core import CellValue
+from excel_grapher.core.logic_funcs import logical_and, logical_not, logical_or
 
 from .errors import raise_if_sentinel_bool
 
@@ -15,14 +12,14 @@ __all__ = ["xl_and", "xl_not", "xl_or"]
 
 def xl_and(*args: CellValue) -> bool:
     """Return logical AND, raising on Excel errors."""
-    return raise_if_sentinel_bool(_sentinel_xl_and(*args))  # noqa: F821
+    return raise_if_sentinel_bool(logical_and(*args))
 
 
 def xl_or(*args: CellValue) -> bool:
     """Return logical OR, raising on Excel errors."""
-    return raise_if_sentinel_bool(_sentinel_xl_or(*args))  # noqa: F821
+    return raise_if_sentinel_bool(logical_or(*args))
 
 
 def xl_not(arg: CellValue) -> bool:
     """Return logical NOT, raising on Excel errors."""
-    return raise_if_sentinel_bool(_sentinel_xl_not(arg))  # noqa: F821
+    return raise_if_sentinel_bool(logical_not(arg))

--- a/excel_grapher/exporter/export_runtime/math.py
+++ b/excel_grapher/exporter/export_runtime/math.py
@@ -1,12 +1,25 @@
-"""Raise-only boundary wrappers for math runtime helpers.
-
-``_sentinel_xl_*`` names are bound at embed time; ``# noqa: F821`` marks those
-intentional forward references in wrapper source.
-"""
+"""Raise-only boundary wrappers for math worksheet functions."""
 
 from __future__ import annotations
 
 from excel_grapher.core import CellValue
+from excel_grapher.core.math_funcs import (
+    abs_number,
+    average_cells,
+    averageif_cells,
+    countif_cells,
+    exp_number,
+    large_kth,
+    max_cells,
+    min_cells,
+    normdist_value,
+    npv_cells,
+    rank_number,
+    round_number,
+    rounddown_number,
+    stdev_cells,
+    sum_cells,
+)
 
 from .errors import raise_if_sentinel_float, raise_if_sentinel_int
 
@@ -31,47 +44,47 @@ __all__ = [
 
 def xl_sum(*args: CellValue) -> float:
     """Return the sum of numeric cells, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_sum(*args))  # noqa: F821
+    return raise_if_sentinel_float(sum_cells(*args))
 
 
 def xl_average(*args: CellValue) -> float:
     """Return the average of numeric cells, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_average(*args))  # noqa: F821
+    return raise_if_sentinel_float(average_cells(*args))
 
 
 def xl_min(*args: CellValue) -> float:
     """Return the minimum of numeric cells, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_min(*args))  # noqa: F821
+    return raise_if_sentinel_float(min_cells(*args))
 
 
 def xl_max(*args: CellValue) -> float:
     """Return the maximum of numeric cells, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_max(*args))  # noqa: F821
+    return raise_if_sentinel_float(max_cells(*args))
 
 
 def xl_round(number: CellValue, num_digits: CellValue) -> float:
     """Round a number, raising on Excel coercion errors."""
-    return raise_if_sentinel_float(_sentinel_xl_round(number, num_digits))  # noqa: F821
+    return raise_if_sentinel_float(round_number(number, num_digits))
 
 
 def xl_rounddown(number: CellValue, num_digits: CellValue) -> float:
     """Round a number down, raising on Excel coercion errors."""
-    return raise_if_sentinel_float(_sentinel_xl_rounddown(number, num_digits))  # noqa: F821
+    return raise_if_sentinel_float(rounddown_number(number, num_digits))
 
 
 def xl_npv(rate: CellValue, *values: CellValue) -> float:
     """Return net present value, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_npv(rate, *values))  # noqa: F821
+    return raise_if_sentinel_float(npv_cells(rate, *values))
 
 
 def xl_stdev(*args: CellValue) -> float:
     """Return sample standard deviation, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_stdev(*args))  # noqa: F821
+    return raise_if_sentinel_float(stdev_cells(*args))
 
 
 def xl_countif(range_values: CellValue, criteria: CellValue) -> int:
     """Count cells matching criteria, raising on Excel errors."""
-    return raise_if_sentinel_int(_sentinel_xl_countif(range_values, criteria))  # noqa: F821
+    return raise_if_sentinel_int(countif_cells(range_values, criteria))
 
 
 def xl_averageif(
@@ -80,19 +93,17 @@ def xl_averageif(
     average_range: CellValue | None = None,
 ) -> float:
     """Return the average of cells matching criteria, raising on Excel errors."""
-    return raise_if_sentinel_float(
-        _sentinel_xl_averageif(range_values, criteria, average_range)  # noqa: F821
-    )
+    return raise_if_sentinel_float(averageif_cells(range_values, criteria, average_range))
 
 
 def xl_large(array: CellValue, k: CellValue) -> float:
     """Return the k-th largest value, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_large(array, k))  # noqa: F821
+    return raise_if_sentinel_float(large_kth(array, k))
 
 
 def xl_rank(number: CellValue, ref: CellValue, order: CellValue = 0) -> int:
     """Return the rank of a number in a list, raising on Excel errors."""
-    return raise_if_sentinel_int(_sentinel_xl_rank(number, ref, order))  # noqa: F821
+    return raise_if_sentinel_int(rank_number(number, ref, order))
 
 
 def xl_normdist(
@@ -102,16 +113,14 @@ def xl_normdist(
     cumulative: CellValue,
 ) -> float:
     """Return the normal distribution value, raising on Excel errors."""
-    return raise_if_sentinel_float(
-        _sentinel_xl_normdist(x, mean, standard_dev, cumulative)  # noqa: F821
-    )
+    return raise_if_sentinel_float(normdist_value(x, mean, standard_dev, cumulative))
 
 
 def xl_abs(*args: CellValue) -> float:
     """Return the absolute value of a number, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_abs(*args))  # noqa: F821
+    return raise_if_sentinel_float(abs_number(*args))
 
 
 def xl_exp(*args: CellValue) -> float:
     """Return e raised to a power, raising on Excel errors."""
-    return raise_if_sentinel_float(_sentinel_xl_exp(*args))  # noqa: F821
+    return raise_if_sentinel_float(exp_number(*args))

--- a/excel_grapher/exporter/export_runtime/reference.py
+++ b/excel_grapher/exporter/export_runtime/reference.py
@@ -1,12 +1,14 @@
-"""Raise-only boundary wrappers for reference runtime helpers.
-
-``_sentinel_xl_*`` names are bound at embed time; ``# noqa: F821`` marks those
-intentional forward references in wrapper source.
-"""
+"""Raise-only boundary wrappers for reference worksheet functions."""
 
 from __future__ import annotations
 
 from excel_grapher.core import CellValue
+from excel_grapher.core.reference_funcs import (
+    address_string,
+    column_number,
+    columns_count,
+    row_number,
+)
 
 from .errors import raise_if_sentinel_int, raise_if_sentinel_str
 
@@ -21,21 +23,19 @@ def xl_address(
     sheet_text: CellValue = None,
 ) -> str:
     """Build an A1-style address string, raising on Excel errors."""
-    return raise_if_sentinel_str(
-        _sentinel_xl_address(row_num, column_num, abs_num, a1, sheet_text)  # noqa: F821
-    )
+    return raise_if_sentinel_str(address_string(row_num, column_num, abs_num, a1, sheet_text))
 
 
 def xl_row(ref: CellValue) -> int:
     """Return the row number of a reference, raising on Excel errors."""
-    return raise_if_sentinel_int(_sentinel_xl_row(ref))  # noqa: F821
+    return raise_if_sentinel_int(row_number(ref))
 
 
 def xl_column(ref: CellValue) -> int:
     """Return the column number of a reference, raising on Excel errors."""
-    return raise_if_sentinel_int(_sentinel_xl_column(ref))  # noqa: F821
+    return raise_if_sentinel_int(column_number(ref))
 
 
 def xl_columns(ref: CellValue) -> int:
     """Return the column count of a reference, raising on Excel errors."""
-    return raise_if_sentinel_int(_sentinel_xl_columns(ref))  # noqa: F821
+    return raise_if_sentinel_int(columns_count(ref))

--- a/excel_grapher/exporter/export_runtime/text.py
+++ b/excel_grapher/exporter/export_runtime/text.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from excel_grapher.core import CellValue, XlError, to_number
+from excel_grapher.core import CellValue
 from excel_grapher.core.text_funcs import (
     concatenate_cells,
     left_chars,
@@ -11,6 +11,7 @@ from excel_grapher.core.text_funcs import (
     numbervalue_parse,
     right_chars,
     text_format,
+    value_from_text,
 )
 
 from .errors import raise_if_sentinel_float, raise_if_sentinel_str
@@ -68,7 +69,4 @@ def xl_lower(text: CellValue) -> str:
 
 def xl_value(text: CellValue) -> float:
     """Convert text to a number, preserving Excel ``VALUE`` fallback semantics."""
-    parsed = numbervalue_parse(text)
-    if parsed is XlError.VALUE and isinstance(text, str):
-        return raise_if_sentinel_float(to_number(text))
-    return raise_if_sentinel_float(parsed)
+    return raise_if_sentinel_float(value_from_text(text))

--- a/excel_grapher/exporter/export_runtime/text.py
+++ b/excel_grapher/exporter/export_runtime/text.py
@@ -1,12 +1,17 @@
-"""Raise-only boundary wrappers for text runtime helpers.
-
-``_sentinel_xl_*`` names are bound at embed time; ``# noqa: F821`` marks those
-intentional forward references in wrapper source.
-"""
+"""Raise-only boundary wrappers for text worksheet functions."""
 
 from __future__ import annotations
 
 from excel_grapher.core import CellValue, XlError, to_number
+from excel_grapher.core.text_funcs import (
+    concatenate_cells,
+    left_chars,
+    lower_text,
+    mid_chars,
+    numbervalue_parse,
+    right_chars,
+    text_format,
+)
 
 from .errors import raise_if_sentinel_float, raise_if_sentinel_str
 
@@ -24,27 +29,27 @@ __all__ = [
 
 def xl_left(text: CellValue, num_chars: CellValue = 1) -> str:
     """Return the leftmost characters of text, raising on Excel errors."""
-    return raise_if_sentinel_str(_sentinel_xl_left(text, num_chars))  # noqa: F821
+    return raise_if_sentinel_str(left_chars(text, num_chars))
 
 
 def xl_right(text: CellValue, num_chars: CellValue = 1) -> str:
     """Return the rightmost characters of text, raising on Excel errors."""
-    return raise_if_sentinel_str(_sentinel_xl_right(text, num_chars))  # noqa: F821
+    return raise_if_sentinel_str(right_chars(text, num_chars))
 
 
 def xl_mid(text: CellValue, start_num: CellValue, num_chars: CellValue) -> str:
     """Return characters from the middle of text, raising on Excel errors."""
-    return raise_if_sentinel_str(_sentinel_xl_mid(text, start_num, num_chars))  # noqa: F821
+    return raise_if_sentinel_str(mid_chars(text, start_num, num_chars))
 
 
 def xl_concatenate(*args: CellValue) -> str:
     """Concatenate text values, raising on Excel errors."""
-    return raise_if_sentinel_str(_sentinel_xl_concatenate(*args))  # noqa: F821
+    return raise_if_sentinel_str(concatenate_cells(*args))
 
 
 def xl_text(value: CellValue, format_text: CellValue) -> str:
     """Format a value as text, raising on Excel errors."""
-    return raise_if_sentinel_str(_sentinel_xl_text(value, format_text))  # noqa: F821
+    return raise_if_sentinel_str(text_format(value, format_text))
 
 
 def xl_numbervalue(
@@ -53,19 +58,17 @@ def xl_numbervalue(
     group_separator: CellValue = ",",
 ) -> float:
     """Convert text to a number, raising on Excel errors."""
-    return raise_if_sentinel_float(
-        _sentinel_xl_numbervalue(text, decimal_separator, group_separator)  # noqa: F821
-    )
+    return raise_if_sentinel_float(numbervalue_parse(text, decimal_separator, group_separator))
 
 
 def xl_lower(text: CellValue) -> str:
     """Return lowercase text, raising on Excel errors."""
-    return raise_if_sentinel_str(_sentinel_xl_lower(text))  # noqa: F821
+    return raise_if_sentinel_str(lower_text(text))
 
 
 def xl_value(text: CellValue) -> float:
     """Convert text to a number, preserving Excel ``VALUE`` fallback semantics."""
-    parsed = _sentinel_xl_numbervalue(text)  # noqa: F821
+    parsed = numbervalue_parse(text)
     if parsed is XlError.VALUE and isinstance(text, str):
         return raise_if_sentinel_float(to_number(text))
     return raise_if_sentinel_float(parsed)

--- a/excel_grapher/runtime/logic.py
+++ b/excel_grapher/runtime/logic.py
@@ -1,41 +1,21 @@
 from __future__ import annotations
 
-from excel_grapher.core import CellValue, XlError, get_error, to_bool, to_number
+from excel_grapher.core import CellValue, XlError, to_number
+from excel_grapher.core.logic_funcs import logical_and, logical_not, logical_or
 
 __all__ = ["xl_and", "xl_choose", "xl_ifna", "xl_not", "xl_or"]
 
 
 def xl_and(*args: CellValue) -> bool | XlError:
-    err = get_error(*args)
-    if err is not None:
-        return err
-    for a in args:
-        b = to_bool(a)
-        if isinstance(b, XlError):
-            return b
-        if not b:
-            return False
-    return True
+    return logical_and(*args)
 
 
 def xl_or(*args: CellValue) -> bool | XlError:
-    err = get_error(*args)
-    if err is not None:
-        return err
-    for a in args:
-        b = to_bool(a)
-        if isinstance(b, XlError):
-            return b
-        if b:
-            return True
-    return False
+    return logical_or(*args)
 
 
 def xl_not(arg: CellValue) -> bool | XlError:
-    b = to_bool(arg)
-    if isinstance(b, XlError):
-        return b
-    return not b
+    return logical_not(arg)
 
 
 def xl_choose(index_num: CellValue, *values: CellValue) -> CellValue:

--- a/excel_grapher/runtime/math.py
+++ b/excel_grapher/runtime/math.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
-import math
-import re
-from typing import TypeVar
-
 import numpy as np
 
-from excel_grapher.core import (
-    CellValue,
-    XlError,
-    excel_casefold,
-    flatten,
-    numeric_values,
-    to_bool,
-    to_number,
-    to_string,
+from excel_grapher.core import CellValue, XlError, flatten
+from excel_grapher.core.math_funcs import (
+    abs_number,
+    average_cells,
+    averageif_cells,
+    countif_cells,
+    exp_number,
+    large_kth,
+    max_cells,
+    min_cells,
+    normdist_value,
+    npv_cells,
+    rank_number,
+    round_number,
+    rounddown_number,
+    stdev_cells,
+    sum_cells,
 )
-from excel_grapher.core.functions import xl_abs, xl_exp
 from excel_grapher.core.sumproduct import xl_sumproduct
-
-T = TypeVar("T", str, float)
 
 __all__ = [
     "xl_abs",
@@ -44,41 +45,19 @@ __all__ = [
 
 
 def xl_sum(*args: CellValue) -> float | XlError:
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    return float(sum(nums))
+    return sum_cells(*args)
 
 
 def xl_average(*args: CellValue) -> float | XlError:
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
-        return XlError.DIV
-    return float(sum(nums) / len(nums))
+    return average_cells(*args)
 
 
 def xl_min(*args: CellValue) -> float | XlError:
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
-        return 0.0
-    return float(min(nums))
+    return min_cells(*args)
 
 
 def xl_max(*args: CellValue) -> float | XlError:
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
-        return 0.0
-    return float(max(nums))
+    return max_cells(*args)
 
 
 def xl_count(*args: CellValue) -> int:
@@ -98,148 +77,23 @@ def xl_counta(*args: CellValue) -> int:
 
 
 def xl_round(number: CellValue, num_digits: CellValue) -> float | XlError:
-    n = to_number(number)
-    if isinstance(n, XlError):
-        return n
-    d = to_number(num_digits)
-    if isinstance(d, XlError):
-        return d
-    return float(round(n, int(d)))
+    return round_number(number, num_digits)
 
 
 def xl_rounddown(number: CellValue, num_digits: CellValue) -> float | XlError:
-    n = to_number(number)
-    if isinstance(n, XlError):
-        return n
-    d = to_number(num_digits)
-    if isinstance(d, XlError):
-        return d
-    digits = int(d)
-    factor = 10**digits
-    if n >= 0:
-        return float(math.floor(n * factor) / factor)
-    return float(math.ceil(n * factor) / factor)
+    return rounddown_number(number, num_digits)
 
 
 def xl_npv(rate: CellValue, *values: CellValue) -> float | XlError:
-    r = to_number(rate)
-    if isinstance(r, XlError):
-        return r
-    all_values = list(flatten(*values))
-    nums, err = numeric_values(all_values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
-        return XlError.VALUE
-    result = 0.0
-    for i, val in enumerate(nums):
-        result += val / ((1 + r) ** (i + 1))
-    return result
+    return npv_cells(rate, *values)
 
 
 def xl_stdev(*args: CellValue) -> float | XlError:
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) < 2:
-        return XlError.DIV
-    mean = sum(nums) / len(nums)
-    variance = sum((x - mean) ** 2 for x in nums) / (len(nums) - 1)
-    return float(variance**0.5)
-
-
-def _iter_numeric_cells(values: list[CellValue]) -> tuple[list[float], XlError | None]:
-    nums: list[float] = []
-    for v in values:
-        if isinstance(v, XlError):
-            return ([], v)
-        if v is None:
-            continue
-        if isinstance(v, bool):
-            continue
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            nums.append(float(v))
-            continue
-        if isinstance(v, (np.integer, np.floating)):
-            nums.append(float(v))
-            continue
-    return (nums, None)
-
-
-def _wildcard_to_regex(pattern: str) -> re.Pattern[str]:
-    out: list[str] = ["^"]
-    i = 0
-    while i < len(pattern):
-        ch = pattern[i]
-        if ch == "~" and i + 1 < len(pattern):
-            i += 1
-            out.append(re.escape(pattern[i]))
-        elif ch == "*":
-            out.append(".*")
-        elif ch == "?":
-            out.append(".")
-        else:
-            out.append(re.escape(ch))
-        i += 1
-    out.append("$")
-    return re.compile("".join(out), re.IGNORECASE)
-
-
-def _parse_countif_criteria(criteria: str) -> tuple[str | None, str]:
-    s = criteria.strip()
-    for op in (">=", "<=", "<>", ">", "<", "="):
-        if s.startswith(op):
-            return (op, s[len(op) :].strip())
-    return (None, s)
-
-
-def _value_matches_criteria(cell_value: CellValue, criteria: CellValue) -> bool:
-    if isinstance(criteria, XlError):
-        return False
-    if not isinstance(criteria, str):
-        target = criteria
-        if isinstance(cell_value, XlError):
-            return False
-        if target is None:
-            return cell_value is None
-        if isinstance(target, bool):
-            b = to_bool(cell_value)
-            return (not isinstance(b, XlError)) and b == target
-        if isinstance(target, (int, float)) and not isinstance(target, bool):
-            vn = to_number(cell_value)
-            return (not isinstance(vn, XlError)) and vn == float(target)
-        return excel_casefold(to_string(cell_value)) == excel_casefold(to_string(target))
-
-    op, rhs = _parse_countif_criteria(criteria)
-    if isinstance(cell_value, XlError):
-        return False
-
-    if op is None:
-        if any(ch in rhs for ch in ("*", "?", "~")):
-            rx = _wildcard_to_regex(rhs)
-            return rx.match(to_string(cell_value)) is not None
-        return excel_casefold(to_string(cell_value)) == excel_casefold(rhs)
-
-    try:
-        rhs_num = float(rhs) if rhs != "" else 0.0
-    except ValueError:
-        rhs_num = None
-
-    if rhs_num is not None:
-        vn = to_number(cell_value)
-        if isinstance(vn, XlError):
-            return False
-        return _criteria_compare(op, vn, rhs_num)
-
-    return _criteria_compare(op, excel_casefold(to_string(cell_value)), excel_casefold(rhs))
+    return stdev_cells(*args)
 
 
 def xl_countif(range_values: CellValue, criteria: CellValue) -> int | XlError:
-    if isinstance(criteria, XlError):
-        return criteria
-    values = list(flatten(range_values))
-    return sum(1 for v in values if _value_matches_criteria(v, criteria))
+    return countif_cells(range_values, criteria)
 
 
 def xl_averageif(
@@ -247,74 +101,15 @@ def xl_averageif(
     criteria: CellValue,
     average_range: CellValue | None = None,
 ) -> float | XlError:
-    if isinstance(criteria, XlError):
-        return criteria
-    crit_vals = list(flatten(range_values))
-    avg_vals = list(flatten(average_range if average_range is not None else range_values))
-    if len(crit_vals) != len(avg_vals):
-        return XlError.VALUE
-    matched: list[float] = []
-    for crit_val, avg_val in zip(crit_vals, avg_vals, strict=True):
-        if not _value_matches_criteria(crit_val, criteria):
-            continue
-        n = to_number(avg_val)
-        if isinstance(n, XlError):
-            return n
-        matched.append(float(n))
-    if not matched:
-        return XlError.DIV
-    return sum(matched) / len(matched)
-
-
-def _criteria_compare(op: str, left: T, right: T) -> bool:
-    """Compare two values of the same type."""
-    if op == "=":
-        return left == right
-    if op == "<>":
-        return left != right
-    if op == ">":
-        return left > right  # type: ignore[operator]
-    if op == "<":
-        return left < right  # type: ignore[operator]
-    if op == ">=":
-        return left >= right  # type: ignore[operator]
-    if op == "<=":
-        return left <= right  # type: ignore[operator]
-    return False
+    return averageif_cells(range_values, criteria, average_range)
 
 
 def xl_large(array: CellValue, k: CellValue) -> float | XlError:
-    kk = to_number(k)
-    if isinstance(kk, XlError):
-        return kk
-    kth = int(kk)
-    if kth < 1:
-        return XlError.NUM
-    values = list(flatten(array))
-    nums, err = _iter_numeric_cells(values)
-    if err is not None:
-        return err
-    if kth > len(nums):
-        return XlError.NUM
-    nums.sort(reverse=True)
-    return float(nums[kth - 1])
+    return large_kth(array, k)
 
 
 def xl_rank(number: CellValue, ref: CellValue, order: CellValue = 0) -> int | XlError:
-    nn = to_number(number)
-    if isinstance(nn, XlError):
-        return nn
-    oo = to_number(order)
-    if isinstance(oo, XlError):
-        return oo
-    ascending = int(oo) != 0
-    values = list(flatten(ref))
-    nums, err = _iter_numeric_cells(values)
-    if err is not None:
-        return err
-    if ascending:
-        return 1 + sum(1 for v in nums if v < nn)
-    return 1 + sum(1 for v in nums if v > nn)
+    return rank_number(number, ref, order)
 
 
 def xl_normdist(
@@ -323,21 +118,12 @@ def xl_normdist(
     standard_dev: CellValue,
     cumulative: CellValue,
 ) -> float | XlError:
-    xx = to_number(x)
-    if isinstance(xx, XlError):
-        return xx
-    mm = to_number(mean)
-    if isinstance(mm, XlError):
-        return mm
-    sd = to_number(standard_dev)
-    if isinstance(sd, XlError):
-        return sd
-    if sd <= 0:
-        return XlError.NUM
-    cc = to_bool(cumulative)
-    if isinstance(cc, XlError):
-        return cc
-    z = (xx - mm) / sd
-    if cc:
-        return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
-    return (1.0 / (sd * math.sqrt(2.0 * math.pi))) * math.exp(-0.5 * z * z)
+    return normdist_value(x, mean, standard_dev, cumulative)
+
+
+def xl_abs(*args: CellValue) -> float | XlError:
+    return abs_number(*args)
+
+
+def xl_exp(*args: CellValue) -> float | XlError:
+    return exp_number(*args)

--- a/excel_grapher/runtime/reference.py
+++ b/excel_grapher/runtime/reference.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
-import re
-
-import fastpyxl.utils.cell
-
-from excel_grapher.core import CellValue, ExcelRange, XlError, to_bool, to_number, to_string
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.reference_funcs import (
+    address_string,
+    column_number,
+    columns_count,
+    row_number,
+)
 
 __all__ = ["xl_address", "xl_column", "xl_columns", "xl_row"]
-
-
-def _quote_sheet_name(sheet: str) -> str:
-    if re.fullmatch(r"[A-Za-z0-9_]+", sheet):
-        return sheet
-    escaped = sheet.replace("'", "''")
-    return f"'{escaped}'"
 
 
 def xl_address(
@@ -23,59 +18,16 @@ def xl_address(
     a1: CellValue = True,
     sheet_text: CellValue = None,
 ) -> str | XlError:
-    rn = to_number(row_num)
-    if isinstance(rn, XlError):
-        return rn
-    cn = to_number(column_num)
-    if isinstance(cn, XlError):
-        return cn
-    an = to_number(abs_num)
-    if isinstance(an, XlError):
-        return an
-    a1_mode = to_bool(a1)
-    if isinstance(a1_mode, XlError):
-        return a1_mode
-    if not a1_mode:
-        return XlError.VALUE
-
-    r = int(rn)
-    c = int(cn)
-    if r < 1 or c < 1:
-        return XlError.VALUE
-
-    abs_flag = int(an)
-    if abs_flag not in (1, 2, 3, 4):
-        return XlError.VALUE
-
-    col_letters = fastpyxl.utils.cell.get_column_letter(c)
-
-    col_abs = abs_flag in (1, 2)
-    row_abs = abs_flag in (1, 3)
-    col_prefix = "$" if col_abs else ""
-    row_prefix = "$" if row_abs else ""
-
-    addr = f"{col_prefix}{col_letters}{row_prefix}{r}"
-
-    if sheet_text is None or sheet_text == "":
-        return addr
-
-    sheet = to_string(sheet_text)
-    return f"{_quote_sheet_name(sheet)}!{addr}"
+    return address_string(row_num, column_num, abs_num, a1, sheet_text)
 
 
 def xl_row(ref: CellValue) -> int | XlError:
-    if isinstance(ref, ExcelRange):
-        return ref.start_row
-    return XlError.VALUE
+    return row_number(ref)
 
 
 def xl_column(ref: CellValue) -> int | XlError:
-    if isinstance(ref, ExcelRange):
-        return ref.start_col
-    return XlError.VALUE
+    return column_number(ref)
 
 
 def xl_columns(ref: CellValue) -> int | XlError:
-    if isinstance(ref, ExcelRange):
-        return ref.end_col - ref.start_col + 1
-    return XlError.VALUE
+    return columns_count(ref)

--- a/excel_grapher/runtime/text.py
+++ b/excel_grapher/runtime/text.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
-from excel_grapher.core import CellValue, XlError, to_number, to_string
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.text_funcs import (
+    concatenate_cells,
+    left_chars,
+    lower_text,
+    mid_chars,
+    numbervalue_parse,
+    right_chars,
+    text_format,
+    value_from_text,
+)
 
 __all__ = [
     "xl_concatenate",
@@ -15,81 +25,23 @@ __all__ = [
 
 
 def xl_left(text: CellValue, num_chars: CellValue = 1) -> str | XlError:
-    s = to_string(text)
-    n = to_number(num_chars)
-    if isinstance(n, XlError):
-        return n
-    chars = int(n)
-    if chars < 0:
-        return XlError.VALUE
-    return s[:chars]
+    return left_chars(text, num_chars)
 
 
 def xl_right(text: CellValue, num_chars: CellValue = 1) -> str | XlError:
-    s = to_string(text)
-    n = to_number(num_chars)
-    if isinstance(n, XlError):
-        return n
-    chars = int(n)
-    if chars < 0:
-        return XlError.VALUE
-    if chars == 0:
-        return ""
-    return s[-chars:]
+    return right_chars(text, num_chars)
 
 
 def xl_mid(text: CellValue, start_num: CellValue, num_chars: CellValue) -> str | XlError:
-    s = to_string(text)
-    start = to_number(start_num)
-    if isinstance(start, XlError):
-        return start
-    num = to_number(num_chars)
-    if isinstance(num, XlError):
-        return num
-    start_idx = int(start) - 1
-    chars = int(num)
-    if start_idx < 0 or chars < 0:
-        return XlError.VALUE
-    return s[start_idx : start_idx + chars]
+    return mid_chars(text, start_num, num_chars)
 
 
 def xl_concatenate(*args: CellValue) -> str | XlError:
-    parts: list[str] = []
-    for a in args:
-        if isinstance(a, XlError):
-            return a
-        parts.append(to_string(a))
-    return "".join(parts)
+    return concatenate_cells(*args)
 
 
 def xl_text(value: CellValue, format_text: CellValue) -> str | XlError:
-    fmt = to_string(format_text)
-    n = to_number(value)
-    if isinstance(n, XlError):
-        return to_string(value)
-
-    if fmt == "0":
-        return str(int(round(n)))
-    if fmt == "0.0":
-        return f"{n:.1f}"
-    if fmt == "0.00":
-        return f"{n:.2f}"
-    if fmt == "0.000":
-        return f"{n:.3f}"
-    if fmt == "#,##0":
-        return f"{int(round(n)):,}"
-    if fmt == "#,##0.00":
-        return f"{n:,.2f}"
-    if fmt == "0%":
-        return f"{int(round(n * 100))}%"
-    if fmt == "0.0%":
-        return f"{n * 100:.1f}%"
-    if fmt == "0.00%":
-        return f"{n * 100:.2f}%"
-
-    if n == int(n):
-        return str(int(n))
-    return str(n)
+    return text_format(value, format_text)
 
 
 def xl_numbervalue(
@@ -98,76 +50,13 @@ def xl_numbervalue(
     group_separator: CellValue = ",",
 ) -> float | XlError:
     """Convert text to a number with explicit decimal and group separators."""
-    if isinstance(text, XlError):
-        return text
-    if isinstance(decimal_separator, XlError):
-        return decimal_separator
-    if isinstance(group_separator, XlError):
-        return group_separator
-
-    if not isinstance(text, str):
-        return to_number(text)
-
-    dec_sep = to_string(decimal_separator)
-    grp_sep = to_string(group_separator)
-    if dec_sep == "" or dec_sep == grp_sep:
-        return XlError.VALUE
-
-    s = text.replace("\u00a0", " ").strip()
-    if s == "":
-        return 0.0
-    currency_symbols = "$€£¥"
-    while s and (s[0] in currency_symbols or s[-1] in currency_symbols):
-        s = s.lstrip(currency_symbols).rstrip(currency_symbols).strip()
-        if s == "":
-            return XlError.VALUE
-    negative = False
-    if s.startswith("(") and s.endswith(")"):
-        negative = True
-        s = s[1:-1].strip()
-        if s == "":
-            return XlError.VALUE
-    percent = False
-    if s.endswith("%"):
-        percent = True
-        s = s[:-1].strip()
-        if s == "":
-            return XlError.VALUE
-    sign = 1.0
-    if s.startswith(("+", "-")):
-        if s[0] == "-":
-            sign = -1.0
-        s = s[1:].strip()
-        if s == "":
-            return XlError.VALUE
-    while s and (s[0] in currency_symbols or s[-1] in currency_symbols):
-        s = s.lstrip(currency_symbols).rstrip(currency_symbols).strip()
-        if s == "":
-            return XlError.VALUE
-    if grp_sep:
-        s = s.replace(grp_sep, "")
-    if dec_sep != ".":
-        s = s.replace(dec_sep, ".")
-    try:
-        value = float(s)
-    except ValueError:
-        return XlError.VALUE
-    if percent:
-        value /= 100.0
-    if negative:
-        value = -abs(value)
-    return value * sign
+    return numbervalue_parse(text, decimal_separator, group_separator)
 
 
 def xl_lower(text: CellValue) -> str | XlError:
-    if isinstance(text, XlError):
-        return text
-    return to_string(text).lower()
+    return lower_text(text)
 
 
 def xl_value(text: CellValue) -> float | XlError:
     """Convert locale-formatted text to a number (Excel VALUE)."""
-    parsed = xl_numbervalue(text)
-    if parsed is XlError.VALUE and isinstance(text, str):
-        return to_number(text)
-    return parsed
+    return value_from_text(text)

--- a/tests/integration/exporter/test_raise_based_errors.py
+++ b/tests/integration/exporter/test_raise_based_errors.py
@@ -227,11 +227,11 @@ class TestDirectCallBoundaryEquivalence:
         graph = _make_graph(*extra_nodes, _make_node("S!A1", formula, None))
         _assert_direct_call_matches_xl_eval(graph, "S!A1", expected)
 
-    def test_embedded_runtime_uses_sentinel_wrappers(self) -> None:
+    def test_embedded_runtime_uses_core_delegation_wrappers(self) -> None:
         graph = _make_graph(_make_node("S!A1", '=AVERAGEIF(S!B1:S!B2, ">5", S!C1:C3)', None))
         code = CodeGenerator(graph).generate(["S!A1"])
-        assert "def _sentinel_xl_averageif" in code
-        assert "_sentinel_xl_averageif" in code
+        assert "def averageif_cells(" in code
+        assert "averageif_cells(" in code
         assert "raise_if_sentinel_float(" in code
         assert "return xl_averageif(" in _cell_function_sources(code)["cell_s_a1"]
 

--- a/tests/unit/exporter/test_export_runtime_boundary.py
+++ b/tests/unit/exporter/test_export_runtime_boundary.py
@@ -14,6 +14,7 @@ def test_emit_runtime_includes_core_math_helpers() -> None:
     assert "def sum_cells(" in code
     assert "def averageif_cells(" in code
     assert "def xl_averageif(" in code
+    assert code.count("def xl_sum(") == 1
     assert "sum_cells(*args)" in code
     assert "raise_if_sentinel_float(" in code
     assert "averageif_cells(" in code
@@ -30,9 +31,9 @@ def test_emit_runtime_includes_core_abs_helper() -> None:
 def test_emit_runtime_includes_core_text_value_fallback() -> None:
     code = emit_runtime({"xl_value", "xl_numbervalue"}, include_offset_table=False)
     assert "def numbervalue_parse(" in code
+    assert "def value_from_text(" in code
     assert "def xl_value(" in code
-    assert "numbervalue_parse(text)" in code
-    assert "raise_if_sentinel_float(to_number(text))" in code
+    assert "raise_if_sentinel_float(value_from_text(text))" in code
 
 
 def test_core_averageif_returns_error_sentinel_without_raising() -> None:

--- a/tests/unit/exporter/test_export_runtime_boundary.py
+++ b/tests/unit/exporter/test_export_runtime_boundary.py
@@ -1,77 +1,47 @@
-"""Tests for export-runtime sentinel shadowing in ``emit_runtime``."""
+"""Tests for export-runtime core delegation in ``emit_runtime``."""
 
 from __future__ import annotations
 
-import ast
-from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
-from excel_grapher.exporter.embed import _format_emitted_symbol_source, emit_runtime
-
-_RUNTIME_MATH = Path(__file__).resolve().parents[3] / "excel_grapher" / "runtime" / "math.py"
+from excel_grapher.exporter.embed import emit_runtime
 
 
-def test_format_emitted_symbol_source_renames_shadowed_def() -> None:
-    """Sentinel emission renames only the top-level ``def`` for shadowed symbols.
-
-    Invariants exercised here (see ``embed._format_emitted_symbol_source``):
-
-    * The shadowed symbol uses the ``_sentinel_{original}`` prefix.
-    * The shared implementation is a plain top-level ``def {original}(...`` with
-      no decorators, so a single ``def {original}(`` replacement is sufficient.
-    * Internal references to other ``xl_*`` names in the extracted body are left
-      untouched by the rename pass.
-    """
-    module_src = _RUNTIME_MATH.read_text(encoding="utf-8")
-    module_ast = ast.parse(module_src, filename=str(_RUNTIME_MATH))
-    sum_node = next(
-        node
-        for node in module_ast.body
-        if isinstance(node, ast.FunctionDef) and node.name == "xl_sum"
-    )
-
-    segment = _format_emitted_symbol_source("_sentinel_xl_sum", module_src, sum_node)
-
-    assert segment.startswith("def _sentinel_xl_sum(")
-    assert "def xl_sum(" not in segment
-    assert "numeric_values" in segment
-
-
-def test_emit_runtime_shadows_sentinel_math_helpers() -> None:
+def test_emit_runtime_includes_core_math_helpers() -> None:
     code = emit_runtime({"xl_averageif", "xl_sum"}, include_offset_table=False)
-    assert "def _sentinel_xl_averageif" in code
-    assert "def _sentinel_xl_sum" in code
-    assert "def xl_averageif" in code
-    assert "_sentinel_xl_averageif" in code
+    assert "def sum_cells(" in code
+    assert "def averageif_cells(" in code
+    assert "def xl_averageif(" in code
+    assert "sum_cells(*args)" in code
     assert "raise_if_sentinel_float(" in code
-    assert "_sentinel_xl_sum(*args)" in code
+    assert "averageif_cells(" in code
 
 
-def test_emit_runtime_shadows_core_abs_helper() -> None:
+def test_emit_runtime_includes_core_abs_helper() -> None:
     code = emit_runtime({"xl_abs"}, include_offset_table=False)
-    assert "def _sentinel_xl_abs" in code
-    assert "def xl_abs" in code
-    assert "_sentinel_xl_abs(*args)" in code
+    assert "def abs_number(" in code
+    assert "def xl_abs(" in code
+    assert "abs_number(*args)" in code
     assert "raise_if_sentinel_float(" in code
 
 
-def test_emit_runtime_shadows_sentinel_text_value_fallback() -> None:
+def test_emit_runtime_includes_core_text_value_fallback() -> None:
     code = emit_runtime({"xl_value", "xl_numbervalue"}, include_offset_table=False)
-    assert "def _sentinel_xl_numbervalue" in code
-    assert "def xl_value" in code
-    assert "_sentinel_xl_numbervalue(text)" in code
+    assert "def numbervalue_parse(" in code
+    assert "def xl_value(" in code
+    assert "numbervalue_parse(text)" in code
     assert "raise_if_sentinel_float(to_number(text))" in code
 
 
-def test_sentinel_averageif_returns_error_sentinel_without_raising() -> None:
-    """Internal ``_sentinel_*`` helpers keep sentinel semantics for delegation."""
+def test_core_averageif_returns_error_sentinel_without_raising() -> None:
+    """Core helpers keep sentinel semantics for evaluator parity."""
     code = emit_runtime({"xl_averageif"}, include_offset_table=False)
     ns: dict[str, Any] = {}
     exec(code, ns)
-    sentinel = ns["_sentinel_xl_averageif"]
-    result = sentinel([1, 2], ">5", [10, 20, 30])
+    core_impl = ns["averageif_cells"]
+    result = core_impl([1, 2], ">5", [10, 20, 30])
     assert result == ns["XlError"].VALUE
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the three-layer layout described in #369, replacing the interim `_sentinel_*` embed-time shadowing from #368 with explicit shared implementations in `core/*_funcs.py`.

- **`core/*_funcs.py`** — single source of truth for math, text, logic, and reference worksheet functions (sentinel-returning semantics)
- **`runtime/*`** — thin delegators for the evaluator path (behavior unchanged)
- **`export_runtime/*`** — thin `raise_if_sentinel_*` delegators for the export path (behavior unchanged)

## Changes

- Added `core/logic_funcs.py`, `core/math_funcs.py`, `core/text_funcs.py`, `core/reference_funcs.py` with shared implementations and criteria helpers
- Slimmed `runtime/{logic,math,text,reference}.py` to one-line delegators
- Updated `export_runtime/{logic,math,text,reference}.py` to import from `core/*_funcs` directly (removed all 34 `F821` noqa comments)
- Removed `_sentinel_*` registration and `def` renaming from `embed.py`
- Updated `core/functions.py` to re-export `xl_abs`/`xl_exp` from `math_funcs` for backward compatibility
- Updated parity docs (`.cursor/rules/parity.mdc`) and boundary tests

## Acceptance criteria (#369)

- [x] Shared implementations live in `core/` modules with sentinel-returning semantics
- [x] `runtime/*` modules are thin delegators to `core/` (evaluator unchanged)
- [x] `export_runtime/*` modules are thin `raise_if_sentinel_*` delegators to `core/` (export unchanged)
- [x] Removed `_sentinel_*` registration/renaming from `embed.py`
- [x] Removed `F821` per-file ignores for export-runtime wrapper modules
- [x] Existing parity tests pass (`assert_codegen_matches_evaluator`, raise-based error tests)
- [x] No third copy of semantics — `core/` is the single source of truth

Closes #369
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c78ae4d5-99bc-43f4-b581-3e756485fc73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c78ae4d5-99bc-43f4-b581-3e756485fc73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

