### PR TITLE
fix(core): unify same-sheet range normalization on single sheet prefix

### DIFF
--- a/.cursor/rules/range_parsing.mdc
+++ b/.cursor/rules/range_parsing.mdc
@@ -10,7 +10,7 @@ alwaysApply: false
 - **Use parser utilities, never ad-hoc colon splitting for formulas.**  
   For formula text:
   - `parse_range_refs_with_spans(...)` returns (`start_ref`, `end_ref`, `span`), where `span` is the matched range's character offsets in the original formula as (`start`, `end`) (end-exclusive).
-  - Prefer `parse_standalone_cell_refs(...)` (or `parse_standalone_cell_refs_with_spans`) when combining range parsing with single-cell parsing so bare endpoints in single-prefix ranges are not double-counted or mis-sheeted. Mask spans first if calling `parse_cell_refs` directly.
+  - Prefer `parse_standalone_cell_refs(...)` (or `parse_standalone_cell_refs_with_spans`) when combining range parsing with single-cell parsing so bare endpoints in single-prefix ranges are not double-counted or mis-sheeted. `parse_cell_refs` refuses formula text that still contains range spans unless `allow_unmasked_ranges=True`.
   - `parse_range_refs(...)` returns (`start_ref`, `end_ref`) when spans are unnecessary.
   - `expand_range(...)` enumerates cells within a range.
 

--- a/.cursor/rules/range_parsing.mdc
+++ b/.cursor/rules/range_parsing.mdc
@@ -10,7 +10,7 @@ alwaysApply: false
 - **Use parser utilities, never ad-hoc colon splitting for formulas.**  
   For formula text:
   - `parse_range_refs_with_spans(...)` returns (`start_ref`, `end_ref`, `span`), where `span` is the matched range's character offsets in the original formula as (`start`, `end`) (end-exclusive).
-  - Use spans when combining range parsing with single-cell parsing from raw formula text (mask spans first so range endpoints are not double-counted).
+  - Prefer `parse_standalone_cell_refs(...)` (or `parse_standalone_cell_refs_with_spans`) when combining range parsing with single-cell parsing so bare endpoints in single-prefix ranges are not double-counted or mis-sheeted. Mask spans first if calling `parse_cell_refs` directly.
   - `parse_range_refs(...)` returns (`start_ref`, `end_ref`) when spans are unnecessary.
   - `expand_range(...)` enumerates cells within a range.
 

--- a/.cursor/rules/range_parsing.mdc
+++ b/.cursor/rules/range_parsing.mdc
@@ -5,7 +5,7 @@ alwaysApply: false
 ## Safe Range Parsing Rules
 
 - **Normalize first, parse second.**  
-  Always run formulas through `FormulaNormalizer.normalize(...)` before extracting refs, so `A1:A3`, `Sheet1!A1:A3`, and `Sheet1!A1:Sheet1!A3` converge to one canonical form.
+  Always run formulas through `FormulaNormalizer.normalize(...)` before extracting refs, so `A1:A3`, `Sheet1!A1:A3`, and `Sheet1!A1:Sheet1!A3` converge to one canonical form (`Sheet1!A1:A3` — single sheet prefix for same-sheet ranges). Cross-sheet ranges keep both endpoints qualified (`Sheet1!A1:Sheet2!D1`).
 
 - **Use parser utilities, never ad-hoc colon splitting for formulas.**  
   For formula text:

--- a/excel_grapher/core/address_keys.py
+++ b/excel_grapher/core/address_keys.py
@@ -16,7 +16,7 @@ from typing import TypeAlias
 
 from fastpyxl.utils.cell import column_index_from_string, coordinate_from_string
 
-# Canonical sheet-qualified cell (`Sheet1!B1`) or range (`Sheet1!C4:Sheet1!D4`).
+# Canonical sheet-qualified cell (`Sheet1!B1`) or same-sheet range (`Sheet1!C4:D4`).
 NormalizedAddress: TypeAlias = str
 
 
@@ -102,18 +102,64 @@ def format_cell_key(sheet: str, column: str, row: int) -> NormalizedAddress:
     return f"{quote_sheet_if_needed(sheet)}!{column}{row}"
 
 
+def format_range_key(sheet: str, start_cell: str, end_cell: str) -> NormalizedAddress:
+    """Format a same-sheet range as a single-prefix canonical address.
+
+    Examples:
+        >>> format_range_key("Sheet1", "A1", "A3")
+        'Sheet1!A1:A3'
+        >>> format_range_key("My Sheet", "A1", "B2")
+        "'My Sheet'!A1:B2"
+    """
+    return f"{quote_sheet_if_needed(sheet)}!{start_cell}:{end_cell}"
+
+
+def _split_top_level_colon(address: str) -> tuple[str, str] | None:
+    """Split an address on the first colon outside quoted sheet names."""
+    in_quote = False
+    i = 0
+    while i < len(address):
+        ch = address[i]
+        if ch == "'":
+            if in_quote and i + 1 < len(address) and address[i + 1] == "'":
+                i += 2
+                continue
+            in_quote = not in_quote
+        elif ch == ":" and not in_quote:
+            return address[:i], address[i + 1 :]
+        i += 1
+    return None
+
+
 def normalize_key(key: str) -> NormalizedAddress:
     """Normalize an address to canonical :data:`NormalizedAddress` form.
 
     Unnecessary quoting is stripped; sheet names with spaces, hyphens, or
     apostrophes are quoted. For single cells, the result matches `Node.key`.
+    Same-sheet ranges collapse to a single sheet prefix (`Sheet1!A1:B2`);
+    cross-sheet ranges keep both endpoints sheet-qualified.
 
     Examples:
         >>> normalize_key("'Sheet1'!A1")
         'Sheet1!A1'
         >>> normalize_key("'My Sheet'!B2")
         "'My Sheet'!B2"
+        >>> normalize_key("Sheet1!A1:Sheet1!B2")
+        'Sheet1!A1:B2'
     """
+    parts = _split_top_level_colon(key)
+    if parts is not None:
+        start_raw, end_raw = parts
+        start_sheet, start_cell = parse_address(start_raw)
+        if "!" in end_raw or end_raw.startswith("'"):
+            end_sheet, end_cell = parse_address(end_raw)
+            if end_sheet == start_sheet:
+                return format_range_key(start_sheet, start_cell, end_cell)
+            start_fmt = format_key(start_sheet, start_cell)
+            end_fmt = format_key(end_sheet, end_cell)
+            return f"{start_fmt}:{end_fmt}"
+        return format_range_key(start_sheet, start_cell, end_raw)
+
     sheet, cell = parse_address(key)
     return format_key(sheet, cell)
 

--- a/excel_grapher/core/address_keys.py
+++ b/excel_grapher/core/address_keys.py
@@ -11,6 +11,7 @@ evaluator/exporter can import them without violating layering rules.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable, Iterable, Sequence
 from typing import TypeAlias
 
@@ -18,6 +19,10 @@ from fastpyxl.utils.cell import column_index_from_string, coordinate_from_string
 
 # Canonical sheet-qualified cell (`Sheet1!B1`) or same-sheet range (`Sheet1!C4:D4`).
 NormalizedAddress: TypeAlias = str
+
+_A1_CELL_COORD_RE = re.compile(r"^\$?([A-Za-z]{1,3})\$?(\d+)$")
+_WHOLE_COL_COORD_RE = re.compile(r"^\$?([A-Za-z]{1,3})$")
+_WHOLE_ROW_COORD_RE = re.compile(r"^\$?(\d+)$")
 
 
 def needs_quoting(sheet: str) -> bool:
@@ -114,8 +119,30 @@ def format_range_key(sheet: str, start_cell: str, end_cell: str) -> NormalizedAd
     return f"{quote_sheet_if_needed(sheet)}!{start_cell}:{end_cell}"
 
 
-def _split_top_level_colon(address: str) -> tuple[str, str] | None:
-    """Split an address on the first colon outside quoted sheet names."""
+def canonical_cell_coord(cell: str) -> str:
+    """Canonicalize an A1 / whole-column / whole-row coordinate fragment.
+
+    Strips `$` markers, uppercases column letters, and normalizes row numbers
+    (`01` -> `1`). Non-matching fragments are returned unchanged.
+    """
+    m = _A1_CELL_COORD_RE.fullmatch(cell)
+    if m is not None:
+        return f"{m.group(1).upper()}{int(m.group(2))}"
+    m_col = _WHOLE_COL_COORD_RE.fullmatch(cell)
+    if m_col is not None:
+        return m_col.group(1).upper()
+    m_row = _WHOLE_ROW_COORD_RE.fullmatch(cell)
+    if m_row is not None:
+        return str(int(m_row.group(1)))
+    return cell
+
+
+def split_address_on_colon(address: str) -> tuple[str, str] | None:
+    """Split an address on the first colon outside quoted sheet names.
+
+    Handles colons embedded in quoted sheet names (`'A:B'!C1:D2`).
+    Returns `None` when there is no top-level colon.
+    """
     in_quote = False
     i = 0
     while i < len(address):
@@ -135,7 +162,8 @@ def normalize_key(key: str) -> NormalizedAddress:
     """Normalize an address to canonical :data:`NormalizedAddress` form.
 
     Unnecessary quoting is stripped; sheet names with spaces, hyphens, or
-    apostrophes are quoted. For single cells, the result matches `Node.key`.
+    apostrophes are quoted. Absolute markers (`$`) are stripped and column
+    letters are uppercased. For single cells, the result matches `Node.key`.
     Same-sheet ranges collapse to a single sheet prefix (`Sheet1!A1:B2`);
     cross-sheet ranges keep both endpoints sheet-qualified.
 
@@ -146,22 +174,26 @@ def normalize_key(key: str) -> NormalizedAddress:
         "'My Sheet'!B2"
         >>> normalize_key("Sheet1!A1:Sheet1!B2")
         'Sheet1!A1:B2'
+        >>> normalize_key("Sheet1!A1:$A$3")
+        'Sheet1!A1:A3'
     """
-    parts = _split_top_level_colon(key)
+    parts = split_address_on_colon(key)
     if parts is not None:
         start_raw, end_raw = parts
         start_sheet, start_cell = parse_address(start_raw)
+        start_cell = canonical_cell_coord(start_cell)
         if "!" in end_raw or end_raw.startswith("'"):
             end_sheet, end_cell = parse_address(end_raw)
+            end_cell = canonical_cell_coord(end_cell)
             if end_sheet == start_sheet:
                 return format_range_key(start_sheet, start_cell, end_cell)
             start_fmt = format_key(start_sheet, start_cell)
             end_fmt = format_key(end_sheet, end_cell)
             return f"{start_fmt}:{end_fmt}"
-        return format_range_key(start_sheet, start_cell, end_raw)
+        return format_range_key(start_sheet, start_cell, canonical_cell_coord(end_raw))
 
     sheet, cell = parse_address(key)
-    return format_key(sheet, cell)
+    return format_key(sheet, canonical_cell_coord(cell))
 
 
 def make_node_key_sort_key(

--- a/excel_grapher/core/formula_normalization.py
+++ b/excel_grapher/core/formula_normalization.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 
 from excel_grapher.core.address_keys import (
     format_cell_key,
+    format_range_key,
     quote_sheet_if_needed,
     quoted_sheet_prefix_regex,
     unescape_formula_sheet_name,
@@ -60,9 +61,9 @@ def build_named_range_replacement_state(
         m_start = re.match(r"^([A-Z]{1,3})(\d+)$", start_a1)
         m_end = re.match(r"^([A-Z]{1,3})(\d+)$", end_a1)
         if m_start and m_end:
-            start_ref = format_cell_key(sheet, m_start.group(1), int(m_start.group(2)))
-            end_ref = format_cell_key(sheet, m_end.group(1), int(m_end.group(2)))
-            replacements[name] = f"{start_ref}:{end_ref}"
+            start_cell = f"{m_start.group(1)}{int(m_start.group(2))}"
+            end_cell = f"{m_end.group(1)}{int(m_end.group(2))}"
+            replacements[name] = format_range_key(sheet, start_cell, end_cell)
 
     if not replacements:
         return {}, None
@@ -214,12 +215,50 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
     """Strip $ markers, qualify ranges and cells, without defined-name substitution."""
     result = _normalize_whole_column_row_shorthand(formula, current_sheet)
 
+    def replace_quoted_both_end_range(m: re.Match[str]) -> str:
+        sheet1 = unescape_formula_sheet_name(m.group("sheet1"))
+        sheet2 = unescape_formula_sheet_name(m.group("sheet2"))
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        start_cell = f"{c1}{int(r1)}"
+        end_cell = f"{c2}{int(r2)}"
+        if sheet1 == sheet2:
+            return format_range_key(sheet1, start_cell, end_cell)
+        return (
+            f"{format_cell_key(sheet1, c1, int(r1))}:"
+            f"{format_cell_key(sheet2, c2, int(r2))}"
+        )
+
+    result = re.sub(
+        _QUOTED_SHEET_PREFIX.replace("?P<sheet>", "?P<sheet1>")
+        + r"\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*"
+        + _QUOTED_SHEET_PREFIX.replace("?P<sheet>", "?P<sheet2>")
+        + r"\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
+        replace_quoted_both_end_range,
+        result,
+    )
+
+    def replace_unquoted_both_end_range(m: re.Match[str]) -> str:
+        sheet1, sheet2 = m.group("sheet1"), m.group("sheet2")
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        start_cell = f"{c1}{int(r1)}"
+        end_cell = f"{c2}{int(r2)}"
+        if sheet1 == sheet2:
+            return format_range_key(sheet1, start_cell, end_cell)
+        return f"{sheet1}!{start_cell}:{sheet2}!{end_cell}"
+
+    result = re.sub(
+        r"(?<![A-Za-z_'])(?P<sheet1>[A-Za-z][A-Za-z0-9_]*)!"
+        r"\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*"
+        r"(?P<sheet2>[A-Za-z][A-Za-z0-9_]*)!"
+        r"\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
+        replace_unquoted_both_end_range,
+        result,
+    )
+
     def replace_quoted_range(m: re.Match[str]) -> str:
         sheet = unescape_formula_sheet_name(m.group("sheet"))
         c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-        a = format_cell_key(sheet, c1, int(r1))
-        b = format_cell_key(sheet, c2, int(r2))
-        return f"{a}:{b}"
+        return format_range_key(sheet, f"{c1}{int(r1)}", f"{c2}{int(r2)}")
 
     result = re.sub(
         _QUOTED_SHEET_PREFIX
@@ -231,7 +270,7 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
     def replace_unquoted_range(m: re.Match[str]) -> str:
         sheet = m.group("sheet")
         c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-        return f"{sheet}!{c1}{r1}:{sheet}!{c2}{r2}"
+        return format_range_key(sheet, f"{c1}{int(r1)}", f"{c2}{int(r2)}")
 
     result = re.sub(
         r"(?<![A-Za-z_'])(?P<sheet>[A-Za-z][A-Za-z0-9_]*)!\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)",
@@ -241,9 +280,9 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
 
     def replace_local_range(m: re.Match[str]) -> str:
         c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-        ref1 = format_cell_key(current_sheet, c1, int(r1))
-        ref2 = format_cell_key(current_sheet, c2, int(r2))
-        return f"{ref1}:{ref2}"
+        return format_range_key(
+            current_sheet, f"{c1}{int(r1)}", f"{c2}{int(r2)}"
+        )
 
     result = re.sub(
         r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",
@@ -279,12 +318,56 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
         return format_cell_key(current_sheet, col, int(row))
 
     result = re.sub(
-        r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
+        r"(?<![!A-Za-z0-9_:])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])",
         replace_local_cell,
         result,
     )
 
-    return result
+    return _collapse_same_sheet_range_prefixes(result)
+
+
+def _collapse_same_sheet_range_prefixes(formula: str) -> str:
+    """Collapse `Sheet!A1:Sheet!B2` to single-prefix `Sheet!A1:B2` when sheets match.
+
+    Cell qualification may re-qualify a bare range endpoint after a single-prefix
+    range is emitted (`Sheet1!A1:A3` -> `Sheet1!A1:Sheet1!A3`). This pass restores
+    the canonical single-prefix form without changing cross-sheet ranges.
+    """
+
+    def replace_quoted(m: re.Match[str]) -> str:
+        sheet1 = unescape_formula_sheet_name(m.group("sheet1"))
+        sheet2 = unescape_formula_sheet_name(m.group("sheet2"))
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        if sheet1 != sheet2:
+            return m.group(0)
+        return format_range_key(sheet1, f"{c1}{int(r1)}", f"{c2}{int(r2)}")
+
+    result = re.sub(
+        quoted_sheet_prefix_regex(capture_group="sheet1")
+        + r"(?P<c1>[A-Z]{1,3})(?P<r1>\d+):"
+        + quoted_sheet_prefix_regex(capture_group="sheet2")
+        + r"(?P<c2>[A-Z]{1,3})(?P<r2>\d+)",
+        replace_quoted,
+        formula,
+        flags=re.IGNORECASE,
+    )
+
+    def replace_unquoted(m: re.Match[str]) -> str:
+        sheet1, sheet2 = m.group("sheet1"), m.group("sheet2")
+        c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
+        if sheet1 != sheet2:
+            return m.group(0)
+        return format_range_key(sheet1, f"{c1}{int(r1)}", f"{c2}{int(r2)}")
+
+    return re.sub(
+        r"(?<![A-Za-z_'])(?P<sheet1>[A-Za-z][A-Za-z0-9_]*)!"
+        r"(?P<c1>[A-Z]{1,3})(?P<r1>\d+):"
+        r"(?P<sheet2>[A-Za-z][A-Za-z0-9_]*)!"
+        r"(?P<c2>[A-Z]{1,3})(?P<r2>\d+)",
+        replace_unquoted,
+        result,
+        flags=re.IGNORECASE,
+    )
 
 
 def normalize_excel_formula_with_name_state(
@@ -300,6 +383,7 @@ def normalize_excel_formula_with_name_state(
     masked, literals = _mask_string_literals(formula)
     result = _normalize_excel_formula_base(masked, current_sheet)
     result = _apply_named_range_replacements(result, replacements, names_re)
+    result = _collapse_same_sheet_range_prefixes(result)
     return _unmask_string_literals(result, literals)
 
 
@@ -313,6 +397,8 @@ def normalize_excel_formula(
     """Normalize a formula string (`=...`) for transpilation and parsing.
 
     - Same-sheet refs (`A1`) become `Sheet!A1` using *current_sheet*.
+    - Same-sheet ranges become single-prefix (`Sheet!A1:A3`); cross-sheet
+      ranges keep both endpoints sheet-qualified.
     - Resolves defined names when maps are provided.
     - Strips `$` markers and qualifies range endpoints.
     """

--- a/excel_grapher/core/formula_normalization.py
+++ b/excel_grapher/core/formula_normalization.py
@@ -223,10 +223,7 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
         end_cell = f"{c2}{int(r2)}"
         if sheet1 == sheet2:
             return format_range_key(sheet1, start_cell, end_cell)
-        return (
-            f"{format_cell_key(sheet1, c1, int(r1))}:"
-            f"{format_cell_key(sheet2, c2, int(r2))}"
-        )
+        return f"{format_cell_key(sheet1, c1, int(r1))}:{format_cell_key(sheet2, c2, int(r2))}"
 
     result = re.sub(
         _QUOTED_SHEET_PREFIX.replace("?P<sheet>", "?P<sheet1>")
@@ -280,9 +277,7 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
 
     def replace_local_range(m: re.Match[str]) -> str:
         c1, r1, c2, r2 = m.group("c1"), m.group("r1"), m.group("c2"), m.group("r2")
-        return format_range_key(
-            current_sheet, f"{c1}{int(r1)}", f"{c2}{int(r2)}"
-        )
+        return format_range_key(current_sheet, f"{c1}{int(r1)}", f"{c2}{int(r2)}")
 
     result = re.sub(
         r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<c1>[A-Z]{1,3})\$?(?P<r1>\d+)\s*:\s*\$?(?P<c2>[A-Z]{1,3})\$?(?P<r2>\d+)(?![A-Za-z0-9_])",

--- a/excel_grapher/core/formula_normalization.py
+++ b/excel_grapher/core/formula_normalization.py
@@ -322,11 +322,12 @@ def _normalize_excel_formula_base(formula: str, current_sheet: str) -> str:
 
 
 def _collapse_same_sheet_range_prefixes(formula: str) -> str:
-    """Collapse `Sheet!A1:Sheet!B2` to single-prefix `Sheet!A1:B2` when sheets match.
+    """Collapse same-sheet both-end ranges to single-prefix form.
 
-    Cell qualification may re-qualify a bare range endpoint after a single-prefix
-    range is emitted (`Sheet1!A1:A3` -> `Sheet1!A1:Sheet1!A3`). This pass restores
-    the canonical single-prefix form without changing cross-sheet ranges.
+    Earlier passes already emit single-prefix ranges and exclude `:` from local
+    cell lookbehinds. This pass is defense-in-depth for residual both-end forms
+    (for example after defined-name substitution) and leaves cross-sheet ranges
+    unchanged.
     """
 
     def replace_quoted(m: re.Match[str]) -> str:

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -13,10 +13,12 @@ import fastpyxl.utils.cell
 
 from excel_grapher.core.address_keys import (
     format_range_key,
-    normalize_key as normalize_address,
     parse_address,
     quote_sheet_if_needed,
     sort_node_keys,
+)
+from excel_grapher.core.address_keys import (
+    normalize_key as normalize_address,
 )
 from excel_grapher.core.operators_fastpath import MIN_OPERATOR_FASTPATH_CELLS
 from excel_grapher.evaluator.errors import MissingNormalizedFormulaError
@@ -719,9 +721,7 @@ class CodeGenerator:
                     col_letter = fastpyxl.utils.cell.get_column_letter(col)
                     col_entries.append(
                         (
-                            format_range_key(
-                                sheet, f"{col_letter}{start}", f"{col_letter}{prev}"
-                            ),
+                            format_range_key(sheet, f"{col_letter}{start}", f"{col_letter}{prev}"),
                             "xl_range_rows",
                         )
                     )

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -12,9 +12,8 @@ from typing import TYPE_CHECKING, Any, Protocol, TypedDict, cast
 import fastpyxl.utils.cell
 
 from excel_grapher.core.address_keys import (
+    format_range_key,
     normalize_key as normalize_address,
-)
-from excel_grapher.core.address_keys import (
     parse_address,
     quote_sheet_if_needed,
     sort_node_keys,
@@ -412,7 +411,7 @@ class CodeGenerator:
     def _emit_range(self, node: RangeNode) -> str:
         """Emit a range as a lazy `Range` value resolved through the context.
 
-        For A1:B3, emits: xl_range(ctx, "S!A1:S!B3"). Consumers evaluate cells
+        For A1:B3, emits: xl_range(ctx, "S!A1:B3"). Consumers evaluate cells
         positionally; unused cells are never evaluated.
         """
         return self._emit_range_address(node.start, node.end)
@@ -420,9 +419,9 @@ class CodeGenerator:
     def _emit_range_address(self, start: str, end: str) -> str:
         """Emit an xl_range call for a normalized start/end address pair."""
         sheet, r1, c1, r2, c2 = self._range_coords(start, end)
-        start_addr = self._format_cell_address(sheet, r1, c1)
-        end_addr = self._format_cell_address(sheet, r2, c2)
-        return f"xl_range(ctx, {repr(f'{start_addr}:{end_addr}')})"
+        start_cell = f"{fastpyxl.utils.cell.get_column_letter(c1)}{r1}"
+        end_cell = f"{fastpyxl.utils.cell.get_column_letter(c2)}{r2}"
+        return f"xl_range(ctx, {repr(format_range_key(sheet, start_cell, end_cell))})"
 
     def _emit_cell_eval(self, address: str) -> str:
         normalized = normalize_address(address)
@@ -671,19 +670,25 @@ class CodeGenerator:
                     if col == prev + 1:
                         prev = col
                         continue
-                    start_addr = self._format_cell_address(sheet, row, start)
-                    end_addr = self._format_cell_address(sheet, row, prev)
                     if start == prev:
-                        row_entries.append((start_addr, "xl_cell"))
+                        row_entries.append(
+                            (self._format_cell_address(sheet, row, start), "xl_cell")
+                        )
                     else:
-                        row_entries.append((f"{start_addr}:{end_addr}", "xl_range_rows"))
+                        start_cell = f"{fastpyxl.utils.cell.get_column_letter(start)}{row}"
+                        end_cell = f"{fastpyxl.utils.cell.get_column_letter(prev)}{row}"
+                        row_entries.append(
+                            (format_range_key(sheet, start_cell, end_cell), "xl_range_rows")
+                        )
                     start = prev = col
-                start_addr = self._format_cell_address(sheet, row, start)
-                end_addr = self._format_cell_address(sheet, row, prev)
                 if start == prev:
-                    row_entries.append((start_addr, "xl_cell"))
+                    row_entries.append((self._format_cell_address(sheet, row, start), "xl_cell"))
                 else:
-                    row_entries.append((f"{start_addr}:{end_addr}", "xl_range_rows"))
+                    start_cell = f"{fastpyxl.utils.cell.get_column_letter(start)}{row}"
+                    end_cell = f"{fastpyxl.utils.cell.get_column_letter(prev)}{row}"
+                    row_entries.append(
+                        (format_range_key(sheet, start_cell, end_cell), "xl_range_rows")
+                    )
 
             col_entries: list[tuple[str, str]] = []
             for col, rows in col_groups.items():
@@ -693,19 +698,33 @@ class CodeGenerator:
                     if row == prev + 1:
                         prev = row
                         continue
-                    start_addr = self._format_cell_address(sheet, start, col)
-                    end_addr = self._format_cell_address(sheet, prev, col)
                     if start == prev:
-                        col_entries.append((start_addr, "xl_cell"))
+                        col_entries.append(
+                            (self._format_cell_address(sheet, start, col), "xl_cell")
+                        )
                     else:
-                        col_entries.append((f"{start_addr}:{end_addr}", "xl_range_rows"))
+                        col_letter = fastpyxl.utils.cell.get_column_letter(col)
+                        col_entries.append(
+                            (
+                                format_range_key(
+                                    sheet, f"{col_letter}{start}", f"{col_letter}{prev}"
+                                ),
+                                "xl_range_rows",
+                            )
+                        )
                     start = prev = row
-                start_addr = self._format_cell_address(sheet, start, col)
-                end_addr = self._format_cell_address(sheet, prev, col)
                 if start == prev:
-                    col_entries.append((start_addr, "xl_cell"))
+                    col_entries.append((self._format_cell_address(sheet, start, col), "xl_cell"))
                 else:
-                    col_entries.append((f"{start_addr}:{end_addr}", "xl_range_rows"))
+                    col_letter = fastpyxl.utils.cell.get_column_letter(col)
+                    col_entries.append(
+                        (
+                            format_range_key(
+                                sheet, f"{col_letter}{start}", f"{col_letter}{prev}"
+                            ),
+                            "xl_range_rows",
+                        )
+                    )
 
             entries.extend(row_entries if len(row_entries) <= len(col_entries) else col_entries)
 

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -243,7 +243,7 @@ def create_dependency_graph(
 
     - sheet-qualified single cells (`"Sheet1!A1"`, `"'My Sheet'!B2"`);
     - sheet-qualified rectangular ranges (`"Sheet1!B12:F12"`,
-      `"Sheet1!A1:Sheet1!B2"`, `"'My Sheet'!A1:B2"`); and
+      `"Sheet1!A1:B2"`, `"'My Sheet'!A1:B2"`); and
     - defined names that resolve to a single cell or a rectangular range
       (`"MyInput"`, `"DataRange"`).
 

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -14,7 +14,7 @@ import fastpyxl.utils.cell
 from fastpyxl.worksheet.formula import ArrayFormula
 from fastpyxl.worksheet.worksheet import Worksheet
 
-from excel_grapher.core.address_keys import parse_address, sort_node_keys
+from excel_grapher.core.address_keys import format_range_key, parse_address, sort_node_keys
 from excel_grapher.core.cell_types import CellType, leaves_missing_cell_type_constraints
 
 from .blank_ranges import (
@@ -47,7 +47,6 @@ from .parser import (
     expand_range_ref,
     format_key,
     mask_spans,
-    parse_cell_refs,
     parse_dynamic_range_refs_with_spans,
     parse_guard_expr,
     parse_range_refs_with_spans,
@@ -211,11 +210,15 @@ def _format_missing_leaves(missing_leaves: set[str]) -> list[str]:
             c_end_letter = get_column_letter(c_last)
             for r1, r2 in ivals:
                 if c0 == c_last and r1 == r2:
-                    parts.append(f"{sheet}!{c_start_letter}{r1}")
-                elif c0 == c_last:
-                    parts.append(f"{sheet}!{c_start_letter}{r1}:{sheet}!{c_end_letter}{r2}")
+                    parts.append(format_key(sheet, f"{c_start_letter}{r1}"))
                 else:
-                    parts.append(f"{sheet}!{c_start_letter}{r1}:{sheet}!{c_end_letter}{r2}")
+                    parts.append(
+                        format_range_key(
+                            sheet,
+                            f"{c_start_letter}{r1}",
+                            f"{c_end_letter}{r2}",
+                        )
+                    )
             i = j
 
     parts.extend(sorted(others))
@@ -869,12 +872,11 @@ def create_dependency_graph(
                         )
             masked = mask_spans(masked, dyn_spans)
 
-            # 1) Expand ranges, then mask them so later cell-ref parsing doesn't
-            # misinterpret the range endpoint as a same-sheet ref.
+            # Expand ranges when requested, then always parse standalone cells
+            # (range spans masked) so bare endpoints in single-prefix forms are
+            # never attributed to the formula's local sheet.
             if expand_ranges:
-                spans: list[tuple[int, int]] = []
-                for start, end, span in parse_range_refs_with_spans(masked):
-                    spans.append(span)
+                for start, end, _span in parse_range_refs_with_spans(masked):
                     sheet = start.sheet if start.sheet is not None else current_sheet
                     _ensure_sheet_bounds(sheet)
                     deps.extend(
@@ -886,9 +888,8 @@ def create_dependency_graph(
                             sheet_bounds=sheet_bounds,
                         )
                     )
-                masked = mask_spans(masked, spans)
 
-            for ref in parse_cell_refs(masked):
+            for ref in parse_standalone_cell_refs(masked):
                 sh = ref.sheet if ref.sheet is not None else current_sheet
                 deps.append((sh, f"{ref.column}{ref.row}"))
 

--- a/excel_grapher/grapher/builder.py
+++ b/excel_grapher/grapher/builder.py
@@ -51,6 +51,7 @@ from .parser import (
     parse_dynamic_range_refs_with_spans,
     parse_guard_expr,
     parse_range_refs_with_spans,
+    parse_standalone_cell_refs,
     split_top_level_choose,
     split_top_level_if,
     split_top_level_ifs,
@@ -419,7 +420,7 @@ def create_dependency_graph(
             sheet_of_cell,
         )
         out: set[str] = set()
-        for ref in parse_cell_refs(normalized):
+        for ref in parse_standalone_cell_refs(normalized):
             sh = ref.sheet if ref.sheet is not None else sheet_of_cell
             out.add(format_key(sh, f"{ref.column}{ref.row}"))
         for start, end, _span in parse_range_refs_with_spans(normalized):
@@ -458,7 +459,7 @@ def create_dependency_graph(
             if _contains_volatile_function(expr):
                 return True
             normalized = normalizer.normalize(expr, current_sheet)
-            for ref in parse_cell_refs(normalized):
+            for ref in parse_standalone_cell_refs(normalized):
                 sh = ref.sheet if ref.sheet is not None else current_sheet
                 to_visit.add(format_key(sh, f"{ref.column}{ref.row}"))
 
@@ -681,7 +682,7 @@ def create_dependency_graph(
                                 # Static ranges are handled by infer_dynamic_index_targets (GH-156).
                                 if fn_name == "INDEX" and i == 0 and "(" not in normalized:
                                     continue
-                                for ref in parse_cell_refs(normalized):
+                                for ref in parse_standalone_cell_refs(normalized):
                                     sh = ref.sheet if ref.sheet is not None else current_sheet
                                     a1 = f"{ref.column}{ref.row}"
                                     deps.append((sh, a1))
@@ -722,7 +723,7 @@ def create_dependency_graph(
                             )
                             norm = normalizer.normalize(masked, sheet_of_cell)
                             out: set[str] = set()
-                            for ref in parse_cell_refs(norm):
+                            for ref in parse_standalone_cell_refs(norm):
                                 sh = ref.sheet if ref.sheet is not None else sheet_of_cell
                                 out.add(format_key(sh, f"{ref.column}{ref.row}"))
                             for start, end, _span in parse_range_refs_with_spans(norm):
@@ -1340,7 +1341,7 @@ def list_dynamic_ref_constraint_candidates(
             masked = mask_spans(f, spans)
             norm = normalizer.normalize(masked, sheet)
             out: set[str] = set()
-            for ref in parse_cell_refs(norm):
+            for ref in parse_standalone_cell_refs(norm):
                 sh = ref.sheet if ref.sheet is not None else sheet
                 out.add(format_key(sh, f"{ref.column}{ref.row}"))
             for start, end, _span in parse_range_refs_with_spans(norm):
@@ -1446,7 +1447,7 @@ def list_dynamic_ref_constraint_candidates(
                             or (fn_name == "INDEX" and i >= 1)
                         )
                         if is_variable:
-                            for ref in parse_cell_refs(normalized_arg):
+                            for ref in parse_standalone_cell_refs(normalized_arg):
                                 sh = ref.sheet if ref.sheet is not None else current_sheet
                                 argument_addrs.add(format_key(sh, f"{ref.column}{ref.row}"))
                             for start, end, _span in parse_range_refs_with_spans(normalized_arg):

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -120,16 +120,33 @@ _RANGE_WHOLE_ROW_LOCAL_RE = re.compile(
 )
 
 
-def parse_cell_refs(formula: str) -> list[CellRef]:
+def _reject_unmasked_ranges(formula: str, *, allow_unmasked_ranges: bool) -> None:
+    """Raise if *formula* still contains range spans and opt-in was not given."""
+    if allow_unmasked_ranges:
+        return
+    if parse_range_refs_with_spans(formula):
+        raise ValueError(
+            "Formula text still contains unmasked range spans; "
+            "prefer parse_standalone_cell_refs (or mask_spans) so range endpoints "
+            "are not treated as standalone cells, or pass allow_unmasked_ranges=True"
+        )
+
+
+def parse_cell_refs(
+    formula: str, *, allow_unmasked_ranges: bool = False
+) -> list[CellRef]:
     """Extract single-cell references from a formula.
 
     This function does not expand ranges. Use parse_range_refs + expand_range.
-    Callers that also extract ranges should mask range spans first (via
-    `parse_standalone_cell_refs` or `mask_spans`) so bare range endpoints like
-    `A3` in `Sheet1!A1:A3` are not double-counted as local cells.
+    By default it refuses formula text that still contains range spans — prefer
+    `parse_standalone_cell_refs` (or mask spans yourself). Pass
+    `allow_unmasked_ranges=True` only when intentionally inspecting raw text
+    that may include ranges (for example lookbehind regression tests).
     """
     if not isinstance(formula, str) or not formula.startswith("="):
         return []
+
+    _reject_unmasked_ranges(formula, allow_unmasked_ranges=allow_unmasked_ranges)
 
     out: list[CellRef] = []
 
@@ -157,10 +174,14 @@ def parse_standalone_cell_refs(formula: str) -> list[CellRef]:
     return parse_cell_refs(mask_spans(formula, spans))
 
 
-def parse_cell_refs_with_spans(formula: str) -> list[tuple[CellRef, tuple[int, int]]]:
+def parse_cell_refs_with_spans(
+    formula: str, *, allow_unmasked_ranges: bool = False
+) -> list[tuple[CellRef, tuple[int, int]]]:
     """Like parse_cell_refs, but returns (CellRef, (start, end)) span positions in `formula`."""
     if not isinstance(formula, str) or not formula.startswith("="):
         return []
+
+    _reject_unmasked_ranges(formula, allow_unmasked_ranges=allow_unmasked_ranges)
 
     out: list[tuple[CellRef, tuple[int, int]]] = []
 

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -74,8 +74,10 @@ _SHEET_CELL_RE = re.compile(
 )
 # Do not treat `Col` in `Sheet!$Col$Row` as a local ref: the column letter can follow `!$`.
 # Sheet tokens may look like A1 (e.g. `S2` / `'S2'`); do not match those as local refs.
+# Exclude `:` so bare endpoints in single-prefix ranges (`Sheet1!A1:A3`) are not
+# treated as local cells; callers that also expand ranges should still mask spans.
 _LOCAL_CELL_RE = re.compile(
-    r"(?<![!A-Za-z0-9_])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])"
+    r"(?<![!A-Za-z0-9_:])(?<!\$)\$?(?P<col>[A-Z]{1,3})\$?(?P<row>\d+)(?![A-Za-z0-9_!'])"
 )
 
 _RANGE_QUOTED_RE = re.compile(
@@ -148,7 +150,8 @@ def parse_standalone_cell_refs(formula: str) -> list[CellRef]:
     """Extract cell refs after masking range spans.
 
     Prefer this over `parse_cell_refs` whenever ranges may appear in the same
-    text, so single-prefix forms like `Sheet1!A1:A3` do not yield a bare `A3`.
+    text, so single-prefix forms like `Sheet1!A1:A3` do not yield a bare `A3`
+    or double-count the range start as a sheet-qualified cell.
     """
     spans = [span for _start, _end, span in parse_range_refs_with_spans(formula)]
     return parse_cell_refs(mask_spans(formula, spans))
@@ -174,6 +177,18 @@ def parse_cell_refs_with_spans(formula: str) -> list[tuple[CellRef, tuple[int, i
         out.append((ref, m.span()))
 
     return out
+
+
+def parse_standalone_cell_refs_with_spans(
+    formula: str,
+) -> list[tuple[CellRef, tuple[int, int]]]:
+    """Like `parse_standalone_cell_refs`, but keep character spans in `formula`.
+
+    Spans remain valid in the original text because `mask_spans` only replaces
+    range characters with spaces of the same width.
+    """
+    spans = [span for _start, _end, span in parse_range_refs_with_spans(formula)]
+    return parse_cell_refs_with_spans(mask_spans(formula, spans))
 
 
 def parse_range_refs(formula: str) -> list[tuple[CellRef, CellRef]]:

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -132,9 +132,7 @@ def _reject_unmasked_ranges(formula: str, *, allow_unmasked_ranges: bool) -> Non
         )
 
 
-def parse_cell_refs(
-    formula: str, *, allow_unmasked_ranges: bool = False
-) -> list[CellRef]:
+def parse_cell_refs(formula: str, *, allow_unmasked_ranges: bool = False) -> list[CellRef]:
     """Extract single-cell references from a formula.
 
     This function does not expand ranges. Use parse_range_refs + expand_range.

--- a/excel_grapher/grapher/parser.py
+++ b/excel_grapher/grapher/parser.py
@@ -122,6 +122,9 @@ def parse_cell_refs(formula: str) -> list[CellRef]:
     """Extract single-cell references from a formula.
 
     This function does not expand ranges. Use parse_range_refs + expand_range.
+    Callers that also extract ranges should mask range spans first (via
+    `parse_standalone_cell_refs` or `mask_spans`) so bare range endpoints like
+    `A3` in `Sheet1!A1:A3` are not double-counted as local cells.
     """
     if not isinstance(formula, str) or not formula.startswith("="):
         return []
@@ -139,6 +142,16 @@ def parse_cell_refs(formula: str) -> list[CellRef]:
         out.append(CellRef(sheet=None, column=col, row=int(m.group("row"))))
 
     return out
+
+
+def parse_standalone_cell_refs(formula: str) -> list[CellRef]:
+    """Extract cell refs after masking range spans.
+
+    Prefer this over `parse_cell_refs` whenever ranges may appear in the same
+    text, so single-prefix forms like `Sheet1!A1:A3` do not yield a bare `A3`.
+    """
+    spans = [span for _start, _end, span in parse_range_refs_with_spans(formula)]
+    return parse_cell_refs(mask_spans(formula, spans))
 
 
 def parse_cell_refs_with_spans(formula: str) -> list[tuple[CellRef, tuple[int, int]]]:
@@ -1210,7 +1223,7 @@ def parse_dynamic_range_refs_with_spans(
                     "=" + arg,
                     current_sheet,
                 )
-                for ref in parse_cell_refs(normalized):
+                for ref in parse_standalone_cell_refs(normalized):
                     sheet = ref.sheet if ref.sheet is not None else current_sheet
                     arg_refs.append(
                         CellRef(

--- a/excel_grapher/grapher/provenance_collect.py
+++ b/excel_grapher/grapher/provenance_collect.py
@@ -29,10 +29,10 @@ from .parser import (
     expand_range,
     format_key,
     mask_spans,
-    parse_cell_refs,
     parse_cell_refs_with_spans,
     parse_dynamic_range_refs_with_spans,
     parse_range_refs_with_spans,
+    parse_standalone_cell_refs,
     split_top_level_choose,
     split_top_level_if,
     split_top_level_ifs,
@@ -160,7 +160,7 @@ def _flat_provenance_one_string(
                             or (fn_name == "OFFSET" and i == 0 and "(" in norm_arg)
                             or fn_name == "INDIRECT"
                         )
-                        for ref in parse_cell_refs(norm_arg):
+                        for ref in parse_standalone_cell_refs(norm_arg):
                             sh = ref.sheet if ref.sheet is not None else current_sheet
                             a1 = f"{ref.column}{ref.row}"
                             k = format_key(sh, a1)
@@ -188,7 +188,7 @@ def _flat_provenance_one_string(
                     )
                     norm = normalizer.normalize(masked2, sheet_of_cell)
                     out: set[str] = set()
-                    for ref in parse_cell_refs(norm):
+                    for ref in parse_standalone_cell_refs(norm):
                         sh = ref.sheet if ref.sheet is not None else sheet_of_cell
                         out.add(format_key(sh, f"{ref.column}{ref.row}"))
                     for start, end, _span in parse_range_refs_with_spans(norm):

--- a/excel_grapher/grapher/provenance_collect.py
+++ b/excel_grapher/grapher/provenance_collect.py
@@ -29,10 +29,10 @@ from .parser import (
     expand_range,
     format_key,
     mask_spans,
-    parse_cell_refs_with_spans,
     parse_dynamic_range_refs_with_spans,
     parse_range_refs_with_spans,
     parse_standalone_cell_refs,
+    parse_standalone_cell_refs_with_spans,
     split_top_level_choose,
     split_top_level_if,
     split_top_level_ifs,
@@ -298,9 +298,7 @@ def _flat_provenance_one_string(
     masked = mask_spans(masked, dyn_spans)
 
     if expand_ranges:
-        spans: list[tuple[int, int]] = []
-        for start, end, span in parse_range_refs_with_spans(masked):
-            spans.append(span)
+        for start, end, _span in parse_range_refs_with_spans(masked):
             sheet = start.sheet if start.sheet is not None else current_sheet
             for dep_sheet, dep_a1 in expand_range(
                 sheet=sheet,
@@ -314,9 +312,8 @@ def _flat_provenance_one_string(
                 _merge_into(
                     acc, k, EdgeProvenance(causes=frozenset({DependencyCause.static_range}))
                 )
-        masked = mask_spans(masked, spans)
 
-    for ref, span in parse_cell_refs_with_spans(masked):
+    for ref, span in parse_standalone_cell_refs_with_spans(masked):
         sh = ref.sheet if ref.sheet is not None else current_sheet
         k = format_key(sh, f"{ref.column}{ref.row}")
         _merge_into(acc, k, _prov_with_direct_span(span, span_target=span_target))

--- a/excel_grapher/grapher/target_expansion.py
+++ b/excel_grapher/grapher/target_expansion.py
@@ -14,22 +14,10 @@ from .parser import expand_range, format_key
 def split_range_target_on_colon(t: str) -> tuple[str, str] | None:
     """Split a sheet-qualified range target into (start_addr, end_addr).
 
-    Handles colons embedded within quoted sheet names (`'It''s Data'!A1:B2`).
-    Returns `None` if the target contains no top-level colon.
+    Thin wrapper around `excel_grapher.core.address_keys.split_address_on_colon`
+    so callers that already import from this module keep working.
     """
-    in_quote = False
-    i = 0
-    while i < len(t):
-        ch = t[i]
-        if ch == "'":
-            if in_quote and i + 1 < len(t) and t[i + 1] == "'":
-                i += 2
-                continue
-            in_quote = not in_quote
-        elif ch == ":" and not in_quote:
-            return t[:i], t[i + 1 :]
-        i += 1
-    return None
+    return _address_keys.split_address_on_colon(t)
 
 
 def expand_targets_to_roots(
@@ -107,6 +95,7 @@ def expand_targets_to_roots(
                     sheet, start_a1 = _address_keys.parse_address(start_addr)
                 except ValueError as exc:
                     raise ValueError(f"Invalid target address: {t}") from exc
+                start_a1 = _address_keys.canonical_cell_coord(start_a1)
                 _require_sheet(sheet, target=t)
                 if "!" in end_addr:
                     try:
@@ -115,8 +104,9 @@ def expand_targets_to_roots(
                         raise ValueError(f"Invalid target address: {t}") from exc
                     if end_sheet != sheet:
                         raise ValueError(f"Range target spans multiple sheets: {t}")
+                    end_a1 = _address_keys.canonical_cell_coord(end_a1)
                 else:
-                    end_a1 = end_addr
+                    end_a1 = _address_keys.canonical_cell_coord(end_addr)
                 _expand_rect(sheet, start_a1, end_a1, target_label=t)
             else:
                 try:
@@ -124,7 +114,7 @@ def expand_targets_to_roots(
                 except ValueError as exc:
                     raise ValueError(f"Invalid target address: {t}") from exc
                 _require_sheet(sheet, target=t)
-                _emit(sheet, cell_part)
+                _emit(sheet, _address_keys.canonical_cell_coord(cell_part))
             continue
 
         cell_resolved = named_ranges.get(t)

--- a/excel_grapher/grapher/target_expansion.py
+++ b/excel_grapher/grapher/target_expansion.py
@@ -46,7 +46,8 @@ def expand_targets_to_roots(
 
     - Sheet-qualified single cells (`Sheet1!A1`, `'My Sheet'!A1`).
     - Sheet-qualified rectangular ranges (`Sheet1!A1:B2`,
-      `Sheet1!A1:Sheet1!B2`, `'My Sheet'!A1:B2`). Expansion follows
+      `Sheet1!A1:B2`, `'My Sheet'!A1:B2`; both-end forms like
+      `Sheet1!A1:Sheet1!B2` are also accepted). Expansion follows
       `expand_range` and `max_range_cells`.
     - Defined names (`MyCell`, `MyRange`) resolved against
       `named_ranges` (single cell) and `named_range_ranges` (rectangle).

--- a/excel_grapher/series_bindings/ranges.py
+++ b/excel_grapher/series_bindings/ranges.py
@@ -75,7 +75,8 @@ def expand_data_range(
     """Expand a binding `data_range` to canonical sheet-qualified cell addresses.
 
     Uses the same target expansion as `create_dependency_graph` (including
-    both-end sheet-qualified ranges like `Sheet1!A1:Sheet1!B2` and defined names).
+    both-end sheet-qualified ranges like `Sheet1!A1:Sheet1!B2`, which collapse
+    to single-prefix form, and defined names).
     """
     nr, nrr, wb_sheets = _resolve_named_range_maps(
         workbook=workbook,

--- a/tests/integration/evaluator/test_parity_circular_references.py
+++ b/tests/integration/evaluator/test_parity_circular_references.py
@@ -70,7 +70,10 @@ def test_parity_indirect_cycle_returns_zero() -> None:
     assert any(wi.category.__name__ == "CircularReferenceWarning" for wi in w)
 
     assert evaluator_result == {"S!A1": 0, "S!B1": 0}
-    if "S!A1:S!B1" in generated_result:
+    if "S!A1:B1" in generated_result:
+        result = cast("list[list[float]]", generated_result["S!A1:B1"])
+        assert result == [[0, 0]]
+    elif "S!A1:S!B1" in generated_result:
         result = cast("list[list[float]]", generated_result["S!A1:S!B1"])
         assert result == [[0, 0]]
     else:
@@ -114,7 +117,10 @@ def test_iterative_mutual_cycle_converges_with_parity() -> None:
     exec(generated_code, ns)
     compute_all = cast(Callable[[], dict[str, Any]], ns["compute_all"])
     generated_raw = compute_all()
-    if "S!A1:S!B1" in generated_raw:
+    if "S!A1:B1" in generated_raw:
+        result = cast("list[list[float]]", generated_raw["S!A1:B1"])
+        generated_result = {"S!A1": result[0][0], "S!B1": result[0][1]}
+    elif "S!A1:S!B1" in generated_raw:
         result = cast("list[list[float]]", generated_raw["S!A1:S!B1"])
         generated_result = {"S!A1": result[0][0], "S!B1": result[0][1]}
     else:

--- a/tests/integration/exporter/test_inline_operators.py
+++ b/tests/integration/exporter/test_inline_operators.py
@@ -175,7 +175,7 @@ class TestArrayOperatorOperandBinding:
         )
         # S!A1:A3 is used twice in the formula; without operand binding the
         # three-way guard duplicates it many times per nesting level.
-        assert body.count("xl_range(ctx, 'S!A1:S!A3')") == 2
+        assert body.count("xl_range(ctx, 'S!A1:A3')") == 2
 
     def test_nested_array_operator_code_size_stays_linear(self) -> None:
         depth1 = self._cell_body(

--- a/tests/integration/exporter/test_lazy_range_migration.py
+++ b/tests/integration/exporter/test_lazy_range_migration.py
@@ -164,8 +164,8 @@ def test_range_target_boundary_is_materialized() -> None:
         _make_node("S!C1", "=S!A1*3", None),
     )
     generated_results, code, _ns = exec_generated_code(graph, ["S!B1", "S!C1"])
-    assert "'S!B1:S!C1': xl_range_rows" in code
-    value = generated_results["S!B1:S!C1"]
+    assert "'S!B1:C1': xl_range_rows" in code
+    value = generated_results["S!B1:C1"]
     assert isinstance(value, list)
     assert value == [[20.0, 30.0]]
 

--- a/tests/integration/grapher/test_named_ranges.py
+++ b/tests/integration/grapher/test_named_ranges.py
@@ -156,4 +156,4 @@ def test_normalized_formula_resolves_range_named_range(tmp_path: Path) -> None:
     assert node is not None
     # Range-based name should be fully expanded in normalized_formula so that
     # downstream parsers never see a bare identifier like NumRange.
-    assert node.normalized_formula == "=VLOOKUP(Sheet1!A1, Sheet1!A1:Sheet1!B1, 2, FALSE())"
+    assert node.normalized_formula == "=VLOOKUP(Sheet1!A1, Sheet1!A1:B1, 2, FALSE())"

--- a/tests/unit/core/test_address_keys.py
+++ b/tests/unit/core/test_address_keys.py
@@ -3,17 +3,22 @@ from __future__ import annotations
 import re
 import typing
 
+import pytest
+
 from excel_grapher.core.address_keys import (
     NormalizedAddress,
+    canonical_cell_coord,
     format_cell_key,
     format_key,
     make_node_key_sort_key,
     normalize_key,
     quoted_sheet_prefix_regex,
     sort_node_keys,
+    split_address_on_colon,
     unescape_formula_sheet_name,
 )
 from excel_grapher.grapher.node import NodeKey
+from excel_grapher.grapher.target_expansion import split_range_target_on_colon
 
 
 def test_normalized_address_is_str_type_alias() -> None:
@@ -25,6 +30,66 @@ def test_normalize_key_returns_normalized_address() -> None:
     assert hints["return"] is NormalizedAddress
     result: NormalizedAddress = normalize_key("'Sheet1'!A1")
     assert result == "Sheet1!A1"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Sheet1!$A$1", "Sheet1!A1"),
+        ("Sheet1!a1", "Sheet1!A1"),
+        ("Sheet1!A1:$A$3", "Sheet1!A1:A3"),
+        ("Sheet1!$A$1:$B$2", "Sheet1!A1:B2"),
+        ("Sheet1!A1:Sheet1!$A$3", "Sheet1!A1:A3"),
+        ("Sheet1!a1:b2", "Sheet1!A1:B2"),
+        ("Sheet1!$A:$A", "Sheet1!A:A"),
+        ("Sheet1!$1:$1", "Sheet1!1:1"),
+        ("Sheet1!$A$1:Sheet2!$B$2", "Sheet1!A1:Sheet2!B2"),
+    ],
+)
+def test_normalize_key_canonicalizes_cell_coords(raw: str, expected: str) -> None:
+    assert normalize_key(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("cell", "expected"),
+    [
+        ("A1", "A1"),
+        ("$A$1", "A1"),
+        ("a1", "A1"),
+        ("$b$10", "B10"),
+        ("A", "A"),
+        ("$A", "A"),
+        ("a", "A"),
+        ("1", "1"),
+        ("$1", "1"),
+        ("01", "1"),
+    ],
+)
+def test_canonical_cell_coord(cell: str, expected: str) -> None:
+    assert canonical_cell_coord(cell) == expected
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "Sheet1!A1:A3",
+        "Sheet1!A1:Sheet1!A3",
+        "'My Sheet'!A1:B2",
+        "'A:B'!A1",
+        "'O''Neil'!A1:B2",
+        "Sheet1!A1",
+    ],
+)
+def test_split_range_target_on_colon_delegates_to_split_address_on_colon(
+    address: str,
+) -> None:
+    assert split_range_target_on_colon(address) == split_address_on_colon(address)
+
+
+def test_split_address_on_colon_ignores_colon_inside_quoted_sheet() -> None:
+    assert split_address_on_colon("'A:B'!C1") is None
+    assert split_address_on_colon("'A:B'!C1:D2") == ("'A:B'!C1", "D2")
+    assert split_address_on_colon("'O''Neil'!A1:B2") == ("'O''Neil'!A1", "B2")
 
 
 def test_format_helpers_return_normalized_address() -> None:

--- a/tests/unit/core/test_formula_normalization.py
+++ b/tests/unit/core/test_formula_normalization.py
@@ -43,7 +43,7 @@ def test_normalize_excel_formula_preserves_quoted_apostrophe_sheet_refs() -> Non
     sheet = "O'Neil"
     cases = [
         ("='O''Neil'!A1*2", "='O''Neil'!A1*2"),
-        ("='O''Neil'!A1:'O''Neil'!B2", "='O''Neil'!A1:'O''Neil'!B2"),
+        ("='O''Neil'!A1:'O''Neil'!B2", "='O''Neil'!A1:B2"),
         ("=SUM('O''Neil'!A:A)", "=SUM('O''Neil'!A:A)"),
         ("=SUM('O''Neil'!1:1)", "=SUM('O''Neil'!1:1)"),
     ]

--- a/tests/unit/core/test_range_single_prefix.py
+++ b/tests/unit/core/test_range_single_prefix.py
@@ -140,8 +140,38 @@ def test_parse_standalone_cell_refs_masks_range_spans(formula: str) -> None:
 
 def test_local_cell_re_does_not_match_bare_range_endpoint() -> None:
     """Defense in depth: `:` blocks local-cell matching of range ends."""
-    refs = parse_cell_refs("=SUM(Sheet1!A1:A3)")
+    refs = parse_cell_refs("=SUM(Sheet1!A1:A3)", allow_unmasked_ranges=True)
     assert CellRef(sheet=None, column="A", row=3) not in refs
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "=SUM(Sheet1!A1:A3)",
+        "=SUM(Sheet1!A1:Sheet1!A3)",
+        "=SUM(A1:A3)+B5",
+        "=SUM(Sheet1!A:A)",
+    ],
+)
+def test_parse_cell_refs_refuses_unmasked_ranges(formula: str) -> None:
+    with pytest.raises(ValueError, match="unmasked range|allow_unmasked_ranges"):
+        parse_cell_refs(formula)
+
+
+def test_parse_cell_refs_allows_unmasked_ranges_opt_in() -> None:
+    refs = parse_cell_refs("=SUM(Sheet1!A1:A3)+B5", allow_unmasked_ranges=True)
+    assert CellRef(sheet="Sheet1", column="A", row=1) in refs
+    assert CellRef(sheet=None, column="B", row=5) in refs
+
+
+def test_parse_cell_refs_accepts_masked_or_range_free_text() -> None:
+    assert parse_cell_refs("=Sheet1!A1+B5") == [
+        CellRef(sheet="Sheet1", column="A", row=1),
+        CellRef(sheet=None, column="B", row=5),
+    ]
+    assert parse_standalone_cell_refs("=SUM(Sheet1!A1:A3)+B5") == [
+        CellRef(sheet=None, column="B", row=5)
+    ]
 
 
 def test_format_missing_leaves_uses_single_prefix() -> None:

--- a/tests/unit/core/test_range_single_prefix.py
+++ b/tests/unit/core/test_range_single_prefix.py
@@ -42,9 +42,7 @@ def test_format_range_key_uses_single_prefix(
         ("Sheet1!A1:Sheet2!D1", "Sheet1!A1:Sheet2!D1"),
     ],
 )
-def test_normalize_key_collapses_same_sheet_range_to_single_prefix(
-    raw: str, expected: str
-) -> None:
+def test_normalize_key_collapses_same_sheet_range_to_single_prefix(raw: str, expected: str) -> None:
     assert normalize_key(raw) == expected
 
 
@@ -66,10 +64,7 @@ class TestFormulaNormalizerSinglePrefix:
     def test_quoted_sheet_local_and_both_end(self) -> None:
         n = FormulaNormalizer()
         assert n.normalize("=SUM(A1:B2)", "My Sheet") == "=SUM('My Sheet'!A1:B2)"
-        assert (
-            n.normalize("=SUM('My Sheet'!A1:'My Sheet'!B2)", "Other")
-            == "=SUM('My Sheet'!A1:B2)"
-        )
+        assert n.normalize("=SUM('My Sheet'!A1:'My Sheet'!B2)", "Other") == "=SUM('My Sheet'!A1:B2)"
 
     def test_cross_sheet_range_keeps_both_endpoints(self) -> None:
         n = FormulaNormalizer()
@@ -103,5 +98,5 @@ def test_ast_and_codegen_emit_single_prefix_xl_range() -> None:
     assert gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!B2")) == "xl_range(ctx, 'Sheet1!A1:B2')"
     assert (
         gen._emit_ast(RangeNode("'My Sheet'!A1", "'My Sheet'!C1"))
-        == 'xl_range(ctx, "\'My Sheet\'!A1:C1")'
+        == "xl_range(ctx, \"'My Sheet'!A1:C1\")"
     )

--- a/tests/unit/core/test_range_single_prefix.py
+++ b/tests/unit/core/test_range_single_prefix.py
@@ -1,0 +1,107 @@
+"""Same-sheet ranges converge to a single sheet prefix (#376)."""
+
+from __future__ import annotations
+
+import pytest
+
+from excel_grapher.core.address_keys import format_range_key, normalize_key
+from excel_grapher.core.formula_ast import RangeNode, parse
+from excel_grapher.exporter.codegen import CodeGenerator
+from excel_grapher.grapher.parser import FormulaNormalizer
+
+
+@pytest.mark.parametrize(
+    ("sheet", "start", "end", "expected"),
+    [
+        ("Sheet1", "A1", "A3", "Sheet1!A1:A3"),
+        ("Sheet1", "A1", "D1", "Sheet1!A1:D1"),
+        ("Sheet1", "A1", "B2", "Sheet1!A1:B2"),
+        ("My Sheet", "A1", "B2", "'My Sheet'!A1:B2"),
+        ("O'Neil", "C4", "D4", "'O''Neil'!C4:D4"),
+    ],
+)
+def test_format_range_key_uses_single_prefix(
+    sheet: str, start: str, end: str, expected: str
+) -> None:
+    assert format_range_key(sheet, start, end) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Sheet1!A1:A3", "Sheet1!A1:A3"),
+        ("Sheet1!A1:Sheet1!A3", "Sheet1!A1:A3"),
+        ("Sheet1!A1:D1", "Sheet1!A1:D1"),
+        ("Sheet1!A1:Sheet1!D1", "Sheet1!A1:D1"),
+        ("Sheet1!A1:B2", "Sheet1!A1:B2"),
+        ("Sheet1!A1:Sheet1!B2", "Sheet1!A1:B2"),
+        ("'My Sheet'!A1:B2", "'My Sheet'!A1:B2"),
+        ("'My Sheet'!A1:'My Sheet'!B2", "'My Sheet'!A1:B2"),
+        ("'Sheet1'!A1:'Sheet1'!A3", "Sheet1!A1:A3"),
+        # Cross-sheet stays both-end (both endpoints require a sheet).
+        ("Sheet1!A1:Sheet2!D1", "Sheet1!A1:Sheet2!D1"),
+    ],
+)
+def test_normalize_key_collapses_same_sheet_range_to_single_prefix(
+    raw: str, expected: str
+) -> None:
+    assert normalize_key(raw) == expected
+
+
+class TestFormulaNormalizerSinglePrefix:
+    """FormulaNormalizer emits single-prefix same-sheet ranges."""
+
+    def test_local_range(self) -> None:
+        n = FormulaNormalizer()
+        assert n.normalize("=SUM(A1:A3)", "Sheet1") == "=SUM(Sheet1!A1:A3)"
+
+    def test_single_prefix_input(self) -> None:
+        n = FormulaNormalizer()
+        assert n.normalize("=SUM(Sheet1!A1:A3)", "Sheet1") == "=SUM(Sheet1!A1:A3)"
+
+    def test_both_end_input_collapsed(self) -> None:
+        n = FormulaNormalizer()
+        assert n.normalize("=SUM(Sheet1!A1:Sheet1!A3)", "Sheet1") == "=SUM(Sheet1!A1:A3)"
+
+    def test_quoted_sheet_local_and_both_end(self) -> None:
+        n = FormulaNormalizer()
+        assert n.normalize("=SUM(A1:B2)", "My Sheet") == "=SUM('My Sheet'!A1:B2)"
+        assert (
+            n.normalize("=SUM('My Sheet'!A1:'My Sheet'!B2)", "Other")
+            == "=SUM('My Sheet'!A1:B2)"
+        )
+
+    def test_cross_sheet_range_keeps_both_endpoints(self) -> None:
+        n = FormulaNormalizer()
+        assert n.normalize("=SUM(Sheet1!A1:Sheet2!D1)", "Sheet1") == "=SUM(Sheet1!A1:Sheet2!D1)"
+
+    def test_named_range_range_uses_single_prefix(self) -> None:
+        n = FormulaNormalizer(named_range_ranges={"MyTable": ("Sheet1", "A1", "B3")})
+        assert n.normalize("=SUM(MyTable)", "Sheet1") == "=SUM(Sheet1!A1:B3)"
+
+    def test_multi_row_and_one_row_agree_with_normalize_key(self) -> None:
+        n = FormulaNormalizer()
+        for formula, sheet in (
+            ("=SUM(A1:A3)", "Sheet1"),
+            ("=SUM(A1:D1)", "Sheet1"),
+            ("=SUM(A1:B2)", "Sheet1"),
+            ("=SUM(Sheet1!A1:Sheet1!B2)", "Sheet1"),
+        ):
+            normalized = n.normalize(formula, sheet)
+            # Extract the range argument inside SUM(...).
+            inner = normalized.removeprefix("=SUM(").removesuffix(")")
+            assert normalize_key(inner) == inner
+
+
+def test_ast_and_codegen_emit_single_prefix_xl_range() -> None:
+    """AST accepts both-end and single-prefix; codegen emits single-prefix."""
+    assert parse("=Sheet1!A1:A3") == RangeNode("Sheet1!A1", "Sheet1!A3")
+    assert parse("=Sheet1!A1:Sheet1!A3") == RangeNode("Sheet1!A1", "Sheet1!A3")
+
+    gen = CodeGenerator(None)  # type: ignore[arg-type]
+    assert gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!A3")) == "xl_range(ctx, 'Sheet1!A1:A3')"
+    assert gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!B2")) == "xl_range(ctx, 'Sheet1!A1:B2')"
+    assert (
+        gen._emit_ast(RangeNode("'My Sheet'!A1", "'My Sheet'!C1"))
+        == 'xl_range(ctx, "\'My Sheet\'!A1:C1")'
+    )

--- a/tests/unit/core/test_range_single_prefix.py
+++ b/tests/unit/core/test_range_single_prefix.py
@@ -93,7 +93,7 @@ def test_ast_and_codegen_emit_single_prefix_xl_range() -> None:
     assert parse("=Sheet1!A1:A3") == RangeNode("Sheet1!A1", "Sheet1!A3")
     assert parse("=Sheet1!A1:Sheet1!A3") == RangeNode("Sheet1!A1", "Sheet1!A3")
 
-    gen = CodeGenerator(None)  # type: ignore[arg-type]
+    gen = CodeGenerator(None)  # type: ignore
     assert gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!A3")) == "xl_range(ctx, 'Sheet1!A1:A3')"
     assert gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!B2")) == "xl_range(ctx, 'Sheet1!A1:B2')"
     assert (

--- a/tests/unit/core/test_range_single_prefix.py
+++ b/tests/unit/core/test_range_single_prefix.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import fastpyxl
 import pytest
 
 from excel_grapher.core.address_keys import format_range_key, normalize_key
 from excel_grapher.core.formula_ast import RangeNode, parse
 from excel_grapher.exporter.codegen import CodeGenerator
-from excel_grapher.grapher.parser import FormulaNormalizer
+from excel_grapher.grapher.builder import _format_missing_leaves, create_dependency_graph
+from excel_grapher.grapher.parser import (
+    CellRef,
+    FormulaNormalizer,
+    parse_cell_refs,
+    parse_standalone_cell_refs,
+)
 
 
 @pytest.mark.parametrize(
@@ -100,3 +109,108 @@ def test_ast_and_codegen_emit_single_prefix_xl_range() -> None:
         gen._emit_ast(RangeNode("'My Sheet'!A1", "'My Sheet'!C1"))
         == "xl_range(ctx, \"'My Sheet'!A1:C1\")"
     )
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "=SUM(A1:A3,B5)",
+        "=SUM(Sheet1!A1:A3,B5)",
+        "=SUM(Sheet1!A1:Sheet1!A3,B5)",
+        "=SUM('My Sheet'!A1:'My Sheet'!B2,C1)",
+    ],
+)
+def test_parse_standalone_cell_refs_masks_range_spans(formula: str) -> None:
+    """Bare range endpoints must not appear as standalone local cells."""
+    normalized = FormulaNormalizer().normalize(formula, "Sheet1")
+    if formula == "=SUM('My Sheet'!A1:'My Sheet'!B2,C1)":
+        normalized = FormulaNormalizer().normalize(formula, "Other")
+
+    standalone = parse_standalone_cell_refs(normalized)
+    assert all(
+        ref.sheet is not None or ref.column + str(ref.row) not in {"A3", "B2"} for ref in standalone
+    )
+    # Extra non-range cell still present.
+    assert any(
+        (ref.sheet is None and f"{ref.column}{ref.row}" in {"B5", "C1"})
+        or (ref.sheet is not None and f"{ref.column}{ref.row}" in {"B5", "C1"})
+        for ref in standalone
+    )
+
+
+def test_local_cell_re_does_not_match_bare_range_endpoint() -> None:
+    """Defense in depth: `:` blocks local-cell matching of range ends."""
+    refs = parse_cell_refs("=SUM(Sheet1!A1:A3)")
+    assert CellRef(sheet=None, column="A", row=3) not in refs
+
+
+def test_format_missing_leaves_uses_single_prefix() -> None:
+    assert _format_missing_leaves({"Sheet1!C4", "Sheet1!C5", "Sheet1!C6"}) == ["Sheet1!C4:C6"]
+    assert _format_missing_leaves({"S!AA100", "S!AB100", "S!AC100"}) == ["S!AA100:AC100"]
+    assert _format_missing_leaves({"S!AA10", "S!AA11", "S!AB10", "S!AB11"}) == ["S!AA10:AB11"]
+    assert _format_missing_leaves({"My Sheet!A1", "My Sheet!A2"}) == ["'My Sheet'!A1:A2"]
+
+
+def _write_cross_sheet_sum(path: Path, *, formula: str) -> None:
+    wb = fastpyxl.Workbook()
+    s1 = wb.active
+    assert s1 is not None
+    s1.title = "Sheet1"
+    s2 = wb.create_sheet("Sheet2")
+    s1["A1"].value = 1
+    s1["A2"].value = 2
+    s1["A3"].value = 3
+    s2["B1"].value = formula
+    s2["B2"].value = 9
+    wb.save(path)
+    wb.close()
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "=SUM(Sheet1!A1:A3)+B2",
+        "=SUM(Sheet1!A1:Sheet1!A3)+B2",
+        "=SUM(A1:A3)+Sheet2!B2",  # written on Sheet1 in helper below
+    ],
+)
+def test_dep_extraction_single_prefix_matrix_no_phantom_sheet(tmp_path: Path, formula: str) -> None:
+    """Dep extraction expands interiors and never mis-sheets bare endpoints."""
+    path = tmp_path / "deps.xlsx"
+    if formula.startswith("=SUM(A1:A3)"):
+        wb = fastpyxl.Workbook()
+        s1 = wb.active
+        assert s1 is not None
+        s1.title = "Sheet1"
+        s2 = wb.create_sheet("Sheet2")
+        s1["A1"].value = 1
+        s1["A2"].value = 2
+        s1["A3"].value = 3
+        s2["B2"].value = 9
+        s1["B1"].value = formula
+        wb.save(path)
+        wb.close()
+        target = "Sheet1!B1"
+        expected = {"Sheet1!A1", "Sheet1!A2", "Sheet1!A3", "Sheet2!B2"}
+    else:
+        _write_cross_sheet_sum(path, formula=formula)
+        target = "Sheet2!B1"
+        expected = {"Sheet1!A1", "Sheet1!A2", "Sheet1!A3", "Sheet2!B2"}
+
+    graph = create_dependency_graph(path, [target], load_values=False)
+    assert graph.get_dependencies(target) == expected
+    assert "Sheet2!A3" not in graph.get_dependencies(target)
+
+
+def test_expand_ranges_false_does_not_mis_sheet_bare_endpoint(tmp_path: Path) -> None:
+    """With expand_ranges=False, bare range ends must not become local-sheet deps."""
+    path = tmp_path / "no_expand.xlsx"
+    _write_cross_sheet_sum(path, formula="=SUM(Sheet1!A1:A3)+B2")
+
+    graph = create_dependency_graph(path, ["Sheet2!B1"], load_values=False, expand_ranges=False)
+    deps = graph.get_dependencies("Sheet2!B1")
+    assert deps == {"Sheet2!B2"}
+    assert "Sheet2!A3" not in deps
+    assert "Sheet1!A1" not in deps
+    assert "Sheet1!A2" not in deps
+    assert "Sheet1!A3" not in deps

--- a/tests/unit/exporter/test_codegen.py
+++ b/tests/unit/exporter/test_codegen.py
@@ -143,17 +143,17 @@ class TestEmitAstReferences:
     def test_emit_range_1d_column(self, gen):
         """1D range (column) emits a lazy xl_range call."""
         result = gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!A3"))
-        assert result == "xl_range(ctx, 'Sheet1!A1:Sheet1!A3')"
+        assert result == "xl_range(ctx, 'Sheet1!A1:A3')"
 
     def test_emit_range_1d_row(self, gen):
         """1D range (row) emits a lazy xl_range call."""
         result = gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!C1"))
-        assert result == "xl_range(ctx, 'Sheet1!A1:Sheet1!C1')"
+        assert result == "xl_range(ctx, 'Sheet1!A1:C1')"
 
     def test_emit_range_2d(self, gen):
         """2D range emits a lazy xl_range call."""
         result = gen._emit_ast(RangeNode("Sheet1!A1", "Sheet1!B2"))
-        assert result == "xl_range(ctx, 'Sheet1!A1:Sheet1!B2')"
+        assert result == "xl_range(ctx, 'Sheet1!A1:B2')"
 
 
 class TestEmitAstOperators:
@@ -782,8 +782,8 @@ class TestCodeGeneratorContextManager:
         )
         gen = CodeGenerator(graph)
         code = gen.generate(["Sheet1!C1", "Sheet1!D1", "Sheet1!E1"])
-        assert "Sheet1!C1:Sheet1!E1" in code
-        assert "'Sheet1!C1:Sheet1!E1': xl_range" in code
+        assert "Sheet1!C1:E1" in code
+        assert "'Sheet1!C1:E1': xl_range_rows" in code
 
     def test_generate_deduplication(self):
         """Cells should only be emitted once even if referenced multiple times."""
@@ -828,7 +828,7 @@ class TestGenerateNamedRanges:
             _make_node("Sheet1!B3", None, 3.0),
         )
         code = CodeGenerator(graph).generate(["BeeCol"])
-        assert "'Sheet1!B1:Sheet1!B3': xl_range" in code
+        assert "'Sheet1!B1:B3': xl_range_rows" in code
 
     def test_generate_modules_expands_defined_name(self):
         graph = self._graph_with_named_ranges(
@@ -838,7 +838,7 @@ class TestGenerateNamedRanges:
         )
         files = CodeGenerator(graph).generate_modules(["BeeCol"])
         api_py = files["api.py"]
-        assert "'Sheet1!B1:Sheet1!B3': xl_range" in api_py
+        assert "'Sheet1!B1:B3': xl_range_rows" in api_py
 
     def test_generate_unknown_defined_name_raises(self):
         graph = self._graph_with_named_ranges(_make_node("Sheet1!A1", None, 1.0))
@@ -1039,7 +1039,7 @@ class TestGeneratedCodeExecution:
         exec(code, namespace)
         result = namespace["compute_all"]()
 
-        assert result["Sheet1!B1:Sheet1!C1"] == [[20.0, 30.0]]
+        assert result["Sheet1!B1:C1"] == [[20.0, 30.0]]
 
 
 class TestIndexPrunedRangeCodegen:

--- a/tests/unit/exporter/test_codegen_edge_cases.py
+++ b/tests/unit/exporter/test_codegen_edge_cases.py
@@ -149,7 +149,7 @@ class TestMissingCellReferences:
         code = gen.generate(["S!B1"])
 
         # Ranges resolve lazily; missing cells must still raise KeyError when reduced.
-        assert "xl_range(ctx, 'S!A1:S!A3')" in code
+        assert "xl_range(ctx, 'S!A1:A3')" in code
 
         namespace: dict = {}
         exec(code, namespace)

--- a/tests/unit/grapher/test_dynamic_refs.py
+++ b/tests/unit/grapher/test_dynamic_refs.py
@@ -834,8 +834,8 @@ def test_dynamic_ref_missing_multiple_leaves_raises_builder_aggregate_not_per_le
     assert "following leaf" in msg
     assert "have no constraint" in msg
     assert "Missing constraint for leaf" not in msg
-    # _format_missing_leaves may merge B1:D1 into one rectangle
-    assert "Sheet1!B1" in msg and "Sheet1!D1" in msg
+    # _format_missing_leaves may merge B1:D1 into one single-prefix rectangle
+    assert "Sheet1!B1:D1" in msg or ("Sheet1!B1" in msg and "Sheet1!D1" in msg)
 
 
 def test_expand_leaf_env_mutual_formula_refs_in_argument_subgraph_issue_54() -> None:
@@ -952,7 +952,7 @@ def test_indirect_does_not_raise_when_argument_is_intermediate_with_domain() -> 
 def test_format_missing_leaves_groups_contiguous_column_into_range() -> None:
     leaves = {"Sheet1!C4", "Sheet1!C5", "Sheet1!C6"}
     formatted = _format_missing_leaves(leaves)
-    assert formatted == ["Sheet1!C4:Sheet1!C6"]
+    assert formatted == ["Sheet1!C4:C6"]
 
 
 def test_format_missing_leaves_does_not_bridge_gaps() -> None:
@@ -964,7 +964,7 @@ def test_format_missing_leaves_does_not_bridge_gaps() -> None:
 def test_format_missing_leaves_merges_adjacent_columns_same_row() -> None:
     """Same row across consecutive columns → one horizontal range."""
     leaves = {"S!AA100", "S!AB100", "S!AC100"}
-    assert _format_missing_leaves(leaves) == ["S!AA100:S!AC100"]
+    assert _format_missing_leaves(leaves) == ["S!AA100:AC100"]
 
 
 def test_format_missing_leaves_merges_rectangle_when_row_runs_match() -> None:
@@ -975,7 +975,7 @@ def test_format_missing_leaves_merges_rectangle_when_row_runs_match() -> None:
         "S!AB10",
         "S!AB11",
     }
-    assert _format_missing_leaves(leaves) == ["S!AA10:S!AB11"]
+    assert _format_missing_leaves(leaves) == ["S!AA10:AB11"]
 
 
 def test_format_missing_leaves_does_not_merge_columns_with_different_row_patterns() -> None:

--- a/tests/unit/grapher/test_formula_normalizer.py
+++ b/tests/unit/grapher/test_formula_normalizer.py
@@ -32,7 +32,7 @@ class TestFormulaNormalizerBasicNormalization:
 
     def test_local_range_qualified(self) -> None:
         n = FormulaNormalizer()
-        assert n.normalize("=SUM(A1:A3)", "Sheet1") == "=SUM(Sheet1!A1:Sheet1!A3)"
+        assert n.normalize("=SUM(A1:A3)", "Sheet1") == "=SUM(Sheet1!A1:A3)"
 
     def test_non_formula_returned_unchanged(self) -> None:
         n = FormulaNormalizer()
@@ -51,7 +51,7 @@ class TestFormulaNormalizerNamedRanges:
     def test_range_named_range_resolved(self) -> None:
         named_range_ranges = {"MyTable": ("Sheet1", "A1", "B3")}
         n = FormulaNormalizer(named_range_ranges=named_range_ranges)
-        assert n.normalize("=SUM(MyTable)", "Sheet1") == "=SUM(Sheet1!A1:Sheet1!B3)"
+        assert n.normalize("=SUM(MyTable)", "Sheet1") == "=SUM(Sheet1!A1:B3)"
 
     def test_name_inside_sheet_ref_not_replaced(self) -> None:
         """Names appearing as sheet qualifiers (Foo!A1) must not be replaced."""

--- a/tests/unit/grapher/test_normalized_formula.py
+++ b/tests/unit/grapher/test_normalized_formula.py
@@ -85,7 +85,7 @@ def test_normalized_formula_qualifies_range_endpoints(tmp_path: Path) -> None:
     node = graph.get_node("Sheet1!A4")
     assert node is not None
     assert node.formula == "=SUM(A1:A3)"
-    assert node.normalized_formula == "=SUM(Sheet1!A1:Sheet1!A3)"
+    assert node.normalized_formula == "=SUM(Sheet1!A1:A3)"
 
 
 def test_normalized_formula_preserves_cross_sheet_refs(tmp_path: Path) -> None:

--- a/user_guide/01-dependency-graphs.qmd
+++ b/user_guide/01-dependency-graphs.qmd
@@ -84,7 +84,8 @@ another).
 `targets` accepts any mix of:
 
 - sheet-qualified single cells: `"Sheet1!A1"`, `"'My Sheet'!B2"`
-- sheet-qualified ranges: `"Sheet1!B12:F12"`, `"Sheet1!A1:Sheet1!B2"`,
+- sheet-qualified ranges: `"Sheet1!B12:F12"`, `"Sheet1!A1:B2"`
+  (both-end forms like `"Sheet1!A1:Sheet1!B2"` are also accepted),
   `"'My Sheet'!A1:B2"`
 - defined names that resolve to a single cell or rectangular range:
   `"MyInput"`, `"DataRange"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #376 by unifying same-sheet range strings on the single-prefix form (`Sheet1!A1:A3`) across formula normalization, address keys, and codegen.

## Changes

- Add `format_range_key` and make `normalize_key` collapse same-sheet both-end ranges (one-row and multi-row); cross-sheet stays both-end
- Formula normalizer emits single-prefix canonical ranges (including named-range expansion and both-end input collapse)
- Prevent local cell requalification of bare range endpoints after `:`
- Add `parse_standalone_cell_refs` and use it on dep-extraction paths so bare endpoints in `Sheet1!A1:A3` are not mistaken for local cells
- Codegen `xl_range` / contiguous `TARGETS` keys use single-prefix
- Docs and tests updated for the convergence matrix from `range_parsing.mdc`

## Acceptance

- [x] Same-sheet ranges in `normalized_formula` use single-prefix
- [x] `normalize_key` and formula normalization agree on canonical shape
- [x] Cross-sheet ranges still both-end qualified
- [x] Parser/target expansion still accept all equivalent input forms
- [x] Regression tests cover the convergence matrix

## Testing

`uv run pytest` — 1915 passed, 1 skipped, 4 xfailed (Linux; live Excel tests deselected as expected)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd2bcaec-1dd3-43f2-a142-1a19cf22db50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd2bcaec-1dd3-43f2-a142-1a19cf22db50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

