### PR TITLE
feat(series_bindings): separate dimension id from concept (schema 1.8.0)

### DIFF
--- a/excel_grapher/series_bindings/docstrings.py
+++ b/excel_grapher/series_bindings/docstrings.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.normalize import effective_dimension_id
 from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
 
 if TYPE_CHECKING:
@@ -143,19 +144,19 @@ def _expected_record_values(series: dict[str, Any]) -> dict[str, object]:
     expected = dict(series.get("series_context") or {})
     for attribute in (series.get("structure") or {}).get("attributes") or []:
         if isinstance(attribute, dict) and "value" in attribute:
-            expected[str(attribute["concept"])] = attribute["value"]
+            expected[effective_dimension_id(attribute)] = attribute["value"]
     return expected
 
 
 def _record_field_names(series: dict[str, Any]) -> list[str]:
     measure = _measure_concept(series)
     dimensions = [
-        str(dimension["concept"])
+        effective_dimension_id(dimension)
         for dimension in (series.get("structure") or {}).get("dimensions") or []
         if isinstance(dimension, dict) and "concept" in dimension
     ]
     attributes = [
-        str(attribute["concept"])
+        effective_dimension_id(attribute)
         for attribute in (series.get("structure") or {}).get("attributes") or []
         if isinstance(attribute, dict) and "concept" in attribute
     ]
@@ -163,11 +164,29 @@ def _record_field_names(series: dict[str, Any]) -> list[str]:
     return _unique([*required, *dimensions, *attributes])
 
 
+def _concept_id_for_field(series: dict[str, Any], field_name: str) -> str:
+    """Map a record field name to the concept id used for scheme lookups."""
+    structure = series.get("structure") or {}
+    components = [
+        *(structure.get("dimensions") or []),
+        *(structure.get("attributes") or []),
+    ]
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        if effective_dimension_id(component) != field_name:
+            continue
+        concept = component.get("concept")
+        if concept:
+            return str(concept)
+    return field_name
+
+
 def _dimension_bind_read(series: dict[str, Any], field_name: str) -> str | None:
     for dimension in (series.get("structure") or {}).get("dimensions") or []:
         if not isinstance(dimension, dict):
             continue
-        if str(dimension.get("concept", "")) != field_name:
+        if effective_dimension_id(dimension) != field_name:
             continue
         bind = dimension.get("bind")
         if isinstance(bind, dict) and bind.get("read") is not None:
@@ -189,7 +208,7 @@ def _field_dtype(
         if concept is not None and concept.get("dtype") is not None:
             return str(concept["dtype"])
         return None
-    concept = concepts.get(field_name)
+    concept = concepts.get(_concept_id_for_field(series, field_name))
     if concept is not None and concept.get("dtype") is not None:
         return str(concept["dtype"])
     bind_read = _dimension_bind_read(series, field_name)
@@ -225,7 +244,7 @@ def derive_doc_contract(
     expected_values = _expected_record_values(series)
     field_contracts: dict[str, FieldContract] = {}
     for field_name in _record_field_names(series):
-        concept = concepts.get(field_name)
+        concept = concepts.get(_concept_id_for_field(series, field_name))
         concept_name = (
             str(concept["name"]) if concept is not None and concept.get("name") else field_name
         )

--- a/excel_grapher/series_bindings/docstrings.py
+++ b/excel_grapher/series_bindings/docstrings.py
@@ -9,7 +9,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from excel_grapher.grapher.graph import DependencyGraph
-from excel_grapher.series_bindings.normalize import effective_dimension_id
+from excel_grapher.series_bindings.normalize import (
+    component_for_field,
+    concept_for_field,
+    effective_dimension_id,
+)
 from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
 
 if TYPE_CHECKING:
@@ -164,24 +168,6 @@ def _record_field_names(series: dict[str, Any]) -> list[str]:
     return _unique([*required, *dimensions, *attributes])
 
 
-def _concept_id_for_field(series: dict[str, Any], field_name: str) -> str:
-    """Map a record field name to the concept id used for scheme lookups."""
-    structure = series.get("structure") or {}
-    components = [
-        *(structure.get("dimensions") or []),
-        *(structure.get("attributes") or []),
-    ]
-    for component in components:
-        if not isinstance(component, dict):
-            continue
-        if effective_dimension_id(component) != field_name:
-            continue
-        concept = component.get("concept")
-        if concept:
-            return str(concept)
-    return field_name
-
-
 def _dimension_bind_read(series: dict[str, Any], field_name: str) -> str | None:
     for dimension in (series.get("structure") or {}).get("dimensions") or []:
         if not isinstance(dimension, dict):
@@ -208,7 +194,10 @@ def _field_dtype(
         if concept is not None and concept.get("dtype") is not None:
             return str(concept["dtype"])
         return None
-    concept = concepts.get(_concept_id_for_field(series, field_name))
+    component = component_for_field(series, field_name)
+    if component is not None and component.get("dtype") is not None:
+        return str(component["dtype"])
+    concept = concepts.get(concept_for_field(series, field_name))
     if concept is not None and concept.get("dtype") is not None:
         return str(concept["dtype"])
     bind_read = _dimension_bind_read(series, field_name)
@@ -244,7 +233,7 @@ def derive_doc_contract(
     expected_values = _expected_record_values(series)
     field_contracts: dict[str, FieldContract] = {}
     for field_name in _record_field_names(series):
-        concept = concepts.get(_concept_id_for_field(series, field_name))
+        concept = concepts.get(concept_for_field(series, field_name))
         concept_name = (
             str(concept["name"]) if concept is not None and concept.get("name") else field_name
         )

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -25,6 +25,16 @@ _STRUCTURAL_FIELDS = frozenset(
 )
 
 
+def effective_dimension_id(component: dict[str, Any]) -> str:
+    """Return the record-field identifier for a dimension or attribute.
+
+    Structure components may declare an `id` distinct from their `concept`
+    (schema 1.8.0), so two dimensions in one series can share a concept.
+    The effective id defaults to the concept when no `id` is declared.
+    """
+    return str(component.get("id") or component.get("concept") or "")
+
+
 def _setter_block(series: dict[str, Any]) -> dict[str, Any] | None:
     input_block = series.get("input")
     if isinstance(input_block, dict):

--- a/excel_grapher/series_bindings/normalize.py
+++ b/excel_grapher/series_bindings/normalize.py
@@ -35,6 +35,36 @@ def effective_dimension_id(component: dict[str, Any]) -> str:
     return str(component.get("id") or component.get("concept") or "")
 
 
+def component_for_field(series: dict[str, Any], field_name: str) -> dict[str, Any] | None:
+    """Return the dimension or attribute whose effective id matches `field_name`."""
+    structure = series.get("structure") or {}
+    components = [
+        *(structure.get("dimensions") or []),
+        *(structure.get("attributes") or []),
+    ]
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        if effective_dimension_id(component) == field_name:
+            return component
+    return None
+
+
+def concept_for_field(series: dict[str, Any], field_name: str) -> str:
+    """Map a record field name to the concept id used for scheme lookups.
+
+    A dimension or attribute whose effective id matches `field_name` may
+    reference a different concept (schema 1.8.0); dtype inheritance from the
+    concept scheme keys on that concept.
+    """
+    component = component_for_field(series, field_name)
+    if component is not None:
+        concept = component.get("concept")
+        if concept:
+            return str(concept)
+    return field_name
+
+
 def _setter_block(series: dict[str, Any]) -> dict[str, Any] | None:
     input_block = series.get("input")
     if isinstance(input_block, dict):

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -28,6 +28,7 @@ from excel_grapher.series_bindings.graph_predicates import (
 )
 from excel_grapher.series_bindings.normalize import (
     InputMode,
+    effective_dimension_id,
     effective_validation,
     has_input_direction,
     has_internal_direction,
@@ -102,6 +103,29 @@ def _lookup_concept_dtype(
                 if dtype is not None:
                     return str(dtype)
     return None
+
+
+def _concept_for_field(series: dict[str, Any], field_name: str) -> str:
+    """Map a record field name to the concept id used for dtype lookup.
+
+    A dimension or attribute whose effective id matches `field_name` may
+    reference a different concept (schema 1.8.0); dtype inheritance from the
+    concept scheme keys on that concept.
+    """
+    structure = series.get("structure") or {}
+    components = [
+        *(structure.get("dimensions") or []),
+        *(structure.get("attributes") or []),
+    ]
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        if effective_dimension_id(component) != field_name:
+            continue
+        concept = component.get("concept")
+        if concept:
+            return str(concept)
+    return field_name
 
 
 def _effective_read_as(
@@ -366,14 +390,16 @@ def _coerce_series_context(
     if not isinstance(raw, dict):
         return {}
     result: dict[str, Scalar] = {}
-    for concept, value in raw.items():
-        concept_name = str(concept)
-        inferred = _lookup_concept_dtype(concept_scheme, series, concept_name)
+    for context_field, value in raw.items():
+        field_name = str(context_field)
+        inferred = _lookup_concept_dtype(
+            concept_scheme, series, _concept_for_field(series, field_name)
+        )
         read_as = _effective_read_as({"kind": "constant"}, inferred_dtype=inferred)
         try:
-            result[concept_name] = coerce_constant(value, read_as=read_as)
+            result[field_name] = coerce_constant(value, read_as=read_as)
         except (ValueError, TypeError) as exc:
-            raise ValueError(f"series_context[{concept_name!r}]: {exc}") from exc
+            raise ValueError(f"series_context[{field_name!r}]: {exc}") from exc
     return result
 
 
@@ -402,18 +428,18 @@ def _build_input_record(
     for dim in structure.get("dimensions") or []:
         if not isinstance(dim, dict):
             continue
-        concept = str(dim.get("concept", ""))
-        if _include_in_record(dim, default=True) and concept in coordinates:
-            record[concept] = coordinates[concept]
+        field_name = effective_dimension_id(dim)
+        if _include_in_record(dim, default=True) and field_name in coordinates:
+            record[field_name] = coordinates[field_name]
 
     for attr in structure.get("attributes") or []:
         if not isinstance(attr, dict):
             continue
-        concept = str(attr.get("concept", ""))
+        field_name = effective_dimension_id(attr)
         if not _include_in_record(attr, default=False):
             continue
-        if concept in coordinates:
-            record[concept] = coordinates[concept]
+        if field_name in coordinates:
+            record[field_name] = coordinates[field_name]
 
     return record
 
@@ -435,16 +461,16 @@ def _build_output_record(
     for dim in structure.get("dimensions") or []:
         if not isinstance(dim, dict):
             continue
-        concept = str(dim.get("concept", ""))
-        if concept in coordinates:
-            record[concept] = coordinates[concept]
+        field_name = effective_dimension_id(dim)
+        if field_name in coordinates:
+            record[field_name] = coordinates[field_name]
 
     for attr in structure.get("attributes") or []:
         if not isinstance(attr, dict):
             continue
-        concept = str(attr.get("concept", ""))
-        if concept in coordinates:
-            record[concept] = coordinates[concept]
+        field_name = effective_dimension_id(attr)
+        if field_name in coordinates:
+            record[field_name] = coordinates[field_name]
 
     if measure_concept not in record:
         record[measure_concept] = coordinates.get(measure_concept)
@@ -731,15 +757,17 @@ def resolve_series_binding(
             for dim in structure.get("dimensions") or []:
                 if not isinstance(dim, dict):
                     continue
-                concept = str(dim.get("concept", ""))
+                field_name = effective_dimension_id(dim)
                 bind = dim.get("bind")
                 if not isinstance(bind, dict):
                     continue
                 scope = dim.get("scope")
-                if scope == "series" and concept in series_coordinates:
-                    coordinates[concept] = series_coordinates[concept]
+                if scope == "series" and field_name in series_coordinates:
+                    coordinates[field_name] = series_coordinates[field_name]
                     continue
-                inferred = _lookup_concept_dtype(concept_scheme, series, concept)
+                inferred = _lookup_concept_dtype(
+                    concept_scheme, series, str(dim.get("concept", ""))
+                )
                 value = _execute_bind(
                     bind,
                     graph=graph,
@@ -747,19 +775,21 @@ def resolve_series_binding(
                     data_address=address,
                     inferred_read_as=inferred,
                 )
-                coordinates[concept] = value
+                coordinates[field_name] = value
                 if scope == "series":
-                    series_coordinates[concept] = value
+                    series_coordinates[field_name] = value
 
             for attr in structure.get("attributes") or []:
                 if not isinstance(attr, dict):
                     continue
-                concept = str(attr.get("concept", ""))
+                field_name = effective_dimension_id(attr)
                 bind = _attribute_bind(attr)
                 if bind is None:
                     continue
-                inferred = _lookup_concept_dtype(concept_scheme, series, concept)
-                coordinates[concept] = _execute_bind(
+                inferred = _lookup_concept_dtype(
+                    concept_scheme, series, str(attr.get("concept", ""))
+                )
+                coordinates[field_name] = _execute_bind(
                     bind,
                     graph=graph,
                     reader=reader,

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -28,6 +28,7 @@ from excel_grapher.series_bindings.graph_predicates import (
 )
 from excel_grapher.series_bindings.normalize import (
     InputMode,
+    component_for_field,
     effective_dimension_id,
     effective_validation,
     has_input_direction,
@@ -105,27 +106,16 @@ def _lookup_concept_dtype(
     return None
 
 
-def _concept_for_field(series: dict[str, Any], field_name: str) -> str:
-    """Map a record field name to the concept id used for dtype lookup.
-
-    A dimension or attribute whose effective id matches `field_name` may
-    reference a different concept (schema 1.8.0); dtype inheritance from the
-    concept scheme keys on that concept.
-    """
-    structure = series.get("structure") or {}
-    components = [
-        *(structure.get("dimensions") or []),
-        *(structure.get("attributes") or []),
-    ]
-    for component in components:
-        if not isinstance(component, dict):
-            continue
-        if effective_dimension_id(component) != field_name:
-            continue
-        concept = component.get("concept")
-        if concept:
-            return str(concept)
-    return field_name
+def _component_dtype(
+    concept_scheme: dict[str, Any] | None,
+    series: dict[str, Any],
+    component: dict[str, Any],
+) -> str | None:
+    """Inferred dtype for a dimension or attribute: declared dtype, else concept scheme."""
+    dtype = component.get("dtype")
+    if dtype is not None:
+        return str(dtype)
+    return _lookup_concept_dtype(concept_scheme, series, str(component.get("concept", "")))
 
 
 def _effective_read_as(
@@ -392,9 +382,11 @@ def _coerce_series_context(
     result: dict[str, Scalar] = {}
     for context_field, value in raw.items():
         field_name = str(context_field)
-        inferred = _lookup_concept_dtype(
-            concept_scheme, series, _concept_for_field(series, field_name)
-        )
+        component = component_for_field(series, field_name)
+        if component is not None:
+            inferred = _component_dtype(concept_scheme, series, component)
+        else:
+            inferred = _lookup_concept_dtype(concept_scheme, series, field_name)
         read_as = _effective_read_as({"kind": "constant"}, inferred_dtype=inferred)
         try:
             result[field_name] = coerce_constant(value, read_as=read_as)
@@ -411,11 +403,11 @@ def _build_input_record(
     series_context: dict[str, Scalar],
 ) -> dict[str, Scalar]:
     record: dict[str, Scalar] = {}
-    key_concepts = [str(c) for c in (series.get("key") or [])]
+    key_fields = [str(c) for c in (series.get("key") or [])]
 
-    for concept in key_concepts:
-        if concept in coordinates:
-            record[concept] = coordinates[concept]
+    for field_name in key_fields:
+        if field_name in coordinates:
+            record[field_name] = coordinates[field_name]
 
     obs_value = coordinates.get(measure_concept)
     if obs_value is not None or measure_concept in coordinates:
@@ -478,8 +470,8 @@ def _build_output_record(
     return record
 
 
-def _extract_key(coordinates: dict[str, Scalar], key_concepts: list[str]) -> dict[str, Scalar]:
-    return {concept: coordinates[concept] for concept in key_concepts if concept in coordinates}
+def _extract_key(coordinates: dict[str, Scalar], key_fields: list[str]) -> dict[str, Scalar]:
+    return {field: coordinates[field] for field in key_fields if field in coordinates}
 
 
 def warn_series_resolution_issues(resolved: SeriesResolution, *, stacklevel: int = 3) -> None:
@@ -714,7 +706,7 @@ def resolve_series_binding(
     measure_bind = measure.get("bind") or {"kind": "data_cell"}
     measure_dtype = measure.get("dtype")
     measure_inferred_read = str(measure_dtype) if measure_dtype is not None else None
-    key_concepts = [str(c) for c in (series.get("key") or [])]
+    key_fields = [str(c) for c in (series.get("key") or [])]
     require_unique_key = bool(validation.get("require_unique_key", True))
 
     reader = _WorkbookValues(workbook)
@@ -765,9 +757,7 @@ def resolve_series_binding(
                 if scope == "series" and field_name in series_coordinates:
                     coordinates[field_name] = series_coordinates[field_name]
                     continue
-                inferred = _lookup_concept_dtype(
-                    concept_scheme, series, str(dim.get("concept", ""))
-                )
+                inferred = _component_dtype(concept_scheme, series, dim)
                 value = _execute_bind(
                     bind,
                     graph=graph,
@@ -786,9 +776,7 @@ def resolve_series_binding(
                 bind = _attribute_bind(attr)
                 if bind is None:
                     continue
-                inferred = _lookup_concept_dtype(
-                    concept_scheme, series, str(attr.get("concept", ""))
-                )
+                inferred = _component_dtype(concept_scheme, series, attr)
                 coordinates[field_name] = _execute_bind(
                     bind,
                     graph=graph,
@@ -800,7 +788,7 @@ def resolve_series_binding(
             bind_failures.setdefault(str(exc), []).append(address)
             continue
 
-        key = _extract_key(coordinates, key_concepts)
+        key = _extract_key(coordinates, key_fields)
         record = build_record(
             coordinates=coordinates,
             series=series,
@@ -816,7 +804,7 @@ def resolve_series_binding(
             }
         )
 
-        if require_unique_key and key_concepts:
+        if require_unique_key and key_fields:
             key_tuple = tuple(sorted(key.items()))
             if key_tuple in seen_keys:
                 requires_address = True
@@ -838,7 +826,7 @@ def resolve_series_binding(
     )
 
     layout = series.get("layout")
-    if layout == "scalar" and not key_concepts and len(leaves) > 1:
+    if layout == "scalar" and not key_fields and len(leaves) > 1:
         issues.append(
             make_issue(
                 "error",

--- a/excel_grapher/series_bindings/schema.py
+++ b/excel_grapher/series_bindings/schema.py
@@ -16,7 +16,7 @@ from excel_grapher.series_bindings.types import WorkbookSeriesBindings
 _REQUIRED_PROPERTY_RE = re.compile(r"'([^']+)' is a required property")
 _UNEXPECTED_PROPERTY_RE = re.compile(r"\('([^']+)' was unexpected\)")
 _FIELD_HINTS: dict[str, str] = {
-    "key": "Add a key list naming the dimension concepts that identify each record.",
+    "key": "Add a key list naming the dimension ids that identify each record.",
     "structure": "Add a structure block describing measure, dimensions, and attributes.",
     "data_range": "Add the Excel range this series covers (for example Sheet1!B3:Q3).",
     "layout": "Optional layout intent: scalar, series, or matrix.",

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -9,8 +9,8 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters). 1.7.0: internal direction for non-I/O formula-cell key triangulation (intersect_graph_formulas validation)."
+      "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0"],
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters). 1.7.0: internal direction for non-I/O formula-cell key triangulation (intersect_graph_formulas validation). 1.8.0: optional dimension/attribute id separating dimension identity from concept, so multiple dimensions can share one concept; record fields and key entries use the effective id (id when declared, else concept) while concept keeps dtype inheritance from concept_scheme."
     },
     "workbook": {
       "type": "string",
@@ -57,6 +57,12 @@
       "minLength": 1,
       "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
       "description": "Stable concept identifier (SDMX-style ids such as REF_AREA or local ids such as DESCRIPTION)."
+    },
+    "DimensionId": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+      "description": "Dimension (or attribute) identifier distinguishing the dimension from the concept it references (SDMX concept identity). Defaults to the concept id when omitted; effective ids must be unique within a series' structure. Record fields and key entries use the effective id; concept_scheme dtype inheritance keys on concept."
     },
     "ScalarValue": {
       "description": "Constant attribute or context value stored in records when include_in_record is true. Datetime constants use ISO 8601 strings (e.g. 2024-01-15 or 2024-01-15T00:00:00); tooling coerces them when read or dtype is datetime.",
@@ -294,6 +300,7 @@
       "additionalProperties": false,
       "required": ["concept", "role", "scope", "bind"],
       "properties": {
+        "id": { "$ref": "#/$defs/DimensionId" },
         "concept": { "$ref": "#/$defs/ConceptId" },
         "role": { "const": "key" },
         "scope": { "$ref": "#/$defs/DimensionScope" },
@@ -310,6 +317,7 @@
       "additionalProperties": false,
       "required": ["concept", "role"],
       "properties": {
+        "id": { "$ref": "#/$defs/DimensionId" },
         "concept": { "$ref": "#/$defs/ConceptId" },
         "role": { "const": "attribute" },
         "bind": { "$ref": "#/$defs/Bind" },
@@ -501,7 +509,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/ConceptId" },
           "uniqueItems": true,
-          "description": "Concept ids required on each incoming record for matching (MVP series: typically [TIME_PERIOD] when country and indicator are series-scoped). Scalar layout may use an empty key when the binding resolves to a single cell."
+          "description": "Effective dimension ids (dimension id when declared, else concept) required on each incoming record for matching (MVP series: typically [TIME_PERIOD] when country and indicator are series-scoped). Scalar layout may use an empty key when the binding resolves to a single cell."
         },
         "series_context": {
           "type": "object",

--- a/excel_grapher/series_bindings/series_binding.schema.json
+++ b/excel_grapher/series_bindings/series_binding.schema.json
@@ -10,7 +10,7 @@
     "schema_version": {
       "type": "string",
       "enum": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0"],
-      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters). 1.7.0: internal direction for non-I/O formula-cell key triangulation (intersect_graph_formulas validation). 1.8.0: optional dimension/attribute id separating dimension identity from concept, so multiple dimensions can share one concept; record fields and key entries use the effective id (id when declared, else concept) while concept keeps dtype inheritance from concept_scheme."
+      "description": "Schema version for tooling and migrations. 1.0.0–1.2.0: row_series and scalar (fully supported). 1.1.0: adds matrix layout (supported with explicit binds). 1.2.0: optional input/output direction blocks and output compute functions. 1.3.0: row_series renamed to series layout; load-time normalization accepts legacy row_series. 1.4.0: adds bool and datetime read modes and dtypes for dimensions and constants (ISO 8601 date strings in manifests). 1.5.0: grouped-row matrix geometry (skip/include/fill/missing on row_label and column_header binds, value_map bind kind, series-level exclude_rows) and optional view-level groups for export sequencing and documentation grouping. 1.6.0: input.mode override for user-editable formula cells (non-leaf input setters). 1.7.0: internal direction for non-I/O formula-cell key triangulation (intersect_graph_formulas validation). 1.8.0: optional dimension/attribute id separating dimension identity from concept, so multiple dimensions can share one concept; record fields and key entries use the effective id (id when declared, else concept) while concept keeps dtype inheritance from concept_scheme. Also adds optional per-dimension dtype overriding the concept-scheme dtype for same-concept dimensions with differing storage types."
     },
     "workbook": {
       "type": "string",
@@ -302,6 +302,11 @@
       "properties": {
         "id": { "$ref": "#/$defs/DimensionId" },
         "concept": { "$ref": "#/$defs/ConceptId" },
+        "dtype": {
+          "type": "string",
+          "enum": ["string", "int", "float", "number", "bool", "datetime"],
+          "description": "Per-dimension storage type overriding the concept-scheme dtype for this dimension only. Use when same-concept dimensions store different types (e.g. an int projection axis and a datetime reference period sharing TIME_PERIOD); an explicit bind read still wins for coercion."
+        },
         "role": { "const": "key" },
         "scope": { "$ref": "#/$defs/DimensionScope" },
         "bind": { "$ref": "#/$defs/Bind" },
@@ -507,7 +512,7 @@
         },
         "key": {
           "type": "array",
-          "items": { "$ref": "#/$defs/ConceptId" },
+          "items": { "$ref": "#/$defs/DimensionId" },
           "uniqueItems": true,
           "description": "Effective dimension ids (dimension id when declared, else concept) required on each incoming record for matching (MVP series: typically [TIME_PERIOD] when country and indicator are series-scoped). Scalar layout may use an empty key when the binding resolves to a single cell."
         },

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -18,7 +18,7 @@ from excel_grapher.series_bindings.docstrings import (
     emit_docstring_literal,
     resolve_series_function_docstring,
 )
-from excel_grapher.series_bindings.normalize import has_input_direction
+from excel_grapher.series_bindings.normalize import effective_dimension_id, has_input_direction
 from excel_grapher.series_bindings.resolve import (
     resolve_series_bindings,
     warn_series_resolution_issues,
@@ -67,10 +67,10 @@ def _allowed_record_fields(
     fields.update(str(c) for c in (series.get("key") or []))
     for dim in (series.get("structure") or {}).get("dimensions") or []:
         if isinstance(dim, dict) and dim.get("include_in_record", True):
-            fields.add(str(dim.get("concept", "")))
+            fields.add(effective_dimension_id(dim))
     for attr in (series.get("structure") or {}).get("attributes") or []:
         if isinstance(attr, dict) and attr.get("include_in_record", False):
-            fields.add(str(attr.get("concept", "")))
+            fields.add(effective_dimension_id(attr))
     fields.update(str(c) for c in (series.get("series_context") or {}))
     if allow_address or requires_address:
         fields.update({"address", "cell_address"})
@@ -175,14 +175,14 @@ def _key_dtypes_for_codegen(series: dict[str, Any], key_fields: list[str]) -> di
     for dim in (series.get("structure") or {}).get("dimensions") or []:
         if not isinstance(dim, dict):
             continue
-        concept = str(dim.get("concept", ""))
-        if concept not in key_fields:
+        field_name = effective_dimension_id(dim)
+        if field_name not in key_fields:
             continue
         bind = dim.get("bind") if isinstance(dim.get("bind"), dict) else {}
         if "read" in bind:
-            dtypes[concept] = str(bind["read"])
+            dtypes[field_name] = str(bind["read"])
         elif dim.get("dtype") is not None:
-            dtypes[concept] = str(dim["dtype"])
+            dtypes[field_name] = str(dim["dtype"])
     return dtypes
 
 

--- a/excel_grapher/series_bindings/smoke.py
+++ b/excel_grapher/series_bindings/smoke.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.normalize import effective_dimension_id
 from excel_grapher.series_bindings.resolve import resolve_series_binding
 from excel_grapher.series_bindings.setter_codegen import _canonical_key_order
 from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
@@ -23,15 +24,15 @@ class BindingsSmokeError(RuntimeError):
     """Raised when a generated setter or compute fails a smoke check."""
 
 
-def _key_concepts(series: dict[str, Any]) -> list[str]:
+def _key_fields(series: dict[str, Any]) -> list[str]:
     key = series.get("key")
     if isinstance(key, list):
         return [str(item) for item in key]
     dimensions = (series.get("structure") or {}).get("dimensions") or []
     return [
-        str(dim["concept"])
+        effective_dimension_id(dim)
         for dim in dimensions
-        if isinstance(dim, dict) and dim.get("role") == "key" and dim.get("concept")
+        if isinstance(dim, dict) and dim.get("role") == "key" and effective_dimension_id(dim)
     ]
 
 
@@ -110,7 +111,7 @@ def _find_single_key_setter_candidate(
         series = _series_for_setter(bindings, name)
         if str(series.get("layout") or "series") == "scalar":
             continue
-        key_fields = _key_concepts(series)
+        key_fields = _key_fields(series)
         if len(key_fields) != 1:
             continue
         resolved = resolve_series_binding(
@@ -140,7 +141,7 @@ def _find_matrix_setter_candidate(
         series = _series_for_setter(bindings, name)
         if str(series.get("layout") or "series") != "matrix":
             continue
-        key_fields = _key_concepts(series)
+        key_fields = _key_fields(series)
         if len(key_fields) < 2:
             continue
         resolved = resolve_series_binding(
@@ -165,7 +166,7 @@ def _smoke_setter_positional_input(
     make_context: Callable[[], Any],
 ) -> None:
     setter = cast(SetterFn, getattr(pkg, setter_name))
-    key_fields = _key_concepts(series)
+    key_fields = _key_fields(series)
     key_field = key_fields[0]
     measure = _measure_concept(series)
     leaves = sorted(resolved["leaves"], key=lambda leaf: leaf["key"][key_field])
@@ -196,7 +197,7 @@ def _smoke_setter_dataframe_input(
     import pandas as pd
 
     setter = cast(SetterFn, getattr(pkg, setter_name))
-    key_fields = _key_concepts(series)
+    key_fields = _key_fields(series)
     key_field = key_fields[0]
     measure = _measure_concept(series)
     leaves = sorted(resolved["leaves"], key=lambda leaf: leaf["key"][key_field])
@@ -225,7 +226,7 @@ def _smoke_setter_matrix_dataframe_input(
     import pandas as pd
 
     setter = cast(SetterFn, getattr(pkg, setter_name))
-    key_fields = _key_concepts(series)
+    key_fields = _key_fields(series)
     measure = _measure_concept(series)
     leaf = resolved["leaves"][0]
     bumped = _bump_value(leaf["record"][measure])
@@ -354,7 +355,7 @@ def smoke_test_computes(
         if not resolved["ok"]:
             raise BindingsSmokeError(f"Compute {name!r} resolution failed: {resolved['issues']}")
         expected_count = len(resolved["leaves"])
-        key_fields = _key_concepts(series)
+        key_fields = _key_fields(series)
         records = compute(ctx=ctx)
         if not isinstance(records, list):
             raise BindingsSmokeError(f"Compute {name!r} did not return a list")

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from excel_grapher.grapher.graph import DependencyGraph
 from excel_grapher.series_bindings.graph_predicates import is_graph_formula_node, is_graph_leaf
 from excel_grapher.series_bindings.normalize import (
+    effective_dimension_id,
     effective_validation,
     has_input_direction,
     has_internal_direction,
@@ -80,10 +81,13 @@ def _validate_input_mode(series: dict[str, Any]) -> list[ValidationIssue]:
     ]
 
 
-def _dimension_concepts(series: dict[str, Any]) -> set[str]:
+def _dimension_field_ids(series: dict[str, Any]) -> set[str]:
+    """Effective dimension ids (declared id, else concept) for key matching."""
     structure = series.get("structure") or {}
     dims = structure.get("dimensions") or []
-    return {str(d.get("concept")) for d in dims if isinstance(d, dict) and d.get("concept")}
+    return {
+        effective_dimension_id(d) for d in dims if isinstance(d, dict) and effective_dimension_id(d)
+    }
 
 
 def _validate_input_binding_overlap(
@@ -336,20 +340,63 @@ def _validate_series_structure(series: dict[str, Any]) -> list[ValidationIssue]:
                 )
             )
 
+    issues.extend(_validate_unique_dimension_ids(series))
+
     key = series.get("key")
     if isinstance(key, list):
-        dim_concepts = _dimension_concepts(series)
-        for concept in key:
-            if concept not in dim_concepts:
+        field_ids = _dimension_field_ids(series)
+        for entry in key:
+            if entry not in field_ids:
                 issues.append(
                     _issue(
                         "error",
                         "key_not_in_dimensions",
-                        f"key concept {concept!r} is not declared in structure.dimensions",
+                        f"key entry {entry!r} does not match any dimension id in "
+                        "structure.dimensions (dimension ids default to concept)",
                         series_id=series_id,
                     )
                 )
 
+    return issues
+
+
+def _validate_unique_dimension_ids(series: dict[str, Any]) -> list[ValidationIssue]:
+    """Effective ids must be unique across dimensions and attributes of one series."""
+    issues: list[ValidationIssue] = []
+    series_id = str(series.get("id", ""))
+    structure = series.get("structure")
+    if not isinstance(structure, dict):
+        return issues
+
+    seen: dict[str, str] = {}
+    components = [
+        *(
+            (f"dimensions[{i}]", dim)
+            for i, dim in enumerate(structure.get("dimensions") or [])
+            if isinstance(dim, dict)
+        ),
+        *(
+            (f"attributes[{i}]", attr)
+            for i, attr in enumerate(structure.get("attributes") or [])
+            if isinstance(attr, dict)
+        ),
+    ]
+    for label, component in components:
+        field_id = effective_dimension_id(component)
+        if not field_id:
+            continue
+        if field_id in seen:
+            issues.append(
+                _issue(
+                    "error",
+                    "duplicate_dimension_id",
+                    f"{label} effective id {field_id!r} duplicates {seen[field_id]}; "
+                    "declare a distinct id to disambiguate components sharing a concept",
+                    series_id=series_id,
+                )
+            )
+        else:
+            seen[field_id] = label
     return issues
 
 
@@ -566,9 +613,10 @@ def validate_series_bindings(
             cell_scoped_keys = [
                 str(c)
                 for c in (series.get("key") or [])
-                if c in _dimension_concepts(series)
-                and any(
-                    isinstance(d, dict) and d.get("concept") == c and d.get("scope") == "cell"
+                if any(
+                    isinstance(d, dict)
+                    and effective_dimension_id(d) == str(c)
+                    and d.get("scope") == "cell"
                     for d in (series.get("structure") or {}).get("dimensions") or []
                 )
             ]

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -513,18 +513,32 @@ def _validate_dtype_read_consistency(
     for index, dim in enumerate(structure.get("dimensions") or []):
         if not isinstance(dim, dict):
             continue
-        concept = str(dim.get("concept", f"dimensions[{index}]"))
-        dtype = concept_dtypes.get(concept)
+        field_id = effective_dimension_id(dim) or f"dimensions[{index}]"
+        declared_dtype = dim.get("dtype")
+        dtype = (
+            str(declared_dtype)
+            if declared_dtype is not None
+            else concept_dtypes.get(str(dim.get("concept", "")))
+        )
         bind = dim.get("bind")
         if not isinstance(bind, dict) or dtype is None:
             continue
         read = str(bind.get("read", "auto"))
         if not _read_matches_dtype(read, dtype):
+            hint = (
+                ""
+                if declared_dtype is not None
+                else (
+                    "; declare a per-dimension dtype if this dimension's storage type "
+                    "intentionally differs from the concept, or use a separate concept"
+                )
+            )
             issues.append(
                 _issue(
                     "warning",
                     "dtype_read_mismatch",
-                    f"dimension {concept!r} dtype {dtype!r} does not match bind read {read!r}",
+                    f"dimension {field_id!r} dtype {dtype!r} does not match bind read "
+                    f"{read!r}{hint}",
                     series_id=series_id,
                 )
             )

--- a/excel_grapher/series_bindings/versions.py
+++ b/excel_grapher/series_bindings/versions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 SUPPORTED_SCHEMA_VERSIONS: frozenset[str] = frozenset(
-    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"}
+    {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0"}
 )
 
 IMPLEMENTED_BIND_KINDS: frozenset[str] = frozenset(

--- a/tests/fixtures/series_bindings/reference_period_1_8_0.yaml
+++ b/tests/fixtures/series_bindings/reference_period_1_8_0.yaml
@@ -1,0 +1,45 @@
+schema_version: "1.8.0"
+workbook: reference_period.xlsx
+concept_scheme:
+  concepts:
+    - id: TIME_PERIOD
+      name: Time period
+      dtype: int
+series:
+  - id: gdp_vs_reference
+    sheet: Inputs
+    data_range: Inputs!F5:H5
+    layout: series
+    input:
+      setter:
+        name: set_gdp_vs_reference
+    structure:
+      measure:
+        concept: OBS_VALUE
+        dtype: float
+        bind:
+          kind: data_cell
+          read: float
+      dimensions:
+        - concept: TIME_PERIOD
+          role: key
+          scope: cell
+          bind:
+            kind: column_header
+            header_row: 1
+            read: int
+        # Comparison period: a second dimension referencing the same
+        # TIME_PERIOD concept, disambiguated by an explicit dimension id.
+        - id: REFERENCE_TIME_PERIOD
+          concept: TIME_PERIOD
+          role: key
+          scope: series
+          bind:
+            kind: cell
+            address: Inputs!B1
+    key:
+      - TIME_PERIOD
+      - REFERENCE_TIME_PERIOD
+    notes: >-
+      GDP by year compared against a reference year; both key dimensions share
+      the TIME_PERIOD concept and inherit its int dtype from the concept scheme.

--- a/tests/unit/series_bindings/test_dimension_id.py
+++ b/tests/unit/series_bindings/test_dimension_id.py
@@ -1,0 +1,317 @@
+"""Tests for dimension id vs concept separation (schema 1.8.0).
+
+A dimension may declare an `id` distinct from its `concept` (SDMX concept
+identity), so two dimensions in one series can share a concept (e.g. a
+`TIME_PERIOD` axis and a `REFERENCE_TIME_PERIOD` comparison period). Record
+fields and `key` entries use the effective dimension id (`id` when declared,
+else `concept`); dtype inheritance from `concept_scheme` keys on `concept`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import xlsxwriter
+
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.runtime.cache import EvalContext, coerce_inputs_dict
+from excel_grapher.series_bindings import (
+    expand_data_range,
+    load_series_bindings,
+    resolve_series_binding,
+    validate_series_bindings,
+)
+from excel_grapher.series_bindings.docstrings import derive_doc_contract
+from excel_grapher.series_bindings.normalize import effective_dimension_id
+from excel_grapher.series_bindings.schema import validate_bindings_document
+from excel_grapher.series_bindings.setter_codegen import (
+    emit_input_coerce_helpers,
+    emit_setter_function,
+    emit_setter_helpers,
+)
+from excel_grapher.series_bindings.versions import SUPPORTED_SCHEMA_VERSIONS
+from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
+
+
+def _write_reference_period_workbook(path: Path) -> None:
+    """Row of GDP by year plus a reference-year cell shared by every leaf."""
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write_number("B1", 2019)
+    ws.write("A2", "Borvelia")
+    ws.write("A5", "GDP")
+    for offset, year in enumerate([2020, 2021, 2022]):
+        ws.write_number(0, 5 + offset, year)
+        ws.write_number(4, 5 + offset, float(offset + 1))
+    wb.close()
+
+
+def _reference_period_series(**overrides: Any) -> dict[str, Any]:
+    series: dict[str, Any] = {
+        "id": "gdp_vs_reference",
+        "sheet": "Inputs",
+        "data_range": "Inputs!F5:H5",
+        "layout": "series",
+        "input": {"setter": {"name": "set_gdp_vs_reference"}},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+            "dimensions": [
+                {
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                },
+                {
+                    "id": "REFERENCE_TIME_PERIOD",
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "series",
+                    "bind": {"kind": "cell", "address": "Inputs!B1"},
+                },
+            ],
+        },
+        "key": ["TIME_PERIOD", "REFERENCE_TIME_PERIOD"],
+    }
+    series.update(overrides)
+    return series
+
+
+def _reference_period_document(**series_overrides: Any) -> dict[str, Any]:
+    return {
+        "schema_version": "1.8.0",
+        "concept_scheme": {
+            "concepts": [{"id": "TIME_PERIOD", "name": "Time period", "dtype": "int"}]
+        },
+        "series": [_reference_period_series(**series_overrides)],
+    }
+
+
+def _reference_period_graph(tmp_path: Path) -> tuple[Path, Any]:
+    wb_path = tmp_path / "reference_period.xlsx"
+    _write_reference_period_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!F5:H5"),
+        load_values=True,
+    )
+    return wb_path, graph
+
+
+# --- effective_dimension_id helper ---
+
+
+def test_effective_dimension_id_defaults_to_concept() -> None:
+    assert effective_dimension_id({"concept": "TIME_PERIOD"}) == "TIME_PERIOD"
+
+
+def test_effective_dimension_id_prefers_declared_id() -> None:
+    dim = {"id": "REFERENCE_TIME_PERIOD", "concept": "TIME_PERIOD"}
+    assert effective_dimension_id(dim) == "REFERENCE_TIME_PERIOD"
+
+
+def test_effective_dimension_id_empty_component() -> None:
+    assert effective_dimension_id({}) == ""
+
+
+# --- schema and versions ---
+
+
+def test_schema_version_1_8_0_supported() -> None:
+    assert "1.8.0" in SUPPORTED_SCHEMA_VERSIONS
+
+
+def test_schema_accepts_dimension_and_attribute_id() -> None:
+    doc = _reference_period_document()
+    doc["series"][0]["structure"]["attributes"] = [
+        {
+            "id": "SOURCE_UNIT",
+            "concept": "UNIT_MEASURE",
+            "role": "attribute",
+            "value": "PC_GDP",
+        }
+    ]
+    bindings = validate_bindings_document(doc)
+    dims = bindings["series"][0]["structure"]["dimensions"]
+    assert dims[1]["id"] == "REFERENCE_TIME_PERIOD"
+    assert dims[1]["concept"] == "TIME_PERIOD"
+
+
+def test_yaml_fixture_loads_and_resolves(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    bindings = load_series_bindings(FIXTURES / "reference_period_1_8_0.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+    assert resolved["ok"] is True, resolved["issues"]
+    keys = {
+        (leaf["key"]["TIME_PERIOD"], leaf["key"]["REFERENCE_TIME_PERIOD"])
+        for leaf in resolved["leaves"]
+    }
+    assert keys == {(2020, 2019), (2021, 2019), (2022, 2019)}
+
+
+# --- validation ---
+
+
+def test_validate_accepts_key_by_dimension_id(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    bindings = validate_bindings_document(_reference_period_document())
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "key_not_in_dimensions" not in codes
+    assert report["ok"] is True
+
+
+def test_validate_rejects_duplicate_effective_dimension_ids(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    del doc["series"][0]["structure"]["dimensions"][1]["id"]
+    doc["series"][0]["key"] = ["TIME_PERIOD"]
+    bindings = validate_bindings_document(doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    duplicate = [i for i in report["issues"] if i["code"] == "duplicate_dimension_id"]
+    assert duplicate, report["issues"]
+    assert duplicate[0]["level"] == "error"
+    assert "TIME_PERIOD" in duplicate[0]["message"]
+    assert report["ok"] is False
+
+
+def test_validate_key_must_use_declared_dimension_id(tmp_path: Path) -> None:
+    """A key entry naming the concept fails when the dimension declares an id."""
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    dims = doc["series"][0]["structure"]["dimensions"]
+    dims[0]["id"] = "PROJECTION_TIME_PERIOD"
+    doc["series"][0]["key"] = ["TIME_PERIOD", "REFERENCE_TIME_PERIOD"]
+    bindings = validate_bindings_document(doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "key_not_in_dimensions" in codes
+    assert report["ok"] is False
+
+
+# --- resolution ---
+
+
+def test_resolve_dimensions_sharing_concept(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    bindings = validate_bindings_document(doc)
+    series = bindings["series"][0]
+
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+
+    assert resolved["ok"] is True, resolved["issues"]
+    assert len(resolved["leaves"]) == 3
+    by_period = {leaf["key"]["TIME_PERIOD"]: leaf for leaf in resolved["leaves"]}
+    assert set(by_period) == {2020, 2021, 2022}
+    leaf = by_period[2021]
+    assert leaf["address"] == "Inputs!G5"
+    assert leaf["coordinates"]["TIME_PERIOD"] == 2021
+    # dtype inherited from concept_scheme via the shared TIME_PERIOD concept
+    assert leaf["coordinates"]["REFERENCE_TIME_PERIOD"] == 2019
+    assert leaf["key"] == {"TIME_PERIOD": 2021, "REFERENCE_TIME_PERIOD": 2019}
+    assert leaf["record"]["TIME_PERIOD"] == 2021
+    assert leaf["record"]["REFERENCE_TIME_PERIOD"] == 2019
+    assert leaf["record"]["OBS_VALUE"] == 2.0
+
+
+# --- setter codegen round trip ---
+
+
+def _exec_setters(lines: list[str]) -> dict[str, object]:
+    namespace: dict[str, object] = {
+        "EvalContext": EvalContext,
+        "coerce_inputs_dict": coerce_inputs_dict,
+    }
+    source_lines = emit_input_coerce_helpers() + emit_setter_helpers() + lines
+    exec("\n".join(source_lines), namespace)
+    return namespace
+
+
+def test_emit_setter_round_trips_dimension_id_key(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    bindings = validate_bindings_document(_reference_period_document())
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+    ns = _exec_setters(emit_setter_function(series, resolved))
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_gdp_vs_reference"],
+    )
+
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    setter(
+        ctx,
+        [{"TIME_PERIOD": 2021, "REFERENCE_TIME_PERIOD": 2019, "OBS_VALUE": 42.0}],
+    )
+    assert ctx.inputs["Inputs!G5"] == 42.0
+
+    with pytest.raises(ValueError, match="unknown fields"):
+        setter(
+            ctx,
+            [
+                {
+                    "TIME_PERIOD": 2021,
+                    "REFERENCE_TIME_PERIOD": 2019,
+                    "COMPARISON_AREA": "x",
+                    "OBS_VALUE": 1.0,
+                }
+            ],
+        )
+
+
+# --- docstring contract ---
+
+
+def test_doc_contract_fields_use_dimension_id(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    bindings = validate_bindings_document(_reference_period_document())
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+
+    contract = derive_doc_contract(
+        series,
+        function_kind="setter",
+        function_name="set_gdp_vs_reference",
+        resolution=resolved,
+        bindings=bindings,
+    )
+
+    assert "REFERENCE_TIME_PERIOD" in contract.fields
+    assert contract.required_fields == ("TIME_PERIOD", "REFERENCE_TIME_PERIOD", "OBS_VALUE")
+    reference = contract.fields["REFERENCE_TIME_PERIOD"]
+    # dtype and human name resolve through the underlying TIME_PERIOD concept
+    assert reference.dtype == "int"
+    assert reference.concept_name == "Time period"

--- a/tests/unit/series_bindings/test_dimension_id.py
+++ b/tests/unit/series_bindings/test_dimension_id.py
@@ -10,6 +10,7 @@ else `concept`); dtype inheritance from `concept_scheme` keys on `concept`.
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -26,7 +27,10 @@ from excel_grapher.series_bindings import (
 )
 from excel_grapher.series_bindings.docstrings import derive_doc_contract
 from excel_grapher.series_bindings.normalize import effective_dimension_id
-from excel_grapher.series_bindings.schema import validate_bindings_document
+from excel_grapher.series_bindings.schema import (
+    SeriesBindingsSchemaError,
+    validate_bindings_document,
+)
 from excel_grapher.series_bindings.setter_codegen import (
     emit_input_coerce_helpers,
     emit_setter_function,
@@ -41,6 +45,8 @@ def _write_reference_period_workbook(path: Path) -> None:
     wb = xlsxwriter.Workbook(path)
     ws = wb.add_worksheet("Inputs")
     ws.write_number("B1", 2019)
+    date_format = wb.add_format({"num_format": "yyyy-mm-dd"})
+    ws.write_datetime("C1", datetime(2019, 1, 15), date_format)
     ws.write("A2", "Borvelia")
     ws.write("A5", "GDP")
     for offset, year in enumerate([2020, 2021, 2022]):
@@ -315,3 +321,188 @@ def test_doc_contract_fields_use_dimension_id(tmp_path: Path) -> None:
     # dtype and human name resolve through the underlying TIME_PERIOD concept
     assert reference.dtype == "int"
     assert reference.concept_name == "Time period"
+
+
+# --- per-dimension dtype (same concept, different storage type) ---
+
+
+def _reference_date_series(**overrides: Any) -> dict[str, Any]:
+    """Same-concept dimensions with differing storage: int axis vs datetime cell."""
+    series = _reference_period_series(**overrides)
+    series["structure"]["dimensions"][1] = {
+        "id": "REFERENCE_TIME_PERIOD",
+        "concept": "TIME_PERIOD",
+        "dtype": "datetime",
+        "role": "key",
+        "scope": "series",
+        "bind": {"kind": "cell", "address": "Inputs!C1"},
+    }
+    return series
+
+
+def test_schema_accepts_dimension_dtype() -> None:
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    bindings = validate_bindings_document(doc)
+    assert bindings["series"][0]["structure"]["dimensions"][1]["dtype"] == "datetime"
+
+
+def test_schema_rejects_attribute_dtype() -> None:
+    doc = _reference_period_document()
+    doc["series"][0]["structure"]["attributes"] = [
+        {
+            "concept": "UNIT_MEASURE",
+            "role": "attribute",
+            "value": "PC_GDP",
+            "dtype": "string",
+        }
+    ]
+    with pytest.raises(SeriesBindingsSchemaError, match="dtype"):
+        validate_bindings_document(doc)
+
+
+def test_resolve_dimension_dtype_overrides_concept_dtype(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    bindings = validate_bindings_document(doc)
+    series = bindings["series"][0]
+
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+
+    assert resolved["ok"] is True, resolved["issues"]
+    leaf = resolved["leaves"][0]
+    # TIME_PERIOD still inherits int from the concept scheme; the reference
+    # dimension's declared dtype wins over the shared concept's int.
+    assert leaf["key"]["TIME_PERIOD"] == 2020
+    assert leaf["key"]["REFERENCE_TIME_PERIOD"] == datetime(2019, 1, 15)
+
+
+def test_resolve_series_context_uses_dimension_dtype(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    dim = doc["series"][0]["structure"]["dimensions"][1]
+    dim["include_in_record"] = False
+    doc["series"][0]["key"] = ["TIME_PERIOD"]
+    doc["series"][0]["series_context"] = {"REFERENCE_TIME_PERIOD": "2019-01-15"}
+    bindings = validate_bindings_document(doc)
+    series = bindings["series"][0]
+
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+
+    assert resolved["ok"] is True, resolved["issues"]
+    record = resolved["leaves"][0]["record"]
+    assert record["REFERENCE_TIME_PERIOD"] == datetime(2019, 1, 15)
+
+
+def test_emit_setter_key_dtypes_include_dimension_dtype(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    bindings = validate_bindings_document(doc)
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+    lines = emit_setter_function(series, resolved)
+    code = "\n".join(lines)
+    assert "'REFERENCE_TIME_PERIOD': 'datetime'" in code
+
+    ns = _exec_setters(lines)
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_gdp_vs_reference"],
+    )
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    setter(
+        ctx,
+        [
+            {
+                "TIME_PERIOD": 2021,
+                "REFERENCE_TIME_PERIOD": datetime(2019, 1, 15),
+                "OBS_VALUE": 42.0,
+            }
+        ],
+    )
+    assert ctx.inputs["Inputs!G5"] == 42.0
+
+
+def test_doc_contract_reports_dimension_dtype(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    bindings = validate_bindings_document(doc)
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+        direction="input",
+    )
+
+    contract = derive_doc_contract(
+        series,
+        function_kind="setter",
+        function_name="set_gdp_vs_reference",
+        resolution=resolved,
+        bindings=bindings,
+    )
+
+    # declared per-dimension dtype wins over the shared concept's int dtype
+    assert contract.fields["REFERENCE_TIME_PERIOD"].dtype == "datetime"
+    assert contract.fields["TIME_PERIOD"].dtype == "int"
+
+
+def test_validate_warns_on_dimension_dtype_read_mismatch(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    dim = doc["series"][0]["structure"]["dimensions"][1]
+    dim["bind"]["read"] = "int"
+    bindings = validate_bindings_document(doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    mismatches = [i for i in report["issues"] if i["code"] == "dtype_read_mismatch"]
+    assert mismatches
+    assert "REFERENCE_TIME_PERIOD" in mismatches[0]["message"]
+
+
+def test_validate_read_diverging_from_concept_suggests_dimension_dtype(tmp_path: Path) -> None:
+    """bind.read conflicting with inherited concept dtype nudges toward dtype or split."""
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    dim = doc["series"][0]["structure"]["dimensions"][1]
+    dim["bind"]["read"] = "datetime"
+    bindings = validate_bindings_document(doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    mismatches = [i for i in report["issues"] if i["code"] == "dtype_read_mismatch"]
+    assert mismatches
+    assert "per-dimension dtype" in mismatches[0]["message"]
+
+
+def test_validate_dimension_dtype_without_read_is_clean(tmp_path: Path) -> None:
+    wb_path, graph = _reference_period_graph(tmp_path)
+    doc = _reference_period_document()
+    doc["series"][0] = _reference_date_series()
+    bindings = validate_bindings_document(doc)
+    report = validate_series_bindings(graph, bindings, workbook=wb_path)
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "dtype_read_mismatch" not in codes
+    assert report["ok"] is True

--- a/tests/unit/series_bindings/test_versions.py
+++ b/tests/unit/series_bindings/test_versions.py
@@ -17,7 +17,9 @@ from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
 
 
 def test_supported_schema_versions() -> None:
-    expected = frozenset({"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0"})
+    expected = frozenset(
+        {"1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0", "1.7.0", "1.8.0"}
+    )
     assert expected == SUPPORTED_SCHEMA_VERSIONS
 
 

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -656,7 +656,7 @@ Generated code imports `datetime` and emits `datetime.datetime(...)` literals on
 | **1.5.0** | Grouped-row matrix geometry: `skip`/`include`/`fill`/`missing` on `row_label` and `column_header` binds, the `value_map` bind kind, and series-level `exclude_rows`. |
 | **1.6.0** | `input.mode: override` for user-editable formula cells (non-leaf input setters). |
 | **1.7.0** | `internal` direction for non-I/O formula-cell key triangulation (`intersect_graph_formulas` validation). |
-| **1.8.0** | Optional dimension/attribute `id` separating dimension identity from concept, so multiple dimensions can share one concept. |
+| **1.8.0** | Optional dimension/attribute `id` separating dimension identity from concept, so multiple dimensions can share one concept; optional per-dimension `dtype` for same-concept dimensions with differing storage types. |
 
 ## Dimension ids vs concepts (1.8.0)
 
@@ -686,6 +686,35 @@ must be used in `key` entries; effective ids must be unique within a series' str
 from `concept_scheme` (here `REFERENCE_TIME_PERIOD` inherits `TIME_PERIOD`'s `int` dtype) and
 docstring names. Attributes accept `id` the same way. Manifests without `id` are unchanged —
 the effective id defaults to the concept.
+
+### Per-dimension `dtype`
+
+Same-concept dimensions usually share the concept's storage type. When they genuinely differ —
+say an `int` projection axis and a calendar-date comparison period — first ask whether the two
+really share one concept: a calendar date and an integer offset under one `TIME_PERIOD` is often
+a semantic stretch, and splitting into separate concepts is the cleaner model. When they do
+belong together, declare a per-dimension `dtype` to override the concept-scheme dtype for that
+dimension only:
+
+```yaml
+dimensions:
+  - concept: TIME_PERIOD            # int, inherited from concept_scheme
+    role: key
+    scope: cell
+    bind: {kind: column_header, header_row: 1, read: int}
+  - id: REFERENCE_TIME_PERIOD
+    concept: TIME_PERIOD
+    dtype: datetime                 # this dimension stores a calendar date
+    role: key
+    scope: series
+    bind: {kind: cell, address: Inputs!C1}
+```
+
+The declared `dtype` drives value coercion when the bind has no explicit `read` (an explicit
+`read` still wins), flows into generated setter key coercion, and is reported in docstrings
+instead of the concept's dtype. Relying on a divergent `bind.read` alone (without `dtype`)
+triggers the `dtype_read_mismatch` warning, which nudges you to either declare the
+per-dimension `dtype` or split the concepts.
 
 ## Validation and codegen closure
 

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -656,6 +656,36 @@ Generated code imports `datetime` and emits `datetime.datetime(...)` literals on
 | **1.5.0** | Grouped-row matrix geometry: `skip`/`include`/`fill`/`missing` on `row_label` and `column_header` binds, the `value_map` bind kind, and series-level `exclude_rows`. |
 | **1.6.0** | `input.mode: override` for user-editable formula cells (non-leaf input setters). |
 | **1.7.0** | `internal` direction for non-I/O formula-cell key triangulation (`intersect_graph_formulas` validation). |
+| **1.8.0** | Optional dimension/attribute `id` separating dimension identity from concept, so multiple dimensions can share one concept. |
+
+## Dimension ids vs concepts (1.8.0)
+
+Following SDMX, a **concept** (e.g. `TIME_PERIOD`) is the meaning category a dimension falls
+into, while a **dimension** is the parameter that keys or qualifies observations. Usually one
+dimension per concept suffices, so `concept` doubles as the dimension's identity. When a series
+needs two dimensions in the same concept category — a projection year *and* a comparison year,
+a reference area *and* a counterpart area — declare an explicit `id` on the extra dimension:
+
+```yaml
+dimensions:
+  - concept: TIME_PERIOD          # effective id: TIME_PERIOD
+    role: key
+    scope: cell
+    bind: {kind: column_header, header_row: 1, read: int}
+  - id: REFERENCE_TIME_PERIOD     # effective id: REFERENCE_TIME_PERIOD
+    concept: TIME_PERIOD          # same concept, different dimension
+    role: key
+    scope: series
+    bind: {kind: cell, address: Inputs!B1}
+key: [TIME_PERIOD, REFERENCE_TIME_PERIOD]
+```
+
+The **effective dimension id** (`id` when declared, else `concept`) names the record field and
+must be used in `key` entries; effective ids must be unique within a series' structure
+(`duplicate_dimension_id` validation). The `concept` keeps its semantic jobs: dtype inheritance
+from `concept_scheme` (here `REFERENCE_TIME_PERIOD` inherits `TIME_PERIOD`'s `int` dtype) and
+docstring names. Attributes accept `id` the same way. Manifests without `id` are unchanged —
+the effective id defaults to the concept.
 
 ## Validation and codegen closure
 

--- a/user_guide/cli.qmd
+++ b/user_guide/cli.qmd
@@ -141,7 +141,7 @@ validation runs:
 
 ```text
 Binding sidecar schema error:
-  series[8] "puka_week_1_fantasy_score": missing required field `key` — Add a key list naming the dimension concepts that identify each record.
+  series[8] "puka_week_1_fantasy_score": missing required field `key` — Add a key list naming the dimension ids that identify each record.
 ```
 
 Locations use the series index and `id` from the sidecar so you can jump straight to the offending


### PR DESCRIPTION
## Summary

Upstream half of Teal-Insights/tiny-dsa-extraction-pipeline#41 ("Separate concept and dimension in bindings schema").

Following SDMX, a **concept** is the meaning category (`TIME_PERIOD`, `REF_AREA`) while a **dimension** is the parameter that keys or qualifies observations. The bindings schema previously collapsed the two: `Dimension.concept` was simultaneously the dimension's identity, the record field name, the `key` entry, and the concept-scheme dtype lookup key — making it impossible to declare two dimensions sharing one concept (a projection year *and* a comparison year; a reference area *and* a counterpart area).

Schema **1.8.0** adds an optional `id` on `Dimension` and `Attribute`. The **effective dimension id** (`id` when declared, else `concept`) names record fields and `key` entries; `concept` keeps its semantic jobs (dtype inheritance from `concept_scheme`, docstring names). Manifests without `id` are byte-for-byte unchanged in behavior.

```yaml
dimensions:
  - concept: TIME_PERIOD          # effective id: TIME_PERIOD
    role: key
    scope: cell
    bind: {kind: column_header, header_row: 1, read: int}
  - id: REFERENCE_TIME_PERIOD     # same concept, distinct dimension
    concept: TIME_PERIOD
    role: key
    scope: series
    bind: {kind: cell, address: Inputs!B1}
key: [TIME_PERIOD, REFERENCE_TIME_PERIOD]
```

## Changes

- `effective_dimension_id()` in `normalize.py`; all field-name derivation in `resolve.py`, `validate.py`, `setter_codegen.py`, `docstrings.py`, and `smoke.py` routes through it
- Resolution keys coordinates/records/keys by effective id; dtype inheritance and docstring concept names still resolve through the underlying concept, so `REFERENCE_TIME_PERIOD` inherits `TIME_PERIOD`'s dtype
- New `duplicate_dimension_id` validation error: effective ids must be unique across a series' dimensions and attributes (previously two dimensions sharing a concept silently collided in the coordinates dict, last bind winning)
- `key_not_in_dimensions` matches effective ids, so a key entry naming the concept is rejected when the dimension declares a different id
- Schema JSON: `DimensionId` def, `id` on Dimension/Attribute, 1.8.0 version enum entry; `versions.py` updated
- Docs: new "Dimension ids vs concepts (1.8.0)" user-guide section, schema-version table row, updated CLI `key` hint

## Test plan

- [x] 12 new tests in `tests/unit/series_bindings/test_dimension_id.py` (TDD, RED-first): helper semantics, schema acceptance, YAML fixture load, `duplicate_dimension_id`, key-by-id matching, resolution of two dimensions sharing `TIME_PERIOD`, generated-setter round trip keyed by both periods, docstring contract dtype/name inheritance
- [x] Full suite: 1864 passed, 1 skipped, 4 xfailed
- [x] `ruff check`, `ruff format --check`, `ty check` clean
- [x] CLI end-to-end: `excel-grapher bindings validate --smoke-test` passes on the shipped `ff.bindings.yaml` example and on a scratch workbook using the new shared-concept manifest (generated setter applies records keyed by `TIME_PERIOD` + `REFERENCE_TIME_PERIOD`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)