### PR TITLE
feat(bindings): support internal series declarations for formula-cell key triangulation

### DIFF
--- a/examples/micro_workbooks/series_bindings.qmd
+++ b/examples/micro_workbooks/series_bindings.qmd
@@ -16,6 +16,7 @@ import yaml
 from excel_grapher.grapher import create_dependency_graph, DependencyGraph
 from excel_grapher.series_bindings import (
     derive_input_series,
+    derive_internal_series,
     derive_output_series,
     expand_data_range,
     resolve_series_binding,
@@ -476,3 +477,68 @@ ctx = make_context()
 set_borvelia_primary_balance(ctx, [{"TIME_PERIOD": 4, "OBS_VALUE": 7.5}])
 records = compute_borvelia_primary_balance(ctx=ctx)
 ```
+
+## 03. Internal formula-cell triangulation (`internal: {}`)
+
+Schema **1.7.0** adds `internal: {}` for formula cells that need dimensional keys without public `set_*` or `compute_*` APIs. Pipelines can shard these as `internals.bindings.yaml` alongside input and output manifests.
+
+Example fixture: [internal_engine_row.yaml](../../tests/fixtures/series_bindings/internal_engine_row.yaml) (uses [formula_override.xlsx](formula_override.xlsx)).
+
+```yaml
+schema_version: "1.7.0"
+workbook: formula_override.xlsx
+series:
+  - id: engine_primary_balance
+    sheet: Engine
+    data_range: Engine!B2:D2
+    layout: series
+    internal: {}
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: { kind: data_cell, read: float }
+      dimensions:
+        - concept: TIME_PERIOD
+          role: key
+          scope: cell
+          bind: { kind: column_header, header_row: 1, read: int }
+    key: [TIME_PERIOD]
+    series_context:
+      INDICATOR: Primary balance
+    validation:
+      intersect_graph_formulas: true
+      require_unique_key: true
+```
+
+```{python}
+from excel_grapher.series_bindings import load_series_bindings, validate_bindings_document
+
+internal_fixture = Path("../../tests/fixtures/series_bindings/internal_engine_row.yaml")
+internal_bindings = load_series_bindings(internal_fixture)
+validate_bindings_document(internal_bindings)
+
+override_graph = create_dependency_graph(
+    Path("formula_override.xlsx"),
+    ["Engine!B2", "Engine!C2", "Engine!D2"],
+    load_values=True,
+)
+internal_series = derive_internal_series(
+    override_graph,
+    internal_bindings,
+    workbook=Path("formula_override.xlsx"),
+)
+print(pformat(internal_series[0]["cells"][:2]))
+```
+
+Internal bindings intersect `data_range` with **formula graph nodes** (default). They emit **no codegen**; validate first, then derive:
+
+```python
+report = validate_series_bindings(
+    override_graph,
+    internal_bindings,
+    workbook=Path("formula_override.xlsx"),
+)
+assert report["ok"]
+```
+

--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -44,6 +44,7 @@ from excel_grapher.series_bindings.groups import (
 )
 from excel_grapher.series_bindings.input_coerce import coerce_setter_input
 from excel_grapher.series_bindings.input_series import derive_input_series
+from excel_grapher.series_bindings.internal_series import derive_internal_series
 from excel_grapher.series_bindings.load import (
     SeriesBindingsLoadError,
     load_series_bindings,
@@ -52,6 +53,7 @@ from excel_grapher.series_bindings.load import (
 )
 from excel_grapher.series_bindings.normalize import (
     has_input_direction,
+    has_internal_direction,
     has_output_direction,
     merge_series_entries,
     normalize_bindings_document,
@@ -75,6 +77,8 @@ from excel_grapher.series_bindings.setter_input_types import Layout, SeriesInput
 from excel_grapher.series_bindings.types import (
     InputSeries,
     InputSeriesCell,
+    InternalSeries,
+    InternalSeriesCell,
     LeafResolution,
     OutputSeries,
     OutputSeriesCell,
@@ -116,6 +120,8 @@ def __getattr__(name: str):
 __all__ = [
     "InputSeries",
     "InputSeriesCell",
+    "InternalSeries",
+    "InternalSeriesCell",
     "OutputSeries",
     "OutputSeriesCell",
     "Record",
@@ -162,6 +168,7 @@ __all__ = [
     "SeriesInput",
     "coerce_setter_input",
     "derive_input_series",
+    "derive_internal_series",
     "derive_output_series",
     "emit_compute_function",
     "emit_computes_block",
@@ -171,6 +178,7 @@ __all__ = [
     "emit_setters_block",
     "generate_computes_module",
     "has_input_direction",
+    "has_internal_direction",
     "has_output_direction",
     "merge_series_entries",
     "normalize_bindings_document",

--- a/excel_grapher/series_bindings/derive_common.py
+++ b/excel_grapher/series_bindings/derive_common.py
@@ -1,0 +1,67 @@
+"""Shared helpers for deriving typed series from binding resolution reports."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.resolve import BindingDirection, resolve_series_bindings
+from excel_grapher.series_bindings.types import (
+    InputSeriesCell,
+    SeriesResolution,
+    WorkbookSeriesBindings,
+)
+
+T = TypeVar("T")
+
+
+def series_entries_by_id(
+    bindings: WorkbookSeriesBindings,
+    *,
+    has_direction: Callable[[dict[str, Any]], bool],
+) -> dict[str, dict[str, Any]]:
+    """Index manifest series entries that declare the requested direction."""
+    return {
+        str(series["id"]): series
+        for series in bindings.get("series", [])
+        if isinstance(series, dict) and "id" in series and has_direction(series)
+    }
+
+
+def resolved_series_cells(resolved: SeriesResolution) -> list[InputSeriesCell]:
+    """Map resolved leaves to the shared per-cell payload used by derive APIs."""
+    return [
+        {
+            "address": leaf["address"],
+            "coordinates": leaf["coordinates"],
+            "key": leaf["key"],
+            "record": leaf["record"],
+        }
+        for leaf in resolved["leaves"]
+    ]
+
+
+def derive_series_for_direction(
+    graph: DependencyGraph,
+    bindings: WorkbookSeriesBindings,
+    *,
+    workbook: Path | str,
+    direction: BindingDirection,
+    has_direction: Callable[[dict[str, Any]], bool],
+    build_series: Callable[[SeriesResolution, dict[str, Any], list[InputSeriesCell]], T],
+) -> list[T]:
+    """Resolve and materialize one typed series object per manifest entry."""
+    report = resolve_series_bindings(graph, bindings, workbook=workbook, direction=direction)
+    series_by_id = series_entries_by_id(bindings, has_direction=has_direction)
+
+    derived: list[T] = []
+    for resolved in report["series"]:
+        if not resolved["leaves"]:
+            continue
+        series = series_by_id.get(resolved["series_id"])
+        if series is None:
+            continue
+        derived.append(build_series(resolved, series, resolved_series_cells(resolved)))
+    return derived

--- a/excel_grapher/series_bindings/graph_predicates.py
+++ b/excel_grapher/series_bindings/graph_predicates.py
@@ -1,0 +1,22 @@
+"""Shared dependency-graph membership predicates for series binding resolution."""
+
+from __future__ import annotations
+
+from excel_grapher.grapher.graph import DependencyGraph
+
+
+def is_graph_node(graph: DependencyGraph, address: str) -> bool:
+    """Return True when `address` is present in the dependency graph."""
+    return address in graph
+
+
+def is_graph_leaf(graph: DependencyGraph, address: str) -> bool:
+    """Return True when `address` is a graph leaf (value cell with no formula)."""
+    node = graph.get_node(address) if address in graph else None
+    return bool(node is not None and node.is_leaf)
+
+
+def is_graph_formula_node(graph: DependencyGraph, address: str) -> bool:
+    """Return True when `address` is a graph node with a workbook formula."""
+    node = graph.get_node(address) if address in graph else None
+    return bool(node is not None and node.formula is not None)

--- a/excel_grapher/series_bindings/input_series.py
+++ b/excel_grapher/series_bindings/input_series.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.derive_common import derive_series_for_direction
 from excel_grapher.series_bindings.normalize import has_input_direction
-from excel_grapher.series_bindings.resolve import resolve_series_bindings
 from excel_grapher.series_bindings.types import (
     InputSeries,
     InputSeriesCell,
+    SeriesResolution,
     WorkbookSeriesBindings,
 )
 
@@ -19,6 +20,21 @@ def _setter_name(series: dict[str, Any]) -> str:
     input_block = series.get("input") or {}
     setter = input_block.get("setter") or series.get("setter") or {}
     return str(setter.get("name", f"set_{series.get('id', 'series')}"))
+
+
+def _build_input_series(
+    resolved: SeriesResolution,
+    series: dict[str, Any],
+    cells: list[InputSeriesCell],
+) -> InputSeries:
+    return {
+        "id": resolved["series_id"],
+        "setter_name": _setter_name(series),
+        "key_fields": [str(field) for field in (series.get("key") or [])],
+        "requires_address": resolved["requires_address"],
+        "cells": cells,
+        "issues": resolved["issues"],
+    }
 
 
 def derive_input_series(
@@ -33,37 +49,11 @@ def derive_input_series(
     corresponds to one manifest `series[]` entry, and each cell corresponds to
     a resolved graph leaf or override cell participating in that series.
     """
-    report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="input")
-    series_by_id = {
-        str(series["id"]): series
-        for series in bindings.get("series", [])
-        if isinstance(series, dict) and "id" in series and has_input_direction(series)
-    }
-
-    input_series: list[InputSeries] = []
-    for resolved in report["series"]:
-        if not resolved["leaves"]:
-            continue
-        series = series_by_id.get(resolved["series_id"])
-        if series is None:
-            continue
-        cells: list[InputSeriesCell] = [
-            {
-                "address": leaf["address"],
-                "coordinates": leaf["coordinates"],
-                "key": leaf["key"],
-                "record": leaf["record"],
-            }
-            for leaf in resolved["leaves"]
-        ]
-        input_series.append(
-            {
-                "id": resolved["series_id"],
-                "setter_name": _setter_name(series),
-                "key_fields": [str(field) for field in (series.get("key") or [])],
-                "requires_address": resolved["requires_address"],
-                "cells": cells,
-                "issues": resolved["issues"],
-            }
-        )
-    return input_series
+    return derive_series_for_direction(
+        graph,
+        bindings,
+        workbook=workbook,
+        direction="input",
+        has_direction=has_input_direction,
+        build_series=_build_input_series,
+    )

--- a/excel_grapher/series_bindings/internal_series.py
+++ b/excel_grapher/series_bindings/internal_series.py
@@ -1,0 +1,56 @@
+"""Derive internal series from explicit series binding manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.normalize import has_internal_direction
+from excel_grapher.series_bindings.resolve import resolve_series_bindings
+from excel_grapher.series_bindings.types import (
+    InternalSeries,
+    InternalSeriesCell,
+    WorkbookSeriesBindings,
+)
+
+
+def derive_internal_series(
+    graph: DependencyGraph,
+    bindings: WorkbookSeriesBindings,
+    *,
+    workbook: Path | str,
+) -> list[InternalSeries]:
+    """Return one internal series per binding entry with internal direction and graph overlap."""
+    report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="internal")
+    series_by_id = {
+        str(series["id"]): series
+        for series in bindings.get("series", [])
+        if isinstance(series, dict) and "id" in series and has_internal_direction(series)
+    }
+
+    internal_series: list[InternalSeries] = []
+    for resolved in report["series"]:
+        if not resolved["leaves"]:
+            continue
+        series = series_by_id.get(resolved["series_id"])
+        if series is None:
+            continue
+        cells: list[InternalSeriesCell] = [
+            {
+                "address": leaf["address"],
+                "coordinates": leaf["coordinates"],
+                "key": leaf["key"],
+                "record": leaf["record"],
+            }
+            for leaf in resolved["leaves"]
+        ]
+        internal_series.append(
+            {
+                "id": resolved["series_id"],
+                "key_fields": [str(field) for field in (series.get("key") or [])],
+                "requires_address": resolved["requires_address"],
+                "cells": cells,
+                "issues": resolved["issues"],
+            }
+        )
+    return internal_series

--- a/excel_grapher/series_bindings/internal_series.py
+++ b/excel_grapher/series_bindings/internal_series.py
@@ -3,15 +3,31 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.derive_common import derive_series_for_direction
 from excel_grapher.series_bindings.normalize import has_internal_direction
-from excel_grapher.series_bindings.resolve import resolve_series_bindings
 from excel_grapher.series_bindings.types import (
     InternalSeries,
     InternalSeriesCell,
+    SeriesResolution,
     WorkbookSeriesBindings,
 )
+
+
+def _build_internal_series(
+    resolved: SeriesResolution,
+    series: dict[str, Any],
+    cells: list[InternalSeriesCell],
+) -> InternalSeries:
+    return {
+        "id": resolved["series_id"],
+        "key_fields": [str(field) for field in (series.get("key") or [])],
+        "requires_address": resolved["requires_address"],
+        "cells": cells,
+        "issues": resolved["issues"],
+    }
 
 
 def derive_internal_series(
@@ -20,37 +36,17 @@ def derive_internal_series(
     *,
     workbook: Path | str,
 ) -> list[InternalSeries]:
-    """Return one internal series per binding entry with internal direction and graph overlap."""
-    report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="internal")
-    series_by_id = {
-        str(series["id"]): series
-        for series in bindings.get("series", [])
-        if isinstance(series, dict) and "id" in series and has_internal_direction(series)
-    }
+    """Return internal series for formula-cell key triangulation without public I/O APIs.
 
-    internal_series: list[InternalSeries] = []
-    for resolved in report["series"]:
-        if not resolved["leaves"]:
-            continue
-        series = series_by_id.get(resolved["series_id"])
-        if series is None:
-            continue
-        cells: list[InternalSeriesCell] = [
-            {
-                "address": leaf["address"],
-                "coordinates": leaf["coordinates"],
-                "key": leaf["key"],
-                "record": leaf["record"],
-            }
-            for leaf in resolved["leaves"]
-        ]
-        internal_series.append(
-            {
-                "id": resolved["series_id"],
-                "key_fields": [str(field) for field in (series.get("key") or [])],
-                "requires_address": resolved["requires_address"],
-                "cells": cells,
-                "issues": resolved["issues"],
-            }
-        )
-    return internal_series
+    Each manifest `series[]` entry with `internal: {}` resolves to per-cell
+    `{address, key, record}` for formula nodes in `data_range`. No `set_*` or
+    `compute_*` codegen is emitted for these entries.
+    """
+    return derive_series_for_direction(
+        graph,
+        bindings,
+        workbook=workbook,
+        direction="internal",
+        has_direction=has_internal_direction,
+        build_series=_build_internal_series,
+    )

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -57,17 +57,24 @@ def is_override_input(series: dict[str, Any]) -> bool:
     return input_mode(series) == "override"
 
 
-def effective_validation(series: dict[str, Any]) -> dict[str, Any]:
-    """Return series validation flags with override-mode defaults applied."""
-    validation = dict(series.get("validation") or {})
-    if is_override_input(series):
-        validation["intersect_graph_leaves"] = False
-    return validation
-
-
 def has_output_direction(series: dict[str, Any]) -> bool:
     output = series.get("output")
     return isinstance(output, dict) and isinstance(output.get("compute"), dict)
+
+
+def has_internal_direction(series: dict[str, Any]) -> bool:
+    """Return True when the series declares internal (non-I/O) binding semantics."""
+    return "internal" in series and isinstance(series.get("internal"), dict)
+
+
+def effective_validation(series: dict[str, Any]) -> dict[str, Any]:
+    """Return series validation flags with direction-specific defaults applied."""
+    validation = dict(series.get("validation") or {})
+    if is_override_input(series):
+        validation["intersect_graph_leaves"] = False
+    if has_internal_direction(series) and "intersect_graph_formulas" not in validation:
+        validation["intersect_graph_formulas"] = True
+    return validation
 
 
 def normalize_series_entry(series: dict[str, Any]) -> dict[str, Any]:
@@ -132,7 +139,7 @@ def merge_series_entries(
         )
 
     merged = dict(left)
-    for direction in ("input", "output"):
+    for direction in ("input", "output", "internal"):
         if direction not in right:
             continue
         if direction in merged and merged[direction] != right[direction]:

--- a/excel_grapher/series_bindings/output_series.py
+++ b/excel_grapher/series_bindings/output_series.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import Any
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.derive_common import derive_series_for_direction
 from excel_grapher.series_bindings.normalize import has_output_direction
-from excel_grapher.series_bindings.resolve import resolve_series_bindings
 from excel_grapher.series_bindings.types import (
     OutputSeries,
     OutputSeriesCell,
+    SeriesResolution,
     WorkbookSeriesBindings,
 )
 
@@ -21,6 +22,20 @@ def _compute_name(series: dict[str, Any]) -> str:
     return str(compute.get("name", f"compute_{series.get('id', 'series')}"))
 
 
+def _build_output_series(
+    resolved: SeriesResolution,
+    series: dict[str, Any],
+    cells: list[OutputSeriesCell],
+) -> OutputSeries:
+    return {
+        "id": resolved["series_id"],
+        "compute_name": _compute_name(series),
+        "key_fields": [str(field) for field in (series.get("key") or [])],
+        "cells": cells,
+        "issues": resolved["issues"],
+    }
+
+
 def derive_output_series(
     graph: DependencyGraph,
     bindings: WorkbookSeriesBindings,
@@ -28,36 +43,11 @@ def derive_output_series(
     workbook: Path | str,
 ) -> list[OutputSeries]:
     """Return one output series per binding entry with output.compute and graph overlap."""
-    report = resolve_series_bindings(graph, bindings, workbook=workbook, direction="output")
-    series_by_id = {
-        str(series["id"]): series
-        for series in bindings.get("series", [])
-        if isinstance(series, dict) and "id" in series and has_output_direction(series)
-    }
-
-    output_series: list[OutputSeries] = []
-    for resolved in report["series"]:
-        if not resolved["leaves"]:
-            continue
-        series = series_by_id.get(resolved["series_id"])
-        if series is None:
-            continue
-        cells: list[OutputSeriesCell] = [
-            {
-                "address": leaf["address"],
-                "coordinates": leaf["coordinates"],
-                "key": leaf["key"],
-                "record": leaf["record"],
-            }
-            for leaf in resolved["leaves"]
-        ]
-        output_series.append(
-            {
-                "id": resolved["series_id"],
-                "compute_name": _compute_name(series),
-                "key_fields": [str(field) for field in (series.get("key") or [])],
-                "cells": cells,
-                "issues": resolved["issues"],
-            }
-        )
-    return output_series
+    return derive_series_for_direction(
+        graph,
+        bindings,
+        workbook=workbook,
+        direction="output",
+        has_direction=has_output_direction,
+        build_series=_build_output_series,
+    )

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -25,6 +25,7 @@ from excel_grapher.series_bindings.normalize import (
     InputMode,
     effective_validation,
     has_input_direction,
+    has_internal_direction,
     has_output_direction,
     input_mode,
 )
@@ -39,7 +40,7 @@ from excel_grapher.series_bindings.types import (
     make_issue,
 )
 
-BindingDirection = Literal["input", "output"]
+BindingDirection = Literal["input", "output", "internal"]
 
 _TRAILING_UNIT_RE = re.compile(r"\s*\([^)]*\)\s*$")
 
@@ -459,6 +460,11 @@ def _is_graph_node(graph: DependencyGraph, address: str) -> bool:
     return address in graph
 
 
+def _is_graph_formula(graph: DependencyGraph, address: str) -> bool:
+    node = graph.get_node(address) if address in graph else None
+    return bool(node is not None and node.formula is not None)
+
+
 def warn_series_resolution_issues(resolved: SeriesResolution, *, stacklevel: int = 3) -> None:
     """Emit Python warnings for partial-overlap issues on a binding resolution."""
     for issue in resolved["issues"]:
@@ -508,6 +514,35 @@ def _select_input_addresses(
     return selected, issues
 
 
+def _select_internal_addresses(
+    graph: DependencyGraph,
+    expanded_addresses: list[str],
+    *,
+    validation: dict[str, Any],
+    series_id: str,
+    candidate_addresses: list[str] | None = None,
+) -> tuple[list[str], list[ResolutionIssue]]:
+    """Select internal binding addresses and report skipped non-formula cells."""
+    issues: list[ResolutionIssue] = []
+    pool = expanded_addresses if candidate_addresses is None else candidate_addresses
+    intersect = bool(validation.get("intersect_graph_formulas", True))
+    if not intersect:
+        selected = list(pool)
+    else:
+        selected = [address for address in pool if _is_graph_formula(graph, address)]
+    skipped = len(pool) - len(selected)
+    if skipped > 0 and bool(validation.get("warn_on_partial_overlap", True)):
+        issues.append(
+            make_issue(
+                "warning",
+                "partial_graph_overlap",
+                f"Skipped {skipped} cell(s) in data_range not graph formula cells",
+                series_id=series_id,
+            )
+        )
+    return selected, issues
+
+
 def _select_addresses(
     graph: DependencyGraph,
     expanded_addresses: list[str],
@@ -553,6 +588,16 @@ def _select_addresses(
             graph,
             expanded_addresses,
             mode=input_binding_mode,
+            validation=validation,
+            series_id=series_id,
+        )
+        issues.extend(overlap_issues)
+        return selected, issues
+
+    if direction == "internal":
+        selected, overlap_issues = _select_internal_addresses(
+            graph,
+            expanded_addresses,
             validation=validation,
             series_id=series_id,
         )
@@ -796,6 +841,8 @@ def resolve_series_binding(
 def _series_supports_direction(series: dict[str, Any], direction: BindingDirection) -> bool:
     if direction == "input":
         return has_input_direction(series)
+    if direction == "internal":
+        return has_internal_direction(series)
     return has_output_direction(series)
 
 

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -21,6 +21,11 @@ from excel_grapher.series_bindings.geometry import (
     expand_row_specs,
     parse_value_map,
 )
+from excel_grapher.series_bindings.graph_predicates import (
+    is_graph_formula_node,
+    is_graph_leaf,
+    is_graph_node,
+)
 from excel_grapher.series_bindings.normalize import (
     InputMode,
     effective_validation,
@@ -451,20 +456,6 @@ def _extract_key(coordinates: dict[str, Scalar], key_concepts: list[str]) -> dic
     return {concept: coordinates[concept] for concept in key_concepts if concept in coordinates}
 
 
-def _is_graph_leaf(graph: DependencyGraph, address: str) -> bool:
-    node = graph.get_node(address) if address in graph else None
-    return bool(node is not None and node.is_leaf)
-
-
-def _is_graph_node(graph: DependencyGraph, address: str) -> bool:
-    return address in graph
-
-
-def _is_graph_formula(graph: DependencyGraph, address: str) -> bool:
-    node = graph.get_node(address) if address in graph else None
-    return bool(node is not None and node.formula is not None)
-
-
 def warn_series_resolution_issues(resolved: SeriesResolution, *, stacklevel: int = 3) -> None:
     """Emit Python warnings for partial-overlap issues on a binding resolution."""
     for issue in resolved["issues"]:
@@ -493,13 +484,13 @@ def _select_input_addresses(
     issues: list[ResolutionIssue] = []
     pool = expanded_addresses if candidate_addresses is None else candidate_addresses
     if mode == "override":
-        selected = [address for address in pool if _is_graph_node(graph, address)]
+        selected = [address for address in pool if is_graph_node(graph, address)]
     else:
         intersect = bool(validation.get("intersect_graph_leaves", True))
         if not intersect:
             selected = list(pool)
         else:
-            selected = [address for address in pool if _is_graph_leaf(graph, address)]
+            selected = [address for address in pool if is_graph_leaf(graph, address)]
     if mode != "override":
         skipped = len(pool) - len(selected)
         if skipped > 0 and bool(validation.get("warn_on_partial_overlap", True)):
@@ -529,7 +520,7 @@ def _select_internal_addresses(
     if not intersect:
         selected = list(pool)
     else:
-        selected = [address for address in pool if _is_graph_formula(graph, address)]
+        selected = [address for address in pool if is_graph_formula_node(graph, address)]
     skipped = len(pool) - len(selected)
     if skipped > 0 and bool(validation.get("warn_on_partial_overlap", True)):
         issues.append(
@@ -607,7 +598,7 @@ def _select_addresses(
     intersect = bool(validation.get("intersect_graph_nodes", True))
     if not intersect:
         return expanded_addresses, issues
-    selected = [address for address in expanded_addresses if _is_graph_node(graph, address)]
+    selected = [address for address in expanded_addresses if is_graph_node(graph, address)]
 
     skipped = len(expanded_addresses) - len(selected)
     if skipped > 0 and bool(validation.get("warn_on_partial_overlap", True)):

--- a/excel_grapher/series_bindings/schema.py
+++ b/excel_grapher/series_bindings/schema.py
@@ -22,6 +22,7 @@ _FIELD_HINTS: dict[str, str] = {
     "layout": "Optional layout intent: scalar, series, or matrix.",
     "input": "Add an input block with a setter for editable series.",
     "output": "Add an output block with a compute for derived series.",
+    "internal": "Add an internal block for non-I/O formula-cell key triangulation.",
 }
 
 

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters)."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"],
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters). 1.7.0: internal direction for non-I/O formula-cell key triangulation (intersect_graph_formulas validation)."
     },
     "workbook": {
       "type": "string",
@@ -392,6 +392,11 @@
         "compute": { "$ref": "#/$defs/Compute" }
       }
     },
+    "InternalDirection": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Marks a non-I/O binding for formula-cell key triangulation. No set_* or compute_* codegen is emitted."
+    },
     "Setter": {
       "type": "object",
       "additionalProperties": false,
@@ -465,6 +470,7 @@
         },
         "input": { "$ref": "#/$defs/InputDirection" },
         "output": { "$ref": "#/$defs/OutputDirection" },
+        "internal": { "$ref": "#/$defs/InternalDirection" },
         "setter": {
           "$ref": "#/$defs/Setter",
           "description": "Deprecated: use input.setter. Accepted for backward compatibility and normalized at load time."
@@ -516,6 +522,7 @@
       },
       "allOf": [
         { "$ref": "#/$defs/SeriesBindingDirectionRules" },
+        { "$ref": "#/$defs/SeriesBindingInternalExclusivity" },
         { "$ref": "#/$defs/SeriesBindingLayoutKeyRules" },
         { "$ref": "#/$defs/SeriesBindingMvpRules" },
         { "$ref": "#/$defs/SeriesBindingMatrixRules" }
@@ -549,12 +556,26 @@
       }
     },
     "SeriesBindingDirectionRules": {
-      "description": "Each series must declare at least one of input or output (legacy top-level setter counts as input).",
+      "description": "Each series must declare at least one of input, output, internal, or legacy setter.",
       "anyOf": [
         { "required": ["input"] },
         { "required": ["output"] },
+        { "required": ["internal"] },
         { "required": ["setter"] }
       ]
+    },
+    "SeriesBindingInternalExclusivity": {
+      "description": "internal direction is mutually exclusive with input, output, and legacy setter.",
+      "if": { "required": ["internal"] },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["input"] },
+            { "required": ["output"] },
+            { "required": ["setter"] }
+          ]
+        }
+      }
     },
     "SeriesBindingMatrixRules": {
       "description": "Constraints for layout matrix (1.1.0).",
@@ -637,6 +658,11 @@
           "type": "boolean",
           "default": true,
           "description": "When true for output bindings, only cells present in the extracted graph are included."
+        },
+        "intersect_graph_formulas": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true for internal bindings, only formula cells present in the extracted graph are included."
         }
       }
     }

--- a/excel_grapher/series_bindings/types.py
+++ b/excel_grapher/series_bindings/types.py
@@ -102,3 +102,18 @@ class OutputSeries(TypedDict):
     key_fields: list[str]
     cells: list[OutputSeriesCell]
     issues: list[ResolutionIssue]
+
+
+class InternalSeriesCell(TypedDict):
+    address: str
+    coordinates: dict[str, Scalar]
+    key: dict[str, Scalar]
+    record: dict[str, Scalar]
+
+
+class InternalSeries(TypedDict):
+    id: str
+    key_fields: list[str]
+    requires_address: bool
+    cells: list[InternalSeriesCell]
+    issues: list[ResolutionIssue]

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.graph_predicates import is_graph_formula_node, is_graph_leaf
 from excel_grapher.series_bindings.normalize import (
     effective_validation,
     has_input_direction,
@@ -58,7 +59,7 @@ def _input_binding_addresses(
     validation = effective_validation(series)
     if not validation.get("intersect_graph_leaves", True):
         return list(addresses)
-    return [address for address in addresses if _is_graph_leaf(graph, address)]
+    return [address for address in addresses if is_graph_leaf(graph, address)]
 
 
 def _validate_input_mode(series: dict[str, Any]) -> list[ValidationIssue]:
@@ -85,16 +86,6 @@ def _dimension_concepts(series: dict[str, Any]) -> set[str]:
     return {str(d.get("concept")) for d in dims if isinstance(d, dict) and d.get("concept")}
 
 
-def _is_graph_leaf(graph: DependencyGraph, address: str) -> bool:
-    node = graph.get_node(address) if address in graph else None
-    return bool(node is not None and node.is_leaf)
-
-
-def _is_formula_graph_node(graph: DependencyGraph, address: str) -> bool:
-    node = graph.get_node(address) if address in graph else None
-    return bool(node is not None and node.formula is not None)
-
-
 def _validate_input_binding_overlap(
     graph: DependencyGraph,
     series: dict[str, Any],
@@ -109,10 +100,10 @@ def _validate_input_binding_overlap(
     mode = input_mode(series)
     graph_addresses = [address for address in addresses if address in graph]
     non_leaf_graph_addresses = [
-        address for address in graph_addresses if not _is_graph_leaf(graph, address)
+        address for address in graph_addresses if not is_graph_leaf(graph, address)
     ]
     formula_graph_addresses = [
-        address for address in graph_addresses if _is_formula_graph_node(graph, address)
+        address for address in graph_addresses if is_graph_formula_node(graph, address)
     ]
 
     if mode == "leaf" and non_leaf_graph_addresses:
@@ -146,7 +137,7 @@ def _internal_binding_addresses(
     validation = effective_validation(series)
     if not validation.get("intersect_graph_formulas", True):
         return list(addresses)
-    return [address for address in addresses if _is_formula_graph_node(graph, address)]
+    return [address for address in addresses if is_graph_formula_node(graph, address)]
 
 
 def _validate_internal_binding_overlap(
@@ -165,7 +156,7 @@ def _validate_internal_binding_overlap(
         return issues
 
     formula_graph_addresses = [
-        address for address in addresses if _is_formula_graph_node(graph, address)
+        address for address in addresses if is_graph_formula_node(graph, address)
     ]
     if not formula_graph_addresses:
         issues.append(

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -7,6 +7,7 @@ from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.series_bindings.normalize import (
     effective_validation,
     has_input_direction,
+    has_internal_direction,
     input_mode,
     is_override_input,
 )
@@ -130,6 +131,48 @@ def _validate_input_binding_overlap(
                 "error",
                 "no_formula_override_targets",
                 "input.mode override requires at least one formula cell in data_range",
+                series_id=series_id,
+            )
+        )
+    return issues
+
+
+def _internal_binding_addresses(
+    graph: DependencyGraph,
+    series: dict[str, Any],
+    addresses: list[str],
+) -> list[str]:
+    """Return addresses that participate in internal binding resolution."""
+    validation = effective_validation(series)
+    if not validation.get("intersect_graph_formulas", True):
+        return list(addresses)
+    return [address for address in addresses if _is_formula_graph_node(graph, address)]
+
+
+def _validate_internal_binding_overlap(
+    graph: DependencyGraph,
+    series: dict[str, Any],
+    addresses: list[str],
+) -> list[ValidationIssue]:
+    """Validate formula-cell semantics for internal binding data ranges."""
+    issues: list[ValidationIssue] = []
+    if not has_internal_direction(series):
+        return issues
+
+    series_id = str(series.get("id", ""))
+    validation = effective_validation(series)
+    if not validation.get("intersect_graph_formulas", True):
+        return issues
+
+    formula_graph_addresses = [
+        address for address in addresses if _is_formula_graph_node(graph, address)
+    ]
+    if not formula_graph_addresses:
+        issues.append(
+            _issue(
+                "error",
+                "no_formula_internal_targets",
+                "internal binding requires at least one formula cell in data_range",
                 series_id=series_id,
             )
         )
@@ -523,8 +566,10 @@ def validate_series_bindings(
 
         issues.extend(_validate_input_mode(series))
         issues.extend(_validate_input_binding_overlap(graph, series, addresses))
+        issues.extend(_validate_internal_binding_overlap(graph, series, addresses))
 
         graph_input_addresses = _input_binding_addresses(graph, series, addresses)
+        graph_internal_addresses = _internal_binding_addresses(graph, series, addresses)
 
         if require_unique_key:
             cell_scoped_keys = [
@@ -536,7 +581,12 @@ def validate_series_bindings(
                     for d in (series.get("structure") or {}).get("dimensions") or []
                 )
             ]
-            if not graph_input_addresses:
+            binding_addresses = (
+                graph_internal_addresses
+                if has_internal_direction(series)
+                else graph_input_addresses
+            )
+            if not binding_addresses:
                 continue
             if cell_scoped_keys and workbook is None:
                 issues.append(
@@ -551,7 +601,8 @@ def validate_series_bindings(
             elif workbook is not None:
                 from excel_grapher.series_bindings.resolve import resolve_series_binding
 
-                resolved = resolve_series_binding(graph, workbook, series, direction="input")
+                direction = "internal" if has_internal_direction(series) else "input"
+                resolved = resolve_series_binding(graph, workbook, series, direction=direction)
                 issues.extend(resolved["issues"])
                 if resolved["requires_address"]:
                     issues.append(

--- a/excel_grapher/series_bindings/versions.py
+++ b/excel_grapher/series_bindings/versions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 SUPPORTED_SCHEMA_VERSIONS: frozenset[str] = frozenset(
-    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"}
+    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"}
 )
 
 IMPLEMENTED_BIND_KINDS: frozenset[str] = frozenset(

--- a/tests/fixtures/series_bindings/internal_engine_row.yaml
+++ b/tests/fixtures/series_bindings/internal_engine_row.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.7.0
+workbook: formula_override.xlsx
+concept_scheme:
+  id: example_model
+  concepts:
+    - id: TIME_PERIOD
+      dtype: int
+    - id: INDICATOR
+      dtype: string
+series:
+  - id: engine_primary_balance
+    sheet: Engine
+    data_range: Engine!B2:D2
+    layout: series
+    internal: {}
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: { kind: data_cell, read: float }
+      dimensions:
+        - concept: TIME_PERIOD
+          role: key
+          scope: cell
+          bind: { kind: column_header, header_row: 1, read: int }
+    key: [TIME_PERIOD]
+    series_context:
+      INDICATOR: Primary balance
+    validation:
+      intersect_graph_formulas: true
+      require_unique_key: true

--- a/tests/unit/series_bindings/test_internal_series.py
+++ b/tests/unit/series_bindings/test_internal_series.py
@@ -283,3 +283,166 @@ def test_validate_internal_series_requires_formula_overlap(tmp_path: Path) -> No
     report = validate_series_bindings(graph, bindings, workbook=wb_path)
     codes = {issue["code"] for issue in report["issues"]}
     assert "no_formula_internal_targets" in codes
+
+
+def test_mcve_internal_document_validates_on_1_7_0() -> None:
+    """Positive MCVE from issue #372: internal-only series accepted at schema 1.7.0."""
+    doc = {
+        "schema_version": "1.7.0",
+        "concept_scheme": {
+            "id": "example_model",
+            "concepts": [
+                {"id": "TIME_PERIOD", "dtype": "int"},
+                {"id": "INDICATOR", "dtype": "string"},
+            ],
+        },
+        "series": [
+            {
+                "id": "engine_primary_balance",
+                "sheet": "Engine",
+                "data_range": "Engine!D22:F22",
+                "layout": "series",
+                "internal": {},
+                "structure": {
+                    "measure": {
+                        "concept": "OBS_VALUE",
+                        "dtype": "float",
+                        "bind": {"kind": "data_cell", "read": "float"},
+                    },
+                    "dimensions": [
+                        {
+                            "concept": "TIME_PERIOD",
+                            "role": "key",
+                            "scope": "cell",
+                            "bind": {
+                                "kind": "column_header",
+                                "header_row": 2,
+                                "read": "int",
+                            },
+                        }
+                    ],
+                },
+                "key": ["TIME_PERIOD"],
+                "series_context": {"INDICATOR": "Primary balance"},
+                "validation": {
+                    "intersect_graph_formulas": True,
+                    "require_unique_key": True,
+                },
+            }
+        ],
+    }
+    bindings = validate_bindings_document(doc)
+    assert has_internal_direction(bindings["series"][0])
+
+
+def test_schema_rejects_internal_with_legacy_setter() -> None:
+    doc = _internal_series_doc(
+        setter={"name": "set_engine_primary_balance"},
+    )
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_resolve_internal_series_warns_on_partial_formula_overlap(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        ["Engine!B1", "Engine!B2", "Engine!C2", "Engine!D2"],
+        load_values=True,
+    )
+    series = _internal_series_doc(data_range="Engine!B1:B2")["series"][0]
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="internal")
+
+    assert [leaf["address"] for leaf in resolved["leaves"]] == ["Engine!B2"]
+    assert any(
+        issue["code"] == "partial_graph_overlap" and issue["level"] == "warning"
+        for issue in resolved["issues"]
+    )
+
+
+def test_resolve_internal_series_includes_constants_when_intersect_disabled(
+    tmp_path: Path,
+) -> None:
+    wb_path = tmp_path / "mixed.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Engine")
+    ws.write_number("A2", 10)
+    ws.write_formula("B2", "=A2+1")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Engine!A2", "Engine!B2"], load_values=True)
+    series = _internal_series_doc(
+        data_range="Engine!A2:B2",
+        structure={
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "constant", "value": 1},
+                }
+            ],
+        },
+        validation={"intersect_graph_formulas": False, "require_unique_key": False},
+    )["series"][0]
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="internal")
+
+    assert [leaf["address"] for leaf in resolved["leaves"]] == ["Engine!A2", "Engine!B2"]
+
+
+def test_load_merged_input_and_internal_shards(tmp_path: Path) -> None:
+    shard_dir = tmp_path / "shards"
+    shard_dir.mkdir()
+    (shard_dir / "inputs.bindings.yaml").write_text(
+        """\
+schema_version: 1.7.0
+workbook: formula_override.xlsx
+series:
+  - id: engine_override
+    sheet: Engine
+    data_range: Engine!B1
+    layout: scalar
+    input:
+      mode: override
+      setter:
+        name: set_engine_b1
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: { kind: data_cell, read: float }
+      dimensions: []
+    key: []
+""",
+        encoding="utf-8",
+    )
+    (shard_dir / "internals.bindings.yaml").write_text(
+        (FIXTURES / "internal_engine_row.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    bindings = load_series_bindings(shard_dir)
+    series_ids = {series["id"] for series in bindings["series"]}
+    assert series_ids == {"engine_override", "engine_primary_balance"}
+
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        ["Engine!B1", "Engine!B2", "Engine!C2", "Engine!D2"],
+        load_values=True,
+    )
+
+    input_series = derive_input_series(graph, bindings, workbook=wb_path)
+    internal_series = derive_internal_series(graph, bindings, workbook=wb_path)
+
+    assert [series["id"] for series in input_series] == ["engine_override"]
+    assert [series["id"] for series in internal_series] == ["engine_primary_balance"]

--- a/tests/unit/series_bindings/test_internal_series.py
+++ b/tests/unit/series_bindings/test_internal_series.py
@@ -1,0 +1,285 @@
+"""Tests for internal (non-I/O) series bindings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import xlsxwriter
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import (
+    SeriesBindingsSchemaError,
+    derive_input_series,
+    derive_internal_series,
+    derive_output_series,
+    emit_series_bindings_block,
+    has_internal_direction,
+    load_series_bindings,
+    merge_series_binding_documents,
+    parse_bindings_file,
+    resolve_series_binding,
+    validate_bindings_document,
+    validate_series_bindings,
+)
+from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
+from tests.unit.series_bindings.test_input_override import (
+    _manual_override_graph,
+    _write_override_workbook,
+)
+
+
+def _internal_series_doc(**series_overrides: Any) -> dict[str, Any]:
+    series: dict[str, Any] = {
+        "id": "engine_primary_balance",
+        "sheet": "Engine",
+        "data_range": "Engine!B2:D2",
+        "layout": "series",
+        "internal": {},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                }
+            ],
+        },
+        "key": ["TIME_PERIOD"],
+        "series_context": {"INDICATOR": "Primary balance"},
+        "validation": {
+            "intersect_graph_formulas": True,
+            "require_unique_key": True,
+        },
+    }
+    series.update(series_overrides)
+    return {
+        "schema_version": "1.7.0",
+        "concept_scheme": {
+            "id": "example_model",
+            "concepts": [
+                {"id": "TIME_PERIOD", "dtype": "int"},
+                {"id": "INDICATOR", "dtype": "string"},
+            ],
+        },
+        "series": [series],
+    }
+
+
+def test_schema_accepts_internal_only_series() -> None:
+    doc = _internal_series_doc()
+    bindings = validate_bindings_document(doc)
+    series = bindings["series"][0]
+    assert has_internal_direction(series)
+    assert "internal" in series
+
+
+def test_schema_rejects_series_without_any_direction() -> None:
+    doc = _internal_series_doc()
+    del doc["series"][0]["internal"]
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_internal_with_input() -> None:
+    doc = _internal_series_doc(
+        input={"setter": {"name": "set_engine_primary_balance"}},
+    )
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_schema_rejects_internal_with_output() -> None:
+    doc = _internal_series_doc(
+        output={"compute": {"name": "compute_engine_primary_balance"}},
+    )
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_mcve_internal_document_fails_on_1_5_0() -> None:
+    doc = _internal_series_doc()
+    del doc["series"][0]["internal"]
+    doc["schema_version"] = "1.5.0"
+    with pytest.raises(SeriesBindingsSchemaError):
+        validate_bindings_document(doc)
+
+
+def test_resolve_internal_series_includes_formula_cells(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        ["Engine!B2", "Engine!C2", "Engine!D2", "Output!B3", "Output!C3", "Output!D3"],
+        load_values=True,
+    )
+    series = _internal_series_doc()["series"][0]
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="internal")
+
+    assert resolved["ok"] is True
+    assert [leaf["address"] for leaf in resolved["leaves"]] == [
+        "Engine!B2",
+        "Engine!C2",
+        "Engine!D2",
+    ]
+    assert resolved["leaves"][1]["key"] == {"TIME_PERIOD": 2}
+    assert resolved["leaves"][1]["record"]["INDICATOR"] == "Primary balance"
+
+
+def test_resolve_internal_series_skips_non_formula_cells(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = _manual_override_graph()
+    series = _internal_series_doc(
+        sheet="Inputs",
+        data_range="Inputs!A1",
+        structure={
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "constant", "value": 1},
+                }
+            ],
+        },
+    )["series"][0]
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="internal")
+
+    assert resolved["leaves"] == []
+    assert any(i["code"] == "no_resolved_cells" for i in resolved["issues"])
+
+
+def test_resolve_internal_series_enforces_unique_keys(tmp_path: Path) -> None:
+    wb_path = tmp_path / "dup.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Engine")
+    ws.write_number("A1", 1)
+    ws.write_number("B1", 1)
+    ws.write_formula("B2", "=A1+1")
+    ws.write_formula("C2", "=A1+2")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Engine!B2", "Engine!C2"], load_values=True)
+    series = _internal_series_doc(
+        data_range="Engine!B2:C2",
+        structure={
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "constant", "value": 1},
+                }
+            ],
+        },
+    )["series"][0]
+
+    resolved = resolve_series_binding(graph, wb_path, series, direction="internal")
+
+    assert resolved["ok"] is False
+    assert resolved["requires_address"] is True
+    assert any(i["code"] == "duplicate_key" for i in resolved["issues"])
+
+
+def test_derive_internal_series_from_fixture(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        ["Engine!B2", "Engine!C2", "Engine!D2", "Output!B3", "Output!C3", "Output!D3"],
+        load_values=True,
+    )
+    bindings = load_series_bindings(FIXTURES / "internal_engine_row.yaml")
+
+    internal_series = derive_internal_series(graph, bindings, workbook=wb_path)
+
+    assert len(internal_series) == 1
+    series = internal_series[0]
+    assert series["id"] == "engine_primary_balance"
+    assert series["key_fields"] == ["TIME_PERIOD"]
+    assert [cell["address"] for cell in series["cells"]] == [
+        "Engine!B2",
+        "Engine!C2",
+        "Engine!D2",
+    ]
+
+
+def test_derive_internal_series_does_not_emit_codegen(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, ["Engine!B2"], load_values=True)
+    bindings = validate_bindings_document(_internal_series_doc())
+    lines = emit_series_bindings_block(graph, wb_path, bindings)
+    assert lines == []
+
+
+def test_input_and_output_derive_skip_internal_series(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        ["Engine!B2", "Engine!C2", "Engine!D2"],
+        load_values=True,
+    )
+    bindings = validate_bindings_document(_internal_series_doc())
+
+    assert derive_input_series(graph, bindings, workbook=wb_path) == []
+    assert derive_output_series(graph, bindings, workbook=wb_path) == []
+
+
+def test_load_merged_internal_shard_directory(tmp_path: Path) -> None:
+    shard_dir = tmp_path / "shards"
+    shard_dir.mkdir()
+    (shard_dir / "internals.bindings.yaml").write_text(
+        (FIXTURES / "internal_engine_row.yaml").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    bindings = load_series_bindings(shard_dir)
+    assert bindings["series"][0]["id"] == "engine_primary_balance"
+    assert has_internal_direction(bindings["series"][0])
+
+
+def test_merge_internal_direction_blocks_across_shards() -> None:
+    base_series = parse_bindings_file(FIXTURES / "internal_engine_row.yaml")["series"][0]
+    structural = {k: v for k, v in base_series.items() if k != "internal"}
+    left_doc = {
+        "schema_version": "1.7.0",
+        "series": [{**structural, "internal": {}}],
+    }
+    right_doc = {
+        "schema_version": "1.7.0",
+        "series": [{**structural, "internal": {}}],
+    }
+    merged = merge_series_binding_documents([left_doc, right_doc])
+    assert has_internal_direction(merged["series"][0])
+
+
+def test_validate_internal_series_requires_formula_overlap(tmp_path: Path) -> None:
+    wb_path = tmp_path / "formula_override.xlsx"
+    _write_override_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, ["Inputs!A1"], load_values=True)
+    bindings = validate_bindings_document(_internal_series_doc())
+
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "no_formula_internal_targets" in codes

--- a/tests/unit/series_bindings/test_versions.py
+++ b/tests/unit/series_bindings/test_versions.py
@@ -17,7 +17,7 @@ from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
 
 
 def test_supported_schema_versions() -> None:
-    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0"})
+    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"})
     assert expected == SUPPORTED_SCHEMA_VERSIONS
 
 

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -71,6 +71,7 @@ lic_inputs.xlsx
 lic_inputs.bindings/
   Inputs.bindings.yaml
   Assumptions.bindings.yaml
+  internals.bindings.yaml   # optional non-I/O formula-cell triangulation
 ```
 
 Rules:
@@ -88,8 +89,9 @@ optional direction blocks:
 
 - **`input.setter`** — generated setter requires key dimensions plus `OBS_VALUE` on each incoming record.
 - **`output.compute`** — generated compute returns all declared dimensions plus computed `OBS_VALUE` per graph cell in `data_range`.
+- **`internal`** — resolve per-cell `{address, key, record}` for formula nodes without emitting `set_*` or `compute_*` APIs.
 
-At least one of `input` or `output` is required per series (legacy top-level `setter` is normalized to `input.setter`; legacy `layout: row_series` is normalized to `series`).
+At least one of `input`, `output`, or `internal` is required per series (legacy top-level `setter` is normalized to `input.setter`; legacy `layout: row_series` is normalized to `series`).
 
 ### Input mode: `leaf` vs `override` (schema 1.6.0+)
 
@@ -127,6 +129,50 @@ Example manifest: [formula_override.bindings.yaml](https://github.com/Teal-Insig
 **Migration (all schema versions):** Leaf-mode bindings that accidentally included formula cells previously emitted a `partial_graph_overlap` warning and dropped those cells. They now **error** at validation. Either narrow `data_range` to leaves only or declare `input.mode: override`.
 
 **Evaluator note:** Durable override setters (this feature) differ from transient per-call overrides tracked in [issue #122](https://github.com/Teal-Insights/excel-grapher/issues/122). `FormulaEvaluator` does not yet expose equivalent durable setter semantics.
+
+### Internal direction (schema 1.7.0+)
+
+Use **`internal: {}`** for formula cells that need the same dimensional key machinery as public I/O bindings but should **not** generate `set_*` or `compute_*` functions. Typical consumers are extraction pipelines that triangulate internal computation cells by concept keys (for example `ref_0[TIME_PERIOD, INDICATOR]`).
+
+Internal bindings:
+
+- Resolve **formula graph nodes** in `data_range` (not leaves).
+- Default to **`validation.intersect_graph_formulas: true`** so constants outside the formula graph are skipped; set `false` to include every expanded cell.
+- Require **at least one formula cell** in the range when intersection is enabled (`no_formula_internal_targets` otherwise).
+- Preserve **`validation.require_unique_key`** so each address is uniquely identified by its declared key concepts.
+- Emit **no codegen**; use `derive_internal_series()` after `validate_series_bindings()`.
+
+Pipelines can add `internals.bindings.yaml` alongside `inputs.bindings.yaml` and `outputs.bindings.yaml`; `load_series_bindings()` merges all `*.bindings.yaml` shards in a directory.
+
+```yaml
+schema_version: "1.7.0"
+series:
+  - id: engine_primary_balance
+    sheet: Engine
+    data_range: Engine!B2:D2
+    layout: series
+    internal: {}
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind: { kind: data_cell, read: float }
+      dimensions:
+        - concept: TIME_PERIOD
+          role: key
+          scope: cell
+          bind: { kind: column_header, header_row: 1, read: int }
+    key: [TIME_PERIOD]
+    series_context:
+      INDICATOR: Primary balance
+    validation:
+      intersect_graph_formulas: true
+      require_unique_key: true
+```
+
+Example fixture: [internal_engine_row.yaml](https://github.com/Teal-Insights/excel-grapher/blob/main/tests/fixtures/series_bindings/internal_engine_row.yaml).
+
+**Pipeline note:** `derive_*_series` omits series with zero resolved leaves. Call `validate_series_bindings()` first so hard errors such as `no_formula_internal_targets` surface before derive.
 
 ## `data_range` addressing
 
@@ -608,11 +654,13 @@ Generated code imports `datetime` and emits `datetime.datetime(...)` literals on
 | **1.3.0** | `row_series` renamed to `series` (no resolver/codegen change). Legacy `row_series` accepted at load time. |
 | **1.4.0** | `bool` and `datetime` read modes and dtypes; ISO date strings in manifest constants. |
 | **1.5.0** | Grouped-row matrix geometry: `skip`/`include`/`fill`/`missing` on `row_label` and `column_header` binds, the `value_map` bind kind, and series-level `exclude_rows`. |
+| **1.6.0** | `input.mode: override` for user-editable formula cells (non-leaf input setters). |
+| **1.7.0** | `internal` direction for non-I/O formula-cell key triangulation (`intersect_graph_formulas` validation). |
 
 ## Validation and codegen closure
 
 `validate_series_bindings()` and `derive_*_series` intersect bindings with the extracted graph (input:
-**leaves**; output: **any graph node**). **Codegen** intersects with the export closure from the current
+**leaves**; output: **any graph node**; internal: **formula nodes**). **Codegen** intersects with the export closure from the current
 `CodeGenerator` targets (formula cells, inputs, and dependencies actually emitted). Cells outside that
 closure are skipped; `validation.warn_on_partial_overlap` (default `true`) emits a warning when that
 happens.
@@ -626,6 +674,7 @@ from excel_grapher.grapher import create_dependency_graph
 from excel_grapher.series_bindings import (
     bindings_canonical_sha256,
     derive_input_series,
+    derive_internal_series,
     expand_data_range,
     load_series_bindings,
     validate_series_bindings,
@@ -647,6 +696,7 @@ assert report["ok"]
 
 bindings_canonical_sha256(bindings)
 input_series = derive_input_series(graph, bindings, workbook=workbook)
+internal_series = derive_internal_series(graph, bindings, workbook=workbook)
 
 with CodeGenerator(graph) as gen:
     code = gen.generate(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#372](https://github.com/Teal-Insights/excel-grapher/issues/372): internal (non-I/O) series bindings for formula-cell key triangulation in extraction pipelines.

- **Schema 1.7.0** adds `internal: {}` as a third series direction, mutually exclusive with `input` / `output` / legacy `setter`
- **`intersect_graph_formulas`** validation flag (default `true` for internal series) filters `data_range` to formula graph nodes
- **`derive_internal_series()`** resolves per-cell `{address, key, record}` without emitting `set_*` / `compute_*` codegen
- Existing input/output bindings, codegen, and merge/load conventions are unchanged

## Example

```yaml
schema_version: 1.7.0
series:
  - id: engine_primary_balance
    sheet: Engine
    data_range: Engine!D22:CP22
    layout: series
    internal: {}
    structure: { ... }
    key: [TIME_PERIOD]
    validation:
      intersect_graph_formulas: true
      require_unique_key: true
```

## Testing

- Added `tests/unit/series_bindings/test_internal_series.py` covering schema validation, resolution, uniqueness, derive API, codegen gating, and directory merge
- Added fixture `tests/fixtures/series_bindings/internal_engine_row.yaml`
- Full CI: `ruff`, `ty`, `pytest` (1847 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b73c145-28a9-41a2-9e90-ccb80b2d4a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b73c145-28a9-41a2-9e90-ccb80b2d4a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

