### PR TITLE
fix(evaluator): re-emit circular-reference warning on memoized re-evaluate

### DIFF
--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -24,7 +24,12 @@ from excel_grapher.grapher.blank_ranges import (
     address_in_blank_ranges,
     normalize_blank_range_specs,
 )
-from excel_grapher.runtime.cache import EvalContext, xl_circular_reference, xl_iterative_compute
+from excel_grapher.runtime.cache import (
+    EvalContext,
+    warn_circular_reference,
+    xl_circular_reference,
+    xl_iterative_compute,
+)
 from excel_grapher.runtime.info import xl_isblank
 
 from .ast_cache import DEFAULT_AST_CACHE_MAXSIZE, AstCache, AstCacheInfo
@@ -115,6 +120,7 @@ class FormulaEvaluator:
         # `EvalContext` runtime, keeping evaluator and export in parity.
         self._runtime_deps: dict[str, set[str]] = {}
         self._runtime_reverse_deps: dict[str, set[str]] = {}
+        self._circular_warning_roots: set[str] = set()
 
     def __enter__(self) -> FormulaEvaluator:
         return self
@@ -125,6 +131,7 @@ class FormulaEvaluator:
     def clear_caches(self) -> None:
         """Clear cached cell values and parsed formula ASTs."""
         self._cache.clear()
+        self._circular_warning_roots.clear()
         self._ast_cache.clear()
 
     def ast_cache_info(self) -> AstCacheInfo:
@@ -157,6 +164,7 @@ class FormulaEvaluator:
                 continue
             seen.add(addr)
             self._cache.pop(addr, None)
+            self._circular_warning_roots.discard(addr)
             to_visit.extend(self._runtime_reverse_deps.get(addr, set()))
             for dep in self._runtime_deps.get(addr, set()):
                 parents = self._runtime_reverse_deps.get(dep)
@@ -281,13 +289,19 @@ class FormulaEvaluator:
                     # Cache was invalidated, need to re-evaluate (fall through)
                     pass
                 else:
+                    if norm in self._circular_warning_roots:
+                        warn_circular_reference(stacklevel=3)
                     return self._cache[norm]
             else:
+                if norm in self._circular_warning_roots:
+                    warn_circular_reference(stacklevel=3)
                 return self._cache[norm]
 
         if norm in self._call_stack:
             if self.iterate_enabled:
                 return self._iteration_values.get(norm, 0)
+            root = self._call_stack[0]
+            self._circular_warning_roots.add(root)
             return xl_circular_reference()
 
         if self._blank_range_rects and address_in_blank_ranges(norm, self._blank_range_rects):

--- a/excel_grapher/runtime/cache.py
+++ b/excel_grapher/runtime/cache.py
@@ -18,6 +18,7 @@ __all__ = [
     "EvalContextBase",
     "circular_safe_cache",
     "coerce_inputs_dict",
+    "warn_circular_reference",
     "xl_cell",
     "xl_circular_reference",
     "xl_eval",
@@ -33,13 +34,18 @@ class CircularReferenceWarning(RuntimeWarning):
     """Warning emitted when a circular reference is encountered (default Excel mode)."""
 
 
-def xl_circular_reference() -> CellValue:
-    """Excel default behavior for circular references (non-iterative calculation)."""
+def warn_circular_reference(*, stacklevel: int = 2) -> None:
+    """Emit the standard circular-reference warning."""
     warnings.warn(
         "Circular reference detected; returning 0 (iterative calculation is disabled).",
         CircularReferenceWarning,
-        stacklevel=2,
+        stacklevel=stacklevel,
     )
+
+
+def xl_circular_reference() -> CellValue:
+    """Excel default behavior for circular references (non-iterative calculation)."""
+    warn_circular_reference(stacklevel=2)
     return 0
 
 
@@ -90,11 +96,15 @@ def _evaluate_address(
         ctx._record_dependency(ctx.stack[-1], address)
 
     if address in ctx.cache:
+        if address in ctx.circular_warning_roots:
+            warn_circular_reference(stacklevel=3)
         return _raise_if_error_value(ctx.cache[address])
 
     if address in ctx.computing:
         if ctx.iterative_enabled:
             return ctx.iteration_values.get(address, 0)
+        root = ctx.stack[0] if ctx.stack else address
+        ctx.circular_warning_roots.add(root)
         return xl_circular_reference()
 
     if address in ctx.inputs:
@@ -259,6 +269,7 @@ def xl_iterative_compute(
     iterations = max(1, int(ctx.iterate_count))
     for _ in range(iterations):
         ctx.cache.clear()
+        ctx.circular_warning_roots.clear()
         ctx.computing.clear()
         ctx.stack.clear()
         ctx.iteration_values.clear()

--- a/excel_grapher/runtime/cache_context.py
+++ b/excel_grapher/runtime/cache_context.py
@@ -18,6 +18,7 @@ class EvalContextBase:
     resolver: Callable[[str], Callable[[EvalContext], CellValue] | None]
     cache: dict[str, CellValue] = field(default_factory=dict)
     computing: set[str] = field(default_factory=set)
+    circular_warning_roots: set[str] = field(default_factory=set)
     iterative_enabled: bool = False
     iterate_count: int = 100
     iterate_delta: float = 0.001
@@ -49,6 +50,7 @@ class EvalContext(EvalContextBase):
             seen.add(addr)
 
             self.cache.pop(addr, None)
+            self.circular_warning_roots.discard(addr)
             self.computing.discard(addr)
 
             dependents = list(self.reverse_deps.get(addr, set()))

--- a/tests/fixtures/dep_tracking_baseline/baseline.json
+++ b/tests/fixtures/dep_tracking_baseline/baseline.json
@@ -2,9 +2,9 @@
   "version": 9,
   "minimal_non_iterative_export": {
     "workload": "S!A1 leaf + S!B1 = S!A1+1",
-    "total_export_lines": 492,
-    "embedded_runtime_lines": 422,
-    "embedded_runtime_share_pct": 85.8,
+    "total_export_lines": 497,
+    "embedded_runtime_lines": 427,
+    "embedded_runtime_share_pct": 85.9,
     "cache_eval_scaffold_lines": 62,
     "dep_tracking_lines": 0
   },

--- a/tests/unit/evaluator/test_evaluator.py
+++ b/tests/unit/evaluator/test_evaluator.py
@@ -125,6 +125,24 @@ def test_evaluator_detects_cycles() -> None:
         assert ev.evaluate(["S!A1"]) == {"S!A1": 0}
 
 
+def test_evaluator_re_emits_circular_reference_warning_on_memoized_re_evaluate() -> None:
+    """Issue #130: repeated root evaluation must not silently drop cycle diagnostics."""
+    graph = _make_graph(
+        _make_node("S!A1", "=S!B1", None),
+        _make_node("S!B1", "=S!A1", None),
+    )
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with FormulaEvaluator(graph) as evaluator:
+            evaluator.evaluate("S!A1")
+            evaluator.evaluate("S!A1")
+
+    assert len(caught) == 2
+    assert all(w.category is CircularReferenceWarning for w in caught)
+
+
 def test_evaluator_raises_for_unimplemented_function() -> None:
     graph = _make_graph(_make_node("S!A1", "=no_such_function(1)", None))
     with (

--- a/tests/unit/exporter/test_dep_tracking_codegen_emission.py
+++ b/tests/unit/exporter/test_dep_tracking_codegen_emission.py
@@ -5,7 +5,7 @@ Non-iterative exports without input-direction series bindings omit ``deps`` /
 ``ctx._record_dependency`` call site in ``_evaluate_address``.
 Minimal non-iterative export baseline (``S!A1`` leaf + ``S!B1`` formula):
 
-- **492 total lines**; embedded runtime **422 lines** (~86% of export)
+- **497 total lines**; embedded runtime **427 lines** (~86% of export)
 - **0 dep-tracking lines**
 - **62 cache-eval scaffold lines** (``_evaluate_address``, ``xl_cell``, ``xl_eval``)
 
@@ -74,7 +74,7 @@ def test_dep_tracking_baseline_fixture_matches_schema() -> None:
     metrics = document["minimal_non_iterative_export"]
     assert isinstance(metrics, dict)
     assert metrics["dep_tracking_lines"] == 0
-    assert metrics["embedded_runtime_lines"] == 422
+    assert metrics["embedded_runtime_lines"] == 427
     targets = document["sprint2_targets"]
     assert targets["dep_tracking_lines"] == 0
     assert targets["cache_eval_scaffold_line_budget"] == SLIM_CACHE_EVAL_SCAFFOLD_LINE_BUDGET

--- a/tests/unit/runtime/test_cache_cell_eval.py
+++ b/tests/unit/runtime/test_cache_cell_eval.py
@@ -179,6 +179,42 @@ class TestSharedEvaluationPath:
         with pytest.warns(CircularReferenceWarning):
             assert evaluate(ctx, self_ref) == 0
 
+    @pytest.mark.parametrize(
+        ("evaluate", "setup"),
+        [
+            pytest.param(
+                lambda ctx, fn: xl_cell(ctx, _ADDR),
+                lambda fn: _ctx(resolver=lambda address: fn if address == _ADDR else None),
+                id="xl_cell",
+            ),
+            pytest.param(
+                lambda ctx, fn: xl_eval(ctx, _ADDR, fn),
+                lambda fn: _ctx(),
+                id="xl_eval",
+            ),
+        ],
+    )
+    def test_non_iterative_cycle_re_emits_warning_on_cache_hit(
+        self,
+        evaluate: Callable[[EvalContext, CellFn], CellValue],
+        setup: Callable[[CellFn], EvalContext],
+    ) -> None:
+        """Issue #130: memoized cycle results must re-emit diagnostics on re-read."""
+        import warnings
+
+        def self_ref(ctx: EvalContext) -> CellValue:
+            return evaluate(ctx, self_ref)
+
+        ctx = setup(self_ref)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert evaluate(ctx, self_ref) == 0
+            assert evaluate(ctx, self_ref) == 0
+
+        assert len(caught) == 2
+        assert all(w.category is CircularReferenceWarning for w in caught)
+
     @pytest.mark.parametrize("entrypoint", ["xl_cell", "xl_eval"])
     def test_iterative_mode_uses_iteration_values_while_computing(
         self,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #130

## Problem

When `FormulaEvaluator.evaluate()` was called more than once for the same address in one session (e.g. a cyclic cell like `Sheet1!C6`), `CircularReferenceWarning` was only emitted on the first evaluation. Subsequent calls returned the memoized value silently.

## Solution

Track root cells whose evaluation encountered a circular reference and re-emit `CircularReferenceWarning` when their memoized value is read again, without recomputing.

Changes apply to both:
- `FormulaEvaluator._evaluate_cell` (evaluator path)
- `EvalContext` / `_evaluate_address` in export runtime (parity with generated code)

## Testing

Added regression tests in:
- `tests/unit/evaluator/test_evaluator.py`
- `tests/unit/runtime/test_cache_cell_eval.py`

Existing circular-reference parity tests continue to pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc1825f6-49c7-45e7-947c-287312ab1cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc1825f6-49c7-45e7-947c-287312ab1cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

