### PR TITLE
feat(series_bindings): input.mode override for formula cell setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- version list -->
 
+## Unreleased
+
+### Features
+
+- **series_bindings**: Add `input.mode: override` (schema 1.6.0) for public setters on user-editable formula cells ([#371](https://github.com/Teal-Insights/excel-grapher/pull/371))
+
+### Changed
+
+- **series_bindings**: Leaf-mode input bindings now **error** on non-leaf `data_range` overlap (`non_leaf_input_overlap`) instead of warning and silently dropping formula cells. Manifests that relied on the old warn-and-drop behavior must either narrow `data_range` to graph leaves or declare `input.mode: override`.
+
 ## v3.1.0 (2026-07-07)
 
 ### Features

--- a/examples/micro_workbooks/formula_override.bindings.yaml
+++ b/examples/micro_workbooks/formula_override.bindings.yaml
@@ -1,0 +1,20 @@
+schema_version: "1.6.0"
+workbook: formula_override.xlsx
+series:
+  - id: engine_override
+    sheet: Engine
+    data_range: Engine!B1
+    layout: scalar
+    input:
+      mode: override
+      setter:
+        name: set_engine_b1
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind:
+          kind: data_cell
+          read: float
+      dimensions: []
+    key: []

--- a/examples/micro_workbooks/series_bindings.qmd
+++ b/examples/micro_workbooks/series_bindings.qmd
@@ -409,6 +409,37 @@ print(records_markdown_table(records))
 
 After the setter runs, period **4** and **5** records reflect the updated input values (`7.5` and `8.0`) while still carrying dimensions such as `REF_AREA` and `UNIT_MEASURE` from the binding. Address-keyed `compute_all(ctx=ctx)` remains available for the full target map; `compute_borvelia_primary_balance` is the tabular, dimension-keyed view of this series only.
 
+## 02. Formula-cell override setters (`input.mode: override`)
+
+Some workbooks expose **user-editable formula cells**: the cell keeps a formula, but analysts can type a value that displaces the computed result for downstream evaluation (Excel's typed-over-formula pattern). Schema **1.6.0** adds `input.mode: override` for these cases.
+
+Example manifest: [formula_override.bindings.yaml](formula_override.bindings.yaml).
+
+```yaml
+schema_version: "1.6.0"
+workbook: formula_override.xlsx
+series:
+  - id: engine_override
+    sheet: Engine
+    data_range: Engine!B1
+    layout: scalar
+    input:
+      mode: override
+      setter:
+        name: set_engine_b1
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: { kind: data_cell, read: float }
+      dimensions: []
+    key: []
+```
+
+**Leaf mode (default)** requires every bound cell to be a graph leaf. If `data_range` includes a formula cell, validation fails with `non_leaf_input_overlap` (older versions warned and silently dropped those cells).
+
+**Override mode** resolves graph nodes in `data_range`, requires at least one formula cell, and routes setter writes through `ctx.set_inputs` so downstream cells use the override value instead of re-evaluating the formula.
+
 ### Discovering the generated API
 
 The generated module also exposes two zero-argument discovery helpers, `list_setters()` and `list_computes()`. They return the names of the emitted `set_*` and `compute_*` functions, so tooling can enumerate the series API without parsing source:

--- a/excel_grapher/series_bindings/input_series.py
+++ b/excel_grapher/series_bindings/input_series.py
@@ -27,11 +27,11 @@ def derive_input_series(
     *,
     workbook: Path | str,
 ) -> list[InputSeries]:
-    """Return one input series per binding series with graph-leaf overlap.
+    """Return one input series per binding series with graph-leaf or override overlap.
 
     Series bindings are the semantic source of truth: each input series
     corresponds to one manifest `series[]` entry, and each cell corresponds to
-    a resolved graph leaf participating in that series.
+    a resolved graph leaf or override cell participating in that series.
     """
     report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="input")
     series_by_id = {

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
+
+InputMode = Literal["leaf", "override"]
 
 _STRUCTURAL_FIELDS = frozenset(
     {
@@ -37,6 +39,30 @@ def _setter_block(series: dict[str, Any]) -> dict[str, Any] | None:
 
 def has_input_direction(series: dict[str, Any]) -> bool:
     return _setter_block(series) is not None
+
+
+def input_mode(series: dict[str, Any]) -> InputMode:
+    """Return the declared input binding mode (default ``leaf``)."""
+    input_block = series.get("input")
+    if not isinstance(input_block, dict):
+        return "leaf"
+    mode = input_block.get("mode", "leaf")
+    if mode in ("leaf", "override"):
+        return mode
+    return "leaf"
+
+
+def is_override_input(series: dict[str, Any]) -> bool:
+    """Return True when the series declares override input semantics."""
+    return input_mode(series) == "override"
+
+
+def effective_validation(series: dict[str, Any]) -> dict[str, Any]:
+    """Return series validation flags with override-mode defaults applied."""
+    validation = dict(series.get("validation") or {})
+    if is_override_input(series):
+        validation["intersect_graph_leaves"] = False
+    return validation
 
 
 def has_output_direction(series: dict[str, Any]) -> bool:

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -21,7 +21,12 @@ from excel_grapher.series_bindings.geometry import (
     expand_row_specs,
     parse_value_map,
 )
-from excel_grapher.series_bindings.normalize import has_input_direction, has_output_direction
+from excel_grapher.series_bindings.normalize import (
+    effective_validation,
+    has_input_direction,
+    has_output_direction,
+    input_mode,
+)
 from excel_grapher.series_bindings.ranges import expand_data_range_for_graph
 from excel_grapher.series_bindings.types import (
     LeafResolution,
@@ -468,6 +473,40 @@ def _normalize_export_addresses(export_addresses: Iterable[str] | None) -> froze
     return frozenset(normalize_address(addr) for addr in export_addresses)
 
 
+def _select_input_addresses(
+    graph: DependencyGraph,
+    expanded_addresses: list[str],
+    *,
+    mode: str,
+    validation: dict[str, Any],
+    series_id: str,
+    candidate_addresses: list[str] | None = None,
+) -> tuple[list[str], list[ResolutionIssue]]:
+    """Select input binding addresses and report skipped non-leaf cells."""
+    issues: list[ResolutionIssue] = []
+    pool = expanded_addresses if candidate_addresses is None else candidate_addresses
+    if mode == "override":
+        selected = [address for address in pool if _is_graph_node(graph, address)]
+    else:
+        intersect = bool(validation.get("intersect_graph_leaves", True))
+        if not intersect:
+            selected = list(pool)
+        else:
+            selected = [address for address in pool if _is_graph_leaf(graph, address)]
+    if mode != "override":
+        skipped = len(pool) - len(selected)
+        if skipped > 0 and bool(validation.get("warn_on_partial_overlap", True)):
+            issues.append(
+                make_issue(
+                    "warning",
+                    "partial_graph_overlap",
+                    f"Skipped {skipped} cell(s) in data_range not graph input leaf cells",
+                    series_id=series_id,
+                )
+            )
+    return selected, issues
+
+
 def _select_addresses(
     graph: DependencyGraph,
     expanded_addresses: list[str],
@@ -476,25 +515,27 @@ def _select_addresses(
     validation: dict[str, Any],
     series_id: str,
     export_addresses: frozenset[str] | None = None,
+    input_binding_mode: str = "leaf",
 ) -> tuple[list[str], list[ResolutionIssue]]:
     issues: list[ResolutionIssue] = []
     if export_addresses is not None:
         if direction == "input":
-            intersect_leaves = bool(validation.get("intersect_graph_leaves", True))
             exported_addresses = [
                 address for address in expanded_addresses if address in export_addresses
             ]
-            selected = [
-                address
-                for address in exported_addresses
-                if not intersect_leaves or _is_graph_leaf(graph, address)
-            ]
+            selected, overlap_issues = _select_input_addresses(
+                graph,
+                expanded_addresses,
+                mode=input_binding_mode,
+                validation=validation,
+                series_id=series_id,
+                candidate_addresses=exported_addresses,
+            )
+            issues.extend(overlap_issues)
             skipped_export = len(expanded_addresses) - len(exported_addresses)
-            skipped_non_leaf = len(exported_addresses) - len(selected)
         else:
             selected = [address for address in expanded_addresses if address in export_addresses]
             skipped_export = len(expanded_addresses) - len(selected)
-            skipped_non_leaf = 0
         if skipped_export > 0 and bool(validation.get("warn_on_partial_overlap", True)):
             issues.append(
                 make_issue(
@@ -504,34 +545,29 @@ def _select_addresses(
                     series_id=series_id,
                 )
             )
-        if skipped_non_leaf > 0 and bool(validation.get("warn_on_partial_overlap", True)):
-            issues.append(
-                make_issue(
-                    "warning",
-                    "partial_graph_overlap",
-                    f"Skipped {skipped_non_leaf} cell(s) in data_range not graph input leaf cells",
-                    series_id=series_id,
-                )
-            )
         return selected, issues
 
     if direction == "input":
-        intersect = bool(validation.get("intersect_graph_leaves", True))
-        if not intersect:
-            return expanded_addresses, issues
-        selected = [address for address in expanded_addresses if _is_graph_leaf(graph, address)]
-    else:
-        intersect = bool(validation.get("intersect_graph_nodes", True))
-        if not intersect:
-            return expanded_addresses, issues
-        selected = [address for address in expanded_addresses if _is_graph_node(graph, address)]
+        selected, overlap_issues = _select_input_addresses(
+            graph,
+            expanded_addresses,
+            mode=input_binding_mode,
+            validation=validation,
+            series_id=series_id,
+        )
+        issues.extend(overlap_issues)
+        return selected, issues
+
+    intersect = bool(validation.get("intersect_graph_nodes", True))
+    if not intersect:
+        return expanded_addresses, issues
+    selected = [address for address in expanded_addresses if _is_graph_node(graph, address)]
 
     skipped = len(expanded_addresses) - len(selected)
     if skipped > 0 and bool(validation.get("warn_on_partial_overlap", True)):
-        if direction == "input":
-            message = f"Skipped {skipped} cell(s) in data_range not graph input leaf cells"
-        else:
-            message = f"Skipped {skipped} cell(s) in data_range not present in graph for {direction} binding"
+        message = (
+            f"Skipped {skipped} cell(s) in data_range not present in graph for {direction} binding"
+        )
         issues.append(
             make_issue(
                 "warning",
@@ -584,7 +620,7 @@ def resolve_series_binding(
             "issues": [make_issue("error", "invalid_data_range", str(exc), series_id=series_id)],
         }
 
-    validation = series.get("validation") or {}
+    validation = effective_validation(series)
     export_set = _normalize_export_addresses(export_addresses)
     addresses, overlap_issues = _select_addresses(
         graph,
@@ -593,6 +629,7 @@ def resolve_series_binding(
         validation=validation,
         series_id=series_id,
         export_addresses=export_set,
+        input_binding_mode=input_mode(series) if direction == "input" else "leaf",
     )
     issues.extend(overlap_issues)
     if not addresses:

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -22,6 +22,7 @@ from excel_grapher.series_bindings.geometry import (
     parse_value_map,
 )
 from excel_grapher.series_bindings.normalize import (
+    InputMode,
     effective_validation,
     has_input_direction,
     has_output_direction,
@@ -477,7 +478,7 @@ def _select_input_addresses(
     graph: DependencyGraph,
     expanded_addresses: list[str],
     *,
-    mode: str,
+    mode: InputMode,
     validation: dict[str, Any],
     series_id: str,
     candidate_addresses: list[str] | None = None,
@@ -515,7 +516,7 @@ def _select_addresses(
     validation: dict[str, Any],
     series_id: str,
     export_addresses: frozenset[str] | None = None,
-    input_binding_mode: str = "leaf",
+    input_binding_mode: InputMode = "leaf",
 ) -> tuple[list[str], list[ResolutionIssue]]:
     issues: list[ResolutionIssue] = []
     if export_addresses is not None:

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"],
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters)."
     },
     "workbook": {
       "type": "string",
@@ -375,6 +375,12 @@
       "additionalProperties": false,
       "required": ["setter"],
       "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["leaf", "override"],
+          "default": "leaf",
+          "description": "Input binding semantics. leaf (default): data_range cells must be graph leaves. override: allow formula cells with dependents; setters write effective values that suppress formula evaluation until changed."
+        },
         "setter": { "$ref": "#/$defs/Setter" }
       }
     },

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from typing import Any, Literal
 
 from excel_grapher.grapher.graph import DependencyGraph
-from excel_grapher.series_bindings.normalize import has_input_direction, input_mode
+from excel_grapher.series_bindings.normalize import (
+    effective_validation,
+    has_input_direction,
+    input_mode,
+    is_override_input,
+)
 from excel_grapher.series_bindings.ranges import expand_data_range_for_graph
 from excel_grapher.series_bindings.types import (
     ValidationIssue,
@@ -35,10 +40,42 @@ def _issue(
 
 
 def _series_validation_flags(series: dict[str, Any]) -> tuple[bool, bool]:
-    validation = series.get("validation") or {}
+    validation = effective_validation(series)
     intersect = validation.get("intersect_graph_leaves", True)
     unique_key = validation.get("require_unique_key", True)
     return bool(intersect), bool(unique_key)
+
+
+def _input_binding_addresses(
+    graph: DependencyGraph,
+    series: dict[str, Any],
+    addresses: list[str],
+) -> list[str]:
+    """Return addresses that participate in input binding resolution."""
+    if is_override_input(series):
+        return [address for address in addresses if address in graph]
+    validation = effective_validation(series)
+    if not validation.get("intersect_graph_leaves", True):
+        return list(addresses)
+    return [address for address in addresses if _is_graph_leaf(graph, address)]
+
+
+def _validate_input_mode(series: dict[str, Any]) -> list[ValidationIssue]:
+    input_block = series.get("input")
+    if not isinstance(input_block, dict):
+        return []
+    mode = input_block.get("mode")
+    if mode is None or mode in ("leaf", "override"):
+        return []
+    series_id = str(series.get("id", ""))
+    return [
+        _issue(
+            "error",
+            "invalid_input_mode",
+            f"input.mode must be 'leaf' or 'override', got {mode!r}",
+            series_id=series_id,
+        )
+    ]
 
 
 def _dimension_concepts(series: dict[str, Any]) -> set[str]:
@@ -455,7 +492,7 @@ def validate_series_bindings(
         if not isinstance(data_range, str):
             continue
 
-        intersect_leaves, require_unique_key = _series_validation_flags(series)
+        _, require_unique_key = _series_validation_flags(series)
         try:
             addresses = expand_data_range_for_graph(
                 graph,
@@ -484,15 +521,10 @@ def validate_series_bindings(
             )
             continue
 
+        issues.extend(_validate_input_mode(series))
         issues.extend(_validate_input_binding_overlap(graph, series, addresses))
 
-        graph_leaf_addresses = [
-            address
-            for address in addresses
-            if not intersect_leaves or _is_graph_leaf(graph, address)
-        ]
-        if input_mode(series) == "override":
-            graph_leaf_addresses = [address for address in addresses if address in graph]
+        graph_input_addresses = _input_binding_addresses(graph, series, addresses)
 
         if require_unique_key:
             cell_scoped_keys = [
@@ -504,7 +536,7 @@ def validate_series_bindings(
                     for d in (series.get("structure") or {}).get("dimensions") or []
                 )
             ]
-            if not graph_leaf_addresses:
+            if not graph_input_addresses:
                 continue
             if cell_scoped_keys and workbook is None:
                 issues.append(

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.normalize import has_input_direction, input_mode
 from excel_grapher.series_bindings.ranges import expand_data_range_for_graph
 from excel_grapher.series_bindings.types import (
     ValidationIssue,
@@ -49,6 +50,53 @@ def _dimension_concepts(series: dict[str, Any]) -> set[str]:
 def _is_graph_leaf(graph: DependencyGraph, address: str) -> bool:
     node = graph.get_node(address) if address in graph else None
     return bool(node is not None and node.is_leaf)
+
+
+def _is_formula_graph_node(graph: DependencyGraph, address: str) -> bool:
+    node = graph.get_node(address) if address in graph else None
+    return bool(node is not None and node.formula is not None)
+
+
+def _validate_input_binding_overlap(
+    graph: DependencyGraph,
+    series: dict[str, Any],
+    addresses: list[str],
+) -> list[ValidationIssue]:
+    """Validate leaf vs override semantics for input binding data ranges."""
+    issues: list[ValidationIssue] = []
+    if not has_input_direction(series):
+        return issues
+
+    series_id = str(series.get("id", ""))
+    mode = input_mode(series)
+    graph_addresses = [address for address in addresses if address in graph]
+    non_leaf_graph_addresses = [
+        address for address in graph_addresses if not _is_graph_leaf(graph, address)
+    ]
+    formula_graph_addresses = [
+        address for address in graph_addresses if _is_formula_graph_node(graph, address)
+    ]
+
+    if mode == "leaf" and non_leaf_graph_addresses:
+        issues.append(
+            _issue(
+                "error",
+                "non_leaf_input_overlap",
+                "data_range includes non-leaf graph cells; declare input.mode: override "
+                "for user-editable formula cells",
+                series_id=series_id,
+            )
+        )
+    elif mode == "override" and not formula_graph_addresses:
+        issues.append(
+            _issue(
+                "error",
+                "no_formula_override_targets",
+                "input.mode override requires at least one formula cell in data_range",
+                series_id=series_id,
+            )
+        )
+    return issues
 
 
 def _validate_bind_smoke(bind: Any, *, series_id: str, context: str) -> list[ValidationIssue]:
@@ -436,11 +484,15 @@ def validate_series_bindings(
             )
             continue
 
+        issues.extend(_validate_input_binding_overlap(graph, series, addresses))
+
         graph_leaf_addresses = [
             address
             for address in addresses
             if not intersect_leaves or _is_graph_leaf(graph, address)
         ]
+        if input_mode(series) == "override":
+            graph_leaf_addresses = [address for address in addresses if address in graph]
 
         if require_unique_key:
             cell_scoped_keys = [

--- a/excel_grapher/series_bindings/versions.py
+++ b/excel_grapher/series_bindings/versions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 SUPPORTED_SCHEMA_VERSIONS: frozenset[str] = frozenset(
-    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"}
+    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"}
 )
 
 IMPLEMENTED_BIND_KINDS: frozenset[str] = frozenset(

--- a/tests/fixtures/series_bindings/formula_override.yaml
+++ b/tests/fixtures/series_bindings/formula_override.yaml
@@ -1,0 +1,20 @@
+schema_version: "1.6.0"
+workbook: formula_override.xlsx
+series:
+  - id: engine_override
+    sheet: Engine
+    data_range: Engine!B1
+    layout: scalar
+    input:
+      mode: override
+      setter:
+        name: set_engine_b1
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind:
+          kind: data_cell
+          read: float
+      dimensions: []
+    key: []

--- a/tests/integration/user_flows/test_input_override_codegen.py
+++ b/tests/integration/user_flows/test_input_override_codegen.py
@@ -1,0 +1,85 @@
+"""Integration: CodeGenerator emits override setters for formula cells."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import xlsxwriter
+
+from excel_grapher.exporter import CodeGenerator
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.runtime.cache import xl_cell
+from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
+
+
+def _write_override_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws_in = wb.add_worksheet("Inputs")
+    ws_in.write_number("A1", 10)
+    ws_eng = wb.add_worksheet("Engine")
+    ws_eng.write_formula("B1", "=Inputs!A1+1")
+    ws_out = wb.add_worksheet("Output")
+    ws_out.write_formula("C1", "=Engine!B1*2")
+    wb.close()
+
+
+BINDINGS_DOCUMENT: dict[str, Any] = {
+    "schema_version": "1.6.0",
+    "workbook": "formula_override.xlsx",
+    "series": [
+        {
+            "id": "engine_override",
+            "sheet": "Engine",
+            "data_range": "Engine!B1",
+            "layout": "scalar",
+            "input": {
+                "mode": "override",
+                "setter": {"name": "set_engine_b1"},
+            },
+            "structure": {
+                "measure": {
+                    "concept": "OBS_VALUE",
+                    "dtype": "float",
+                    "bind": {"kind": "data_cell", "read": "float"},
+                },
+                "dimensions": [],
+            },
+            "key": [],
+        }
+    ],
+}
+
+
+def test_codegen_override_setter_updates_formula_cell_and_downstream(tmp_path: Path) -> None:
+    workbook = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(workbook)
+    bindings = validate_bindings_document(BINDINGS_DOCUMENT)
+    targets = ["Output!C1"]
+    for series in bindings["series"]:
+        targets.extend(expand_data_range(series["data_range"], workbook=workbook))
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+
+    with CodeGenerator(graph) as gen:
+        code = gen.generate(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+    assert "def set_engine_b1(" in code
+
+    ns: dict[str, object] = {}
+    exec(code, ns)
+    make_context = cast(Callable[[], Any], ns["make_context"])
+    set_engine_b1 = cast(Callable[[Any, object], None], ns["set_engine_b1"])
+
+    ctx = make_context()
+    assert ctx.inputs["Inputs!A1"] == 10
+
+    set_engine_b1(ctx, 99)
+    assert ctx.inputs["Engine!B1"] == 99
+    assert "Engine!B1" not in ctx.cache
+    assert "Output!C1" not in ctx.cache
+    assert xl_cell(ctx, "Output!C1") == 198

--- a/tests/unit/series_bindings/test_input_override.py
+++ b/tests/unit/series_bindings/test_input_override.py
@@ -1,0 +1,273 @@
+"""Tests for input.mode: override (non-leaf formula cell setters)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import xlsxwriter
+
+from excel_grapher.core import CellValue
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.grapher.node import Node
+from excel_grapher.runtime.cache import EvalContext, coerce_inputs_dict, xl_cell
+from excel_grapher.series_bindings import derive_input_series, resolve_series_binding
+from excel_grapher.series_bindings.setter_codegen import emit_setters_block
+from excel_grapher.series_bindings.types import WorkbookSeriesBindings
+from excel_grapher.series_bindings.validate import validate_series_bindings
+
+
+def _write_override_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws_in = wb.add_worksheet("Inputs")
+    ws_in.write_number("A1", 10)
+    ws_eng = wb.add_worksheet("Engine")
+    ws_eng.write_formula("B1", "=Inputs!A1+1")
+    ws_out = wb.add_worksheet("Output")
+    ws_out.write_formula("C1", "=Engine!B1*2")
+    for col in range(2, 5):
+        col_letter = chr(ord("A") + col - 1)
+        ws_eng.write_number(f"{col_letter}1", col - 1)
+        ws_eng.write_formula(f"{col_letter}2", f"=Inputs!A1+{col}")
+        ws_out.write_formula(f"{col_letter}3", f"=Engine!{col_letter}2*2")
+    wb.close()
+
+
+def _override_scalar_series(*, series_id: str = "engine_override") -> dict[str, object]:
+    return {
+        "id": series_id,
+        "sheet": "Engine",
+        "data_range": "Engine!B1",
+        "layout": "scalar",
+        "input": {"mode": "override", "setter": {"name": "set_engine_b1"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "dtype": "float", "bind": {"kind": "data_cell"}},
+            "dimensions": [],
+        },
+    }
+
+
+def _manual_override_graph() -> DependencyGraph:
+    graph = DependencyGraph()
+    graph.add_node(
+        Node(
+            sheet="Inputs",
+            column="A",
+            row=1,
+            formula=None,
+            normalized_formula=None,
+            value=10,
+            is_leaf=True,
+        )
+    )
+    graph.add_node(
+        Node(
+            sheet="Engine",
+            column="B",
+            row=1,
+            formula="=Inputs!A1+1",
+            normalized_formula="=Inputs!A1+1",
+            value=11,
+            is_leaf=False,
+        )
+    )
+    graph.add_node(
+        Node(
+            sheet="Output",
+            column="C",
+            row=1,
+            formula="=Engine!B1*2",
+            normalized_formula="=Engine!B1*2",
+            value=22,
+            is_leaf=False,
+            is_target=True,
+        )
+    )
+    graph.add_edge("Engine!B1", "Inputs!A1")
+    graph.add_edge("Output!C1", "Engine!B1")
+    return graph
+
+
+def test_resolve_input_override_includes_non_leaf_formula_cell(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    series = _override_scalar_series()
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="input")
+
+    engine_b1 = graph.get_node("Engine!B1")
+    assert engine_b1 is not None
+    assert engine_b1.is_leaf is False
+    assert len(resolved["leaves"]) == 1
+    assert resolved["leaves"][0]["address"] == "Engine!B1"
+    assert not any(i["code"] == "partial_graph_overlap" for i in resolved["issues"])
+
+
+def test_resolve_input_override_series_includes_formula_row(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        ["Engine!B2", "Engine!C2", "Engine!D2", "Output!B3", "Output!C3", "Output!D3"],
+        load_values=True,
+    )
+    series = {
+        "id": "engine_row_override",
+        "sheet": "Engine",
+        "data_range": "Engine!B2:D2",
+        "layout": "series",
+        "input": {"mode": "override", "setter": {"name": "set_engine_row"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "dtype": "float", "bind": {"kind": "data_cell"}},
+            "dimensions": [
+                {
+                    "concept": "IDX",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                }
+            ],
+        },
+        "key": ["IDX"],
+    }
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="input")
+
+    assert [leaf["address"] for leaf in resolved["leaves"]] == [
+        "Engine!B2",
+        "Engine!C2",
+        "Engine!D2",
+    ]
+    assert all(
+        (node := graph.get_node(addr)) is not None and not node.is_leaf
+        for addr in ["Engine!B2", "Engine!C2", "Engine!D2"]
+    )
+
+
+def _override_bindings() -> WorkbookSeriesBindings:
+    return cast(
+        WorkbookSeriesBindings,
+        {"schema_version": "1.6.0", "series": [_override_scalar_series()]},
+    )
+
+
+def test_validate_leaf_mode_errors_on_non_leaf_overlap(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    series = _override_scalar_series()
+    series = dict(series)
+    series["input"] = {"setter": {"name": "set_engine_b1"}}
+
+    report = validate_series_bindings(graph, {"schema_version": "1.6.0", "series": [series]})
+
+    assert report["ok"] is False
+    assert any(i["code"] == "non_leaf_input_overlap" for i in report["issues"])
+
+
+def test_validate_override_requires_at_least_one_formula_node(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, ["Inputs!A1"], load_values=True)
+    series = {
+        "id": "leaf_only_override",
+        "sheet": "Inputs",
+        "data_range": "Inputs!A1",
+        "layout": "scalar",
+        "input": {"mode": "override", "setter": {"name": "set_inputs_a1"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "dtype": "float", "bind": {"kind": "data_cell"}},
+            "dimensions": [],
+        },
+    }
+
+    report = validate_series_bindings(graph, {"schema_version": "1.6.0", "series": [series]})
+
+    assert report["ok"] is False
+    assert any(i["code"] == "no_formula_override_targets" for i in report["issues"])
+
+
+def test_validate_override_mode_accepts_mixed_leaf_and_formula_cells(tmp_path: Path) -> None:
+    wb_path = tmp_path / "mixed.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number("A1", 1)
+    ws.write_formula("B1", "=A1+1")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Sheet1!A1", "Sheet1!B1"], load_values=True)
+    series = {
+        "id": "mixed_override",
+        "sheet": "Sheet1",
+        "data_range": "Sheet1!A1:B1",
+        "layout": "series",
+        "input": {"mode": "override", "setter": {"name": "set_mixed"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "dtype": "float", "bind": {"kind": "data_cell"}},
+            "dimensions": [
+                {
+                    "concept": "IDX",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "read": "int"},
+                }
+            ],
+        },
+        "key": ["IDX"],
+    }
+
+    report = validate_series_bindings(graph, {"schema_version": "1.6.0", "series": [series]})
+
+    assert report["ok"] is True
+
+
+def test_derive_input_series_from_override_binding(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    bindings = _override_bindings()
+
+    input_series = derive_input_series(graph, bindings, workbook=wb_path)
+
+    assert len(input_series) == 1
+    assert input_series[0]["setter_name"] == "set_engine_b1"
+    assert [cell["address"] for cell in input_series[0]["cells"]] == ["Engine!B1"]
+
+
+def test_override_setter_invalidates_parent_cache(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    bindings = _override_bindings()
+
+    def make_resolver() -> Callable[[str], Callable[[EvalContext], CellValue] | None]:
+        def _engine_b1(ctx: EvalContext) -> CellValue:
+            return cast(CellValue, cast(float, xl_cell(ctx, "Inputs!A1")) + 1)
+
+        def _output_c1(ctx: EvalContext) -> CellValue:
+            return cast(CellValue, cast(float, xl_cell(ctx, "Engine!B1")) * 2)
+
+        impls: dict[str, Callable[[EvalContext], CellValue]] = {
+            "Engine!B1": _engine_b1,
+            "Output!C1": _output_c1,
+        }
+        return lambda addr: impls.get(addr)
+
+    lines = emit_setters_block(graph, wb_path, bindings, include_helpers=True)
+    ns: dict[str, object] = {"EvalContext": EvalContext, "coerce_inputs_dict": coerce_inputs_dict}
+    exec("\n".join(lines), ns)
+
+    resolver = make_resolver()
+    ctx = EvalContext(inputs=coerce_inputs_dict({"Inputs!A1": 10}), resolver=resolver)
+    assert xl_cell(ctx, "Output!C1") == 22
+
+    setter = cast(Callable[[EvalContext, object], None], ns["set_engine_b1"])
+    setter(ctx, 99)
+
+    assert ctx.inputs["Engine!B1"] == 99
+    assert "Engine!B1" not in ctx.cache
+    assert "Output!C1" not in ctx.cache
+    assert xl_cell(ctx, "Output!C1") == 198

--- a/tests/unit/series_bindings/test_input_override.py
+++ b/tests/unit/series_bindings/test_input_override.py
@@ -224,6 +224,73 @@ def test_validate_override_mode_accepts_mixed_leaf_and_formula_cells(tmp_path: P
     assert report["ok"] is True
 
 
+def test_resolve_input_override_mixed_range_includes_leaf_and_formula(tmp_path: Path) -> None:
+    wb_path = tmp_path / "mixed.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write_number("A1", 1)
+    ws.write_number("B1", 2)
+    ws.write_formula("C1", "=A1+1")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Sheet1!A1", "Sheet1!C1"], load_values=True)
+    series = {
+        "id": "mixed_override",
+        "sheet": "Sheet1",
+        "data_range": "Sheet1!A1:C1",
+        "layout": "series",
+        "input": {"mode": "override", "setter": {"name": "set_mixed"}},
+        "structure": {
+            "measure": {"concept": "OBS_VALUE", "dtype": "float", "bind": {"kind": "data_cell"}},
+            "dimensions": [
+                {
+                    "concept": "IDX",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                }
+            ],
+        },
+        "key": ["IDX"],
+    }
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="input")
+
+    assert [leaf["address"] for leaf in resolved["leaves"]] == ["Sheet1!A1", "Sheet1!C1"]
+
+
+def test_validate_rejects_unknown_input_mode(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    series = _override_scalar_series()
+    series = dict(series)
+    series["input"] = {"mode": "replace", "setter": {"name": "set_engine_b1"}}
+
+    report = validate_series_bindings(graph, {"schema_version": "1.6.0", "series": [series]})
+
+    assert report["ok"] is False
+    assert any(i["code"] == "invalid_input_mode" for i in report["issues"])
+
+
+def test_resolve_input_override_respects_export_closure(tmp_path: Path) -> None:
+    wb_path = tmp_path / "override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    series = _override_scalar_series()
+
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        direction="input",
+        export_addresses=frozenset({"Output!C1"}),
+    )
+
+    assert resolved["leaves"] == []
+    assert any(i["code"] == "no_resolved_cells" for i in resolved["issues"])
+
+
 def test_derive_input_series_from_override_binding(tmp_path: Path) -> None:
     wb_path = tmp_path / "override.xlsx"
     _write_override_workbook(wb_path)

--- a/tests/unit/series_bindings/test_schema.py
+++ b/tests/unit/series_bindings/test_schema.py
@@ -700,3 +700,28 @@ def test_schema_rejects_non_enum_datetime_tokens(
     assert errors
     with pytest.raises(SeriesBindingsSchemaError):
         validate_bindings_document(doc)
+
+
+def test_schema_accepts_input_mode_override() -> None:
+    doc = {
+        "schema_version": "1.6.0",
+        "series": [
+            {
+                "id": "formula_override",
+                "sheet": "Engine",
+                "data_range": "Engine!B1",
+                "layout": "scalar",
+                "input": {
+                    "mode": "override",
+                    "setter": {"name": "set_formula_override"},
+                },
+                "structure": {
+                    "measure": {"concept": "OBS_VALUE", "bind": {"kind": "data_cell"}},
+                    "dimensions": [],
+                },
+                "key": [],
+            }
+        ],
+    }
+    bindings = validate_bindings_document(doc)
+    assert bindings["series"][0]["input"]["mode"] == "override"

--- a/tests/unit/series_bindings/test_smoke.py
+++ b/tests/unit/series_bindings/test_smoke.py
@@ -18,6 +18,11 @@ from excel_grapher.series_bindings.workflow import (
 )
 from tests.integration.user_flows.utils import write_ffv2_workbook
 from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
+from tests.unit.series_bindings.test_input_override import (
+    _manual_override_graph,
+    _override_bindings,
+    _write_override_workbook,
+)
 
 FFV2_BINDINGS = FIXTURES / "ffv2.yaml"
 BORVELIA_BINDINGS = FIXTURES / "borvelia_primary_balance.yaml"
@@ -93,6 +98,27 @@ def test_smoke_test_setters_positional_and_dataframe_inputs(tmp_path: Path) -> N
         workbook=workbook,
         module_dir=tmp_path / "bindings_module",
         package_name="bindings_module",
+    )
+
+
+def test_smoke_test_override_formula_setter(tmp_path: Path) -> None:
+    workbook = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(workbook)
+    graph = _manual_override_graph()
+    bindings = _override_bindings()
+    files = generate_bindings_modules(
+        graph,
+        targets=["Output!C1", "Engine!B1"],
+        bindings=bindings,
+        workbook=workbook,
+    )
+    smoke_test_bindings_module(
+        files,
+        bindings=bindings,
+        graph=graph,
+        workbook=workbook,
+        module_dir=tmp_path / "bindings_override_module",
+        package_name="bindings_override_module",
     )
 
 

--- a/tests/unit/series_bindings/test_validate.py
+++ b/tests/unit/series_bindings/test_validate.py
@@ -90,8 +90,8 @@ def test_validate_reports_non_leaf_formula_cell(tmp_path: Path) -> None:
     )
     bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
     report = validate_series_bindings(graph, bindings, workbook=wb_path)
-    assert report["ok"] is True
-    assert not any(i["code"] == "not_a_leaf" for i in report["issues"])
+    assert report["ok"] is False
+    assert any(i["code"] == "non_leaf_input_overlap" for i in report["issues"])
 
 
 def test_validate_warns_when_measure_dtype_and_read_disagree(tmp_path: Path) -> None:

--- a/tests/unit/series_bindings/test_versions.py
+++ b/tests/unit/series_bindings/test_versions.py
@@ -17,7 +17,7 @@ from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
 
 
 def test_supported_schema_versions() -> None:
-    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"})
+    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"})
     assert expected == SUPPORTED_SCHEMA_VERSIONS
 
 

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -91,6 +91,43 @@ optional direction blocks:
 
 At least one of `input` or `output` is required per series (legacy top-level `setter` is normalized to `input.setter`; legacy `layout: row_series` is normalized to `series`).
 
+### Input mode: `leaf` vs `override` (schema 1.6.0+)
+
+By default, input bindings use **`input.mode: leaf`**: every cell in `data_range` must be a **graph leaf** (a value cell with no formula in the dependency graph). If `data_range` includes a formula cell, validation fails with `non_leaf_input_overlap` instead of silently skipping it.
+
+Use **`input.mode: override`** for the Excel **typed-over-formula** pattern: cells that keep a formula in the workbook but expose a public setter that displaces the computed value until changed. Override bindings:
+
+- Resolve **graph nodes** in `data_range` (formula cells and, when mixed, leaf cells too).
+- Require **at least one formula cell** in the range (`no_formula_override_targets` otherwise).
+- Write through generated `set_*` functions via `ctx.set_inputs`; the export runtime returns the override value before re-evaluating the cell formula.
+- Leave graph formulas and dependency edges unchanged (evaluation-time displacement only).
+
+```yaml
+schema_version: "1.6.0"
+series:
+  - id: productivity_turning_point
+    sheet: Productivity
+    data_range: Productivity!J21
+    layout: scalar
+    input:
+      mode: override
+      setter:
+        name: set_productivity_turning_point
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: { kind: data_cell }
+      dimensions: []
+    key: []
+```
+
+Example manifest: [formula_override.bindings.yaml](https://github.com/Teal-Insights/excel-grapher/blob/main/examples/micro_workbooks/formula_override.bindings.yaml).
+
+**Migration (all schema versions):** Leaf-mode bindings that accidentally included formula cells previously emitted a `partial_graph_overlap` warning and dropped those cells. They now **error** at validation. Either narrow `data_range` to leaves only or declare `input.mode: override`.
+
+**Evaluator note:** Durable override setters (this feature) differ from transient per-call overrides tracked in [issue #122](https://github.com/Teal-Insights/excel-grapher/issues/122). `FormulaEvaluator` does not yet expose equivalent durable setter semantics.
+
 ## `data_range` addressing
 
 Expansion uses the same path as graph **targets** (`expand_targets_to_roots`), including:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `input.mode: override` to series bindings (schema **1.6.0**) so manifests can declare public setters on **non-leaf formula cells** — the Excel "typed-over-formula" pattern needed by Q-CRAFT productivity setters.

Override bindings resolve graph nodes from `data_range` (leaves and formula cells). Generated `set_*` functions write via `EvalContext.set_inputs`; export runtime input precedence suppresses formula evaluation and invalidates dependent caches.

## Schema

```yaml
input:
  mode: override   # default: leaf
  setter:
    name: set_productivity_turning_point
```

## Validation

- **Leaf mode (default):** `non_leaf_input_overlap` **error** when `data_range` includes non-leaf graph cells (replaces silent warn-and-drop).
- **Override mode:** requires **at least one formula cell** in `data_range` (`no_formula_override_targets` error otherwise). Mixed leaf + formula ranges are allowed.

## Tests

- Scalar and series override resolution/codegen
- Leaf-mode validation error on accidental non-leaf overlap
- Override setter invalidates parent cache (same contract as leaf setters)
- Schema acceptance for `input.mode: override`

## Notes

- Evaluator parity remains tracked in #122; export path is complete.
- Graph formula metadata and dependency edges are unchanged — overrides are evaluation-time value displacements via `ctx.inputs`.

Closes #355.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97e3fb84-8a45-4517-a0ad-8de0bdc28a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97e3fb84-8a45-4517-a0ad-8de0bdc28a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

