### PR TITLE
test(parity): assert Excel error codes in excel_workbook_parity

### DIFF
--- a/tests/utils/excel_live_parity.py
+++ b/tests/utils/excel_live_parity.py
@@ -15,8 +15,14 @@ import fastpyxl.utils.cell
 import pytest
 import xlsxwriter
 
-from excel_grapher import FormulaEvaluator, XlError, create_dependency_graph
+from excel_grapher import FormulaEvaluator, create_dependency_graph
 from excel_grapher.core.address_keys import normalize_key
+from tests.utils.excel_workbook_parity import (
+    ParityMismatchKind,
+)
+from tests.utils.excel_workbook_parity import (
+    compare_cached_to_evaluator as _compare_cached_to_evaluator,
+)
 from tests.utils.modify_and_recalculate import (
     ExcelRecalculationError,
     modify_and_recalculate_workbook,
@@ -35,9 +41,12 @@ class LiveExcelParityMismatchKind(Enum):
     NUMBER_VS_XL_ERROR = "number_vs_xl_error"
     EXCEPTION = "exception"
     NOT_IMPLEMENTED = "not_implemented"
-    NONE_RESULT = "none_result"
     TYPE_MISMATCH = "type_mismatch"
     MISSING_TARGET = "missing_target"
+
+
+def _workbook_kind_to_live(kind: ParityMismatchKind) -> LiveExcelParityMismatchKind:
+    return LiveExcelParityMismatchKind(kind.value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,21 +110,6 @@ def write_live_excel_workbook(
     wb.close()
 
 
-def _normalize_cached_excel_value(raw: object) -> object:
-    if isinstance(raw, str):
-        err = XlError.from_text(raw)
-        if err is not None:
-            return err
-    return raw
-
-
-def _numeric_close(a: float, b: float, *, rtol: float, atol: float) -> bool:
-    if a == b:
-        return True
-    scale = max(abs(a), abs(b), 1.0)
-    return abs(a - b) <= max(atol, rtol * scale)
-
-
 def compare_cached_to_evaluator(
     excel_cached: object,
     evaluator_result: object,
@@ -124,31 +118,15 @@ def compare_cached_to_evaluator(
     atol: float = 1e-9,
 ) -> LiveExcelParityMismatchKind | None:
     """Return a mismatch kind when Excel cached value differs from evaluator output."""
-    cached = _normalize_cached_excel_value(excel_cached)
-
-    if isinstance(cached, XlError):
-        if isinstance(evaluator_result, XlError):
-            if cached == evaluator_result:
-                return None
-            return LiveExcelParityMismatchKind.XL_ERROR_CODE_MISMATCH
-        return LiveExcelParityMismatchKind.XL_ERROR_VS_NUMBER
-
-    if isinstance(evaluator_result, XlError):
-        return LiveExcelParityMismatchKind.NUMBER_VS_XL_ERROR
-
-    if (
-        isinstance(cached, (int, float))
-        and not isinstance(cached, bool)
-        and isinstance(evaluator_result, (int, float))
-        and not isinstance(evaluator_result, bool)
-    ):
-        if _numeric_close(float(cached), float(evaluator_result), rtol=rtol, atol=atol):
-            return None
-        return LiveExcelParityMismatchKind.NUMERIC_DRIFT
-
-    if cached == evaluator_result:
+    kind = _compare_cached_to_evaluator(
+        excel_cached,
+        evaluator_result,
+        rtol=rtol,
+        atol=atol,
+    )
+    if kind is None:
         return None
-    return LiveExcelParityMismatchKind.TYPE_MISMATCH
+    return _workbook_kind_to_live(kind)
 
 
 def format_live_excel_parity_report(mismatches: list[LiveExcelParityMismatch]) -> str:

--- a/tests/utils/excel_workbook_parity.py
+++ b/tests/utils/excel_workbook_parity.py
@@ -23,6 +23,7 @@ class ParityMismatchKind(Enum):
     """High-level classification for workbook-vs-evaluator differences."""
 
     NUMERIC_DRIFT = "numeric_drift"
+    XL_ERROR_CODE_MISMATCH = "xl_error_code_mismatch"
     XL_ERROR_VS_NUMBER = "xl_error_vs_number"
     NUMBER_VS_XL_ERROR = "number_vs_xl_error"
     EXCEPTION = "exception"
@@ -61,6 +62,57 @@ def _numeric_close(a: float, b: float, *, rtol: float, atol: float) -> bool:
     return abs(a - b) <= max(atol, rtol * scale)
 
 
+def _normalize_cached_excel_value(raw: object) -> object:
+    if isinstance(raw, str):
+        err = XlError.from_text(raw)
+        if err is not None:
+            return err
+    return raw
+
+
+def compare_cached_to_evaluator(
+    excel_cached: object,
+    evaluator_result: object,
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-9,
+) -> ParityMismatchKind | None:
+    """Return a mismatch kind when Excel cached value differs from evaluator output."""
+    cached = _normalize_cached_excel_value(excel_cached)
+
+    if isinstance(cached, XlError):
+        if isinstance(evaluator_result, XlError):
+            if cached == evaluator_result:
+                return None
+            return ParityMismatchKind.XL_ERROR_CODE_MISMATCH
+        return ParityMismatchKind.XL_ERROR_VS_NUMBER
+
+    if isinstance(evaluator_result, XlError):
+        return ParityMismatchKind.NUMBER_VS_XL_ERROR
+
+    if (
+        isinstance(cached, (int, float))
+        and not isinstance(cached, bool)
+        and isinstance(evaluator_result, (int, float))
+        and not isinstance(evaluator_result, bool)
+    ):
+        if _numeric_close(float(cached), float(evaluator_result), rtol=rtol, atol=atol):
+            return None
+        return ParityMismatchKind.NUMERIC_DRIFT
+
+    if cached == evaluator_result:
+        return None
+    return ParityMismatchKind.TYPE_MISMATCH
+
+
+def _is_comparable_cached_value(cached: object) -> bool:
+    if isinstance(cached, XlError):
+        return True
+    if isinstance(cached, (int, float)) and not isinstance(cached, bool):
+        return True
+    return isinstance(cached, str) and XlError.from_text(cached) is not None
+
+
 def compare_evaluator_to_excel_cache(
     graph: DependencyGraph,
     addresses: list[str],
@@ -71,7 +123,7 @@ def compare_evaluator_to_excel_cache(
 ) -> list[WorkbookParityMismatch]:
     """Evaluate each address and compare to the node's cached workbook value.
 
-    Only compares when the cached value is a finite float/int (non-bool).
+    Compares finite numeric cells and Excel error strings (e.g. ``'#NUM!'``).
     """
     mismatches: list[WorkbookParityMismatch] = []
 
@@ -90,8 +142,6 @@ def compare_evaluator_to_excel_cache(
             if node is None:
                 continue
             cached = node.value
-            if not isinstance(cached, (int, float)) or isinstance(cached, bool):
-                continue
             formula = _formula_for(addr)
             try:
                 computed = ev._evaluate_cell(addr)  # noqa: SLF001
@@ -122,52 +172,24 @@ def compare_evaluator_to_excel_cache(
                     return mismatches
                 continue
 
-            if isinstance(computed, XlError):
-                mismatches.append(
-                    WorkbookParityMismatch(
-                        address=addr,
-                        kind=ParityMismatchKind.XL_ERROR_VS_NUMBER,
-                        excel_cached=cached,
-                        evaluator_result=computed,
-                        formula=formula,
-                    )
-                )
-                if fail_fast:
-                    return mismatches
-                continue
-            if computed is None:
-                mismatches.append(
-                    WorkbookParityMismatch(
-                        address=addr,
-                        kind=ParityMismatchKind.NONE_RESULT,
-                        excel_cached=cached,
-                        evaluator_result=None,
-                        formula=formula,
-                    )
-                )
-                if fail_fast:
-                    return mismatches
-                continue
-            if isinstance(computed, (int, float)) and not isinstance(computed, bool):
-                if _numeric_close(float(cached), float(computed), rtol=rtol, atol=atol):
-                    continue
-                mismatches.append(
-                    WorkbookParityMismatch(
-                        address=addr,
-                        kind=ParityMismatchKind.NUMERIC_DRIFT,
-                        excel_cached=cached,
-                        evaluator_result=computed,
-                        formula=formula,
-                    )
-                )
-                if fail_fast:
-                    return mismatches
+            if computed is None and cached is None:
                 continue
 
+            if not _is_comparable_cached_value(cached):
+                continue
+
+            kind = compare_cached_to_evaluator(
+                cached,
+                computed,
+                rtol=rtol,
+                atol=atol,
+            )
+            if kind is None:
+                continue
             mismatches.append(
                 WorkbookParityMismatch(
                     address=addr,
-                    kind=ParityMismatchKind.TYPE_MISMATCH,
+                    kind=kind,
                     excel_cached=cached,
                     evaluator_result=computed,
                     formula=formula,

--- a/tests/utils/excel_workbook_parity.py
+++ b/tests/utils/excel_workbook_parity.py
@@ -28,7 +28,6 @@ class ParityMismatchKind(Enum):
     NUMBER_VS_XL_ERROR = "number_vs_xl_error"
     EXCEPTION = "exception"
     NOT_IMPLEMENTED = "not_implemented"
-    NONE_RESULT = "none_result"
     TYPE_MISMATCH = "type_mismatch"
 
 
@@ -77,7 +76,10 @@ def compare_cached_to_evaluator(
     rtol: float = 1e-5,
     atol: float = 1e-9,
 ) -> ParityMismatchKind | None:
-    """Return a mismatch kind when Excel cached value differs from evaluator output."""
+    """Return a mismatch kind when Excel cached value differs from evaluator output.
+
+    Returns ``None`` when the cached value and evaluator result match.
+    """
     cached = _normalize_cached_excel_value(excel_cached)
 
     if isinstance(cached, XlError):

--- a/tests/utils/test_excel_workbook_parity.py
+++ b/tests/utils/test_excel_workbook_parity.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from excel_grapher import DependencyGraph, Node, XlError
+from pathlib import Path
+
+import pytest
+import xlsxwriter
+
+from excel_grapher import DependencyGraph, Node, XlError, create_dependency_graph
 from excel_grapher.core.address_keys import parse_address
 from tests.utils.excel_workbook_parity import (
     ParityMismatchKind,
@@ -49,6 +54,14 @@ def test_compare_cached_error_string_matches_xl_error() -> None:
     assert compare_cached_to_evaluator("#NUM!", XlError.NUM, rtol=1e-5, atol=1e-9) is None
 
 
+def test_compare_cached_error_string_normalizes_whitespace_and_case() -> None:
+    assert compare_cached_to_evaluator("  #num!  ", XlError.NUM, rtol=1e-5, atol=1e-9) is None
+
+
+def test_compare_cached_xl_error_sentinel_matches() -> None:
+    assert compare_cached_to_evaluator(XlError.DIV, XlError.DIV, rtol=1e-5, atol=1e-9) is None
+
+
 def test_compare_cached_error_code_mismatch() -> None:
     assert (
         compare_cached_to_evaluator("#NUM!", XlError.DIV, rtol=1e-5, atol=1e-9)
@@ -91,9 +104,16 @@ def test_compare_evaluator_to_excel_cache_number_vs_error() -> None:
 
 
 def test_compare_evaluator_to_excel_cache_error_vs_number() -> None:
-    graph = _make_graph(_make_node("S!A1", None, 1.0))
+    graph = _make_graph(_make_node("S!A1", "=1", "#NUM!"))
     mismatches = compare_evaluator_to_excel_cache(graph, ["S!A1"])
-    assert mismatches == []
+    assert len(mismatches) == 1
+    assert mismatches[0].kind == ParityMismatchKind.XL_ERROR_VS_NUMBER
+    assert mismatches[0].evaluator_result == 1.0
+
+
+def test_compare_evaluator_to_excel_cache_leaf_literal_matches_cached_number() -> None:
+    graph = _make_graph(_make_node("S!A1", None, 1.0))
+    assert compare_evaluator_to_excel_cache(graph, ["S!A1"]) == []
 
 
 def test_assert_workbook_parity_numeric_unchanged() -> None:
@@ -103,3 +123,24 @@ def test_assert_workbook_parity_numeric_unchanged() -> None:
     )
     graph.add_edge("S!B1", "S!A1")
     assert_workbook_parity(graph, ["S!B1"])
+
+
+def test_assert_workbook_parity_raises_on_error_code_mismatch() -> None:
+    graph = _make_graph(_make_node("S!A1", "=1/0", "#NUM!"))
+    with pytest.raises(AssertionError, match="xl_error_code_mismatch"):
+        assert_workbook_parity(graph, ["S!A1"])
+
+
+def test_workbook_parity_error_strings_from_xlsx(tmp_path: Path) -> None:
+    wb_path = tmp_path / "errors.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("S")
+    ws.write_formula(0, 0, "=1/0", None, "#DIV/0!")
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["S!A1"], load_values=True)
+    node = graph.get_node("S!A1")
+    assert node is not None
+    assert node.value == "#DIV/0!"
+
+    assert compare_evaluator_to_excel_cache(graph, ["S!A1"]) == []

--- a/tests/utils/test_excel_workbook_parity.py
+++ b/tests/utils/test_excel_workbook_parity.py
@@ -1,0 +1,105 @@
+"""Unit tests for cached-workbook parity helpers (no xlwings required)."""
+
+from __future__ import annotations
+
+from excel_grapher import DependencyGraph, Node, XlError
+from excel_grapher.core.address_keys import parse_address
+from tests.utils.excel_workbook_parity import (
+    ParityMismatchKind,
+    assert_workbook_parity,
+    compare_cached_to_evaluator,
+    compare_evaluator_to_excel_cache,
+)
+
+
+def _make_node(address: str, formula: str | None, value: object) -> Node:
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=formula,
+        value=value,
+        is_leaf=formula is None,
+    )
+
+
+def _make_graph(*nodes: Node) -> DependencyGraph:
+    graph = DependencyGraph()
+    for node in nodes:
+        graph.add_node(node)
+    return graph
+
+
+def test_compare_cached_numeric_match() -> None:
+    assert compare_cached_to_evaluator(3.0, 3.0, rtol=1e-5, atol=1e-9) is None
+
+
+def test_compare_cached_numeric_drift() -> None:
+    assert (
+        compare_cached_to_evaluator(3.0, 4.0, rtol=1e-5, atol=1e-9)
+        == ParityMismatchKind.NUMERIC_DRIFT
+    )
+
+
+def test_compare_cached_error_string_matches_xl_error() -> None:
+    assert compare_cached_to_evaluator("#NUM!", XlError.NUM, rtol=1e-5, atol=1e-9) is None
+
+
+def test_compare_cached_error_code_mismatch() -> None:
+    assert (
+        compare_cached_to_evaluator("#NUM!", XlError.DIV, rtol=1e-5, atol=1e-9)
+        == ParityMismatchKind.XL_ERROR_CODE_MISMATCH
+    )
+
+
+def test_compare_cached_number_vs_evaluator_error() -> None:
+    assert (
+        compare_cached_to_evaluator(1.0, XlError.NUM, rtol=1e-5, atol=1e-9)
+        == ParityMismatchKind.NUMBER_VS_XL_ERROR
+    )
+
+
+def test_compare_cached_error_vs_evaluator_number() -> None:
+    assert (
+        compare_cached_to_evaluator("#NUM!", 1.0, rtol=1e-5, atol=1e-9)
+        == ParityMismatchKind.XL_ERROR_VS_NUMBER
+    )
+
+
+def test_compare_evaluator_to_excel_cache_matching_div_error() -> None:
+    graph = _make_graph(_make_node("S!A1", "=1/0", "#DIV/0!"))
+    assert compare_evaluator_to_excel_cache(graph, ["S!A1"]) == []
+
+
+def test_compare_evaluator_to_excel_cache_error_code_mismatch() -> None:
+    graph = _make_graph(_make_node("S!A1", "=1/0", "#NUM!"))
+    mismatches = compare_evaluator_to_excel_cache(graph, ["S!A1"])
+    assert len(mismatches) == 1
+    assert mismatches[0].kind == ParityMismatchKind.XL_ERROR_CODE_MISMATCH
+    assert mismatches[0].evaluator_result == XlError.DIV
+
+
+def test_compare_evaluator_to_excel_cache_number_vs_error() -> None:
+    graph = _make_graph(_make_node("S!A1", "=1/0", 1.0))
+    mismatches = compare_evaluator_to_excel_cache(graph, ["S!A1"])
+    assert len(mismatches) == 1
+    assert mismatches[0].kind == ParityMismatchKind.NUMBER_VS_XL_ERROR
+
+
+def test_compare_evaluator_to_excel_cache_error_vs_number() -> None:
+    graph = _make_graph(_make_node("S!A1", None, 1.0))
+    mismatches = compare_evaluator_to_excel_cache(graph, ["S!A1"])
+    assert mismatches == []
+
+
+def test_assert_workbook_parity_numeric_unchanged() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", None, 2.0),
+        _make_node("S!B1", "=S!A1+1", 3.0),
+    )
+    graph.add_edge("S!B1", "S!A1")
+    assert_workbook_parity(graph, ["S!B1"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #335. Extends the cached-workbook parity harness so evaluator ↔ Excel comparisons cover Excel error codes (`#NUM!`, `#DIV/0!`, etc.), not just finite numeric cells.

## Changes

- Add `XL_ERROR_CODE_MISMATCH` to `ParityMismatchKind` for evaluator/Excel both-errors-but-wrong-code cases.
- Add `compare_cached_to_evaluator` (mirrors `excel_live_parity`) with `XlError.from_text` normalization for cached error strings.
- Refactor `compare_evaluator_to_excel_cache` to route numeric and error comparisons through the shared helper.
- Add `tests/utils/test_excel_workbook_parity.py` with unit and synthetic-graph integration coverage.

## Testing

- `uv run pytest tests/utils/test_excel_workbook_parity.py -v` (11 passed)
- `uv run pytest tests/unit/gaps/test_sumproduct_criteria_gaps.py tests/utils/test_excel_live_parity.py -v` (existing callers, no regression)
- `uv run ruff check` / `ruff format --check` on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de7d5a31-5989-42ac-9f90-723041f280a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de7d5a31-5989-42ac-9f90-723041f280a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

