### PR TITLE
feat(series-bindings): enforce measure dtype in generated setters

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -514,10 +514,12 @@ class CodeGenerator:
         return "\n".join(lines).rstrip() + "\n"
 
     _SERIES_HELPER_IMPORT_NAMES: tuple[str, ...] = (
+        "DataFrameInput",
         "EmptyMeasure",
         "Record",
         "Records",
         "Scalar",
+        "Sequence",
         "SeriesInput",
         "_apply_series_records",
         "coerce_setter_input",

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -520,7 +520,6 @@ class CodeGenerator:
         "Scalar",
         "SeriesInput",
         "_apply_series_records",
-        "_coerce_records",
         "coerce_setter_input",
     )
 

--- a/excel_grapher/series_bindings/codegen_literals.py
+++ b/excel_grapher/series_bindings/codegen_literals.py
@@ -12,10 +12,57 @@ __all__ = [
     "emit_compute_preamble_lines",
     "emit_setter_type_alias_lines",
     "py_scalar_literal",
+    "python_annotation_for_dtype",
     "resolution_includes_datetime",
     "resolutions_include_datetime",
+    "setter_input_annotation",
     "values_include_datetime",
 ]
+
+
+def python_annotation_for_dtype(dtype: str | None) -> str | None:
+    """Return a Python type-annotation fragment for a binding dtype.
+
+    Returns:
+        Annotation text such as `float` or `int | float`, or `None` when the dtype
+        is missing/`auto`/unknown.
+    """
+    if dtype is None or dtype == "auto":
+        return None
+    mapping = {
+        "float": "float",
+        "number": "int | float",
+        "int": "int",
+        "bool": "bool",
+        "string": "str",
+        "datetime": "datetime",
+    }
+    return mapping.get(dtype)
+
+
+def setter_input_annotation(
+    *,
+    layout: str,
+    measure_dtype: str | None,
+    scalar_shorthand: bool,
+) -> str:
+    """Return the parameter annotation for a generated setter input.
+
+    Scalar shorthand keeps a records union so dict/list inputs remain valid while
+    exposing the measure dtype on the bare-value arm. Series/matrix narrow the
+    positional measure sequence when a dtype is known.
+    """
+    measure_type = python_annotation_for_dtype(measure_dtype)
+    if scalar_shorthand:
+        if measure_type is None:
+            return "Records | Record | Scalar"
+        return f"Records | Record | {measure_type}"
+    if measure_type is None:
+        return "SeriesInput"
+    if layout == "matrix":
+        # Positional 1D measure iterables are not accepted for matrix setters.
+        return "Records | Record | DataFrameInput"
+    return f"Records | Record | Sequence[{measure_type}] | DataFrameInput"
 
 
 def values_include_datetime(*containers: Mapping[str, object] | None) -> bool:

--- a/excel_grapher/series_bindings/coerce.py
+++ b/excel_grapher/series_bindings/coerce.py
@@ -15,7 +15,7 @@ _BOOL_FALSE = frozenset({"false", "0", "no"})
 _DATETIME_CLS = datetime
 _DATE_CLS = date
 
-__all__ = ["coerce_constant", "coerce_scalar"]
+__all__ = ["coerce_constant", "coerce_scalar", "validate_binding_scalar"]
 
 
 def _ensure_naive_datetime(value: datetime) -> datetime:
@@ -116,3 +116,56 @@ def coerce_scalar(raw: Any, read_as: str) -> Scalar:
 def coerce_constant(value: Any, *, read_as: str) -> Scalar:
     """Coerce a manifest constant using the effective read mode."""
     return coerce_scalar(value, read_as)
+
+
+def _type_error(dtype: str, raw: Any) -> TypeError:
+    return TypeError(f"expected {dtype}, got {type(raw).__name__}: {raw!r}")
+
+
+def validate_binding_scalar(raw: Any, dtype: str) -> Scalar:
+    """Validate a setter input value against a binding dtype.
+
+    Unlike `coerce_scalar`, this rejects values that are not already the expected
+    Python type (with limited safe coercions such as `int` -> `float`).
+
+    Args:
+        raw: Caller-supplied measure or field value.
+        dtype: Binding dtype (`string`, `int`, `float`, `number`, `bool`, `datetime`,
+            or `auto`).
+
+    Returns:
+        The validated scalar, possibly after a safe coercion.
+
+    Raises:
+        TypeError: When `raw` does not match `dtype`.
+        ValueError: When a datetime value is timezone-aware or `dtype` is unknown.
+    """
+    if raw is None or dtype == "auto":
+        return raw
+    if dtype == "float":
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise _type_error(dtype, raw)
+        return float(raw)
+    if dtype == "number":
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise _type_error(dtype, raw)
+        return raw
+    if dtype == "int":
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            raise _type_error(dtype, raw)
+        return raw
+    if dtype == "bool":
+        if not isinstance(raw, bool):
+            raise _type_error(dtype, raw)
+        return raw
+    if dtype == "string":
+        if not isinstance(raw, str):
+            raise _type_error(dtype, raw)
+        return raw
+    if dtype == "datetime":
+        if isinstance(raw, _DATETIME_CLS):
+            return _ensure_naive_datetime(raw)
+        if isinstance(raw, _DATE_CLS):
+            return _normalize_date(raw)
+        raise _type_error(dtype, raw)
+    raise ValueError(f"Unknown binding dtype: {dtype!r}")

--- a/excel_grapher/series_bindings/coerce.py
+++ b/excel_grapher/series_bindings/coerce.py
@@ -122,11 +122,36 @@ def _type_error(dtype: str, raw: Any) -> TypeError:
     return TypeError(f"expected {dtype}, got {type(raw).__name__}: {raw!r}")
 
 
+def _as_builtin_scalar(raw: Any) -> Any:
+    """Unwrap 0-d array-like scalars (e.g. numpy) to Python builtins via `.item()`.
+
+    Does not import numpy. Multi-element arrays keep their original value so later
+    isinstance checks reject them.
+    """
+    if raw is None or isinstance(
+        raw, (str, bytes, bytearray, bool, int, float, _DATETIME_CLS, _DATE_CLS)
+    ):
+        return raw
+    item = getattr(raw, "item", None)
+    if not callable(item):
+        return raw
+    try:
+        converted = item()
+    except (ValueError, TypeError, RuntimeError):
+        return raw
+    if converted is None or isinstance(
+        converted, (str, bool, int, float, _DATETIME_CLS, _DATE_CLS)
+    ):
+        return converted
+    return raw
+
+
 def validate_binding_scalar(raw: Any, dtype: str) -> Scalar:
     """Validate a setter input value against a binding dtype.
 
     Unlike `coerce_scalar`, this rejects values that are not already the expected
-    Python type (with limited safe coercions such as `int` -> `float`).
+    Python type (with limited safe coercions such as `int` -> `float`). Numpy
+    0-d numeric/bool scalars are accepted after conversion to builtins.
 
     Args:
         raw: Caller-supplied measure or field value.
@@ -142,6 +167,7 @@ def validate_binding_scalar(raw: Any, dtype: str) -> Scalar:
     """
     if raw is None or dtype == "auto":
         return raw
+    raw = _as_builtin_scalar(raw)
     if dtype == "float":
         if isinstance(raw, bool) or not isinstance(raw, (int, float)):
             raise _type_error(dtype, raw)

--- a/excel_grapher/series_bindings/docstring_renderers.py
+++ b/excel_grapher/series_bindings/docstring_renderers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Literal, Protocol, TypeAlias, cast, runtime_checkable
 
+from excel_grapher.series_bindings.codegen_literals import setter_input_annotation
 from excel_grapher.series_bindings.docstrings import (
     FieldContract,
     SeriesBindingDocstringContract,
@@ -76,16 +77,14 @@ def _is_single_key(contract: SeriesBindingDocstringContract) -> bool:
     return len(contract.required_fields) == 2
 
 
-_SETTER_INPUT_TYPE_NAMES: dict[str, str] = {
-    "scalar": "Scalar | Record | Records",
-    "series": "SeriesInput",
-    "matrix": "SeriesInput",
-}
-
-
 def _setter_input_type_name(contract: SeriesBindingDocstringContract) -> str:
-    """Return the type-alias name advertised by the generated setter signature."""
-    return _SETTER_INPUT_TYPE_NAMES.get(contract.layout, "SeriesInput")
+    """Return the input type text advertised in generated setter docstrings."""
+    scalar_shorthand = contract.layout == "scalar" and len(contract.required_fields) <= 1
+    return setter_input_annotation(
+        layout=contract.layout,
+        measure_dtype=contract.value_type,
+        scalar_shorthand=scalar_shorthand,
+    )
 
 
 def _setter_input_description(contract: SeriesBindingDocstringContract) -> str:

--- a/excel_grapher/series_bindings/input_coerce.py
+++ b/excel_grapher/series_bindings/input_coerce.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, TypeGuard, cast
 
-from excel_grapher.series_bindings.coerce import coerce_scalar
+from excel_grapher.series_bindings.coerce import coerce_scalar, validate_binding_scalar
 from excel_grapher.series_bindings.setter_input_types import EmptyMeasure, Layout, SetterInput
 from excel_grapher.series_bindings.types import Record, Records
 
@@ -198,6 +198,37 @@ def _apply_key_dtypes(
     return coerced
 
 
+def _apply_measure_dtype(
+    records: Records,
+    *,
+    measure_field: str,
+    measure_dtype: str | None,
+) -> Records:
+    """Validate and coerce measure values against the binding measure dtype."""
+    if measure_dtype is None:
+        return records
+    validated: list[dict[str, object]] = []
+    for index, record in enumerate(records):
+        if measure_field not in record:
+            validated.append(record)
+            continue
+        raw = record[measure_field]
+        try:
+            value = validate_binding_scalar(raw, measure_dtype)
+        except TypeError as exc:
+            raise TypeError(
+                f"record[{index}]: {measure_field} must be {measure_dtype}, "
+                f"got {type(raw).__name__}: {raw!r}"
+            ) from exc
+        if value is raw:
+            validated.append(record)
+            continue
+        updated = dict(record)
+        updated[measure_field] = value
+        validated.append(updated)
+    return validated
+
+
 def _coerce_dataframe_records(
     data: object,
     *,
@@ -346,6 +377,7 @@ def coerce_setter_input(
     key_order: tuple[object, ...] | None,
     strict: bool,
     key_dtypes: Mapping[str, str] | None = None,
+    measure_dtype: str | None = None,
     empty_measure: EmptyMeasure = "write",
     requires_address: bool = False,
 ) -> Records:
@@ -359,6 +391,7 @@ def coerce_setter_input(
         key_order: Canonical key values for positional measure iterables.
         strict: When true, reject unknown DataFrame columns.
         key_dtypes: Optional read modes per key field applied to all input shapes.
+        measure_dtype: Optional binding dtype enforced for `measure_field` values.
         empty_measure: How to treat rows with missing/NaN measure values.
         requires_address: When true, reject DataFrame input (records must carry addresses).
 
@@ -367,13 +400,19 @@ def coerce_setter_input(
 
     Raises:
         ImportError: When a DataFrame-like value is passed but pandas/polars is missing.
-        TypeError: When the input shape is unsupported for the layout.
+        TypeError: When the input shape is unsupported for the layout, or a measure
+            value does not match `measure_dtype`.
         ValueError: When columns, keys, or positional lengths are invalid.
     """
     if layout == "scalar":
         if _is_tabular_dataframe(data):
             raise TypeError("scalar setters do not accept DataFrame input")
-        return _coerce_scalar_records(data, measure_field)
+        records = _coerce_scalar_records(data, measure_field)
+        return _apply_measure_dtype(
+            records,
+            measure_field=measure_field,
+            measure_dtype=measure_dtype,
+        )
 
     if requires_address and _is_tabular_dataframe(data):
         raise TypeError(
@@ -393,6 +432,11 @@ def coerce_setter_input(
         records,
         key_fields=key_fields,
         key_dtypes=key_dtypes,
+    )
+    records = _apply_measure_dtype(
+        records,
+        measure_field=measure_field,
+        measure_dtype=measure_dtype,
     )
     return _apply_empty_measure(
         records,

--- a/excel_grapher/series_bindings/input_coerce.py
+++ b/excel_grapher/series_bindings/input_coerce.py
@@ -220,6 +220,8 @@ def _apply_measure_dtype(
                 f"record[{index}]: {measure_field} must be {measure_dtype}, "
                 f"got {type(raw).__name__}: {raw!r}"
             ) from exc
+        except ValueError as exc:
+            raise ValueError(f"record[{index}]: {measure_field}: {exc}") from exc
         if value is raw:
             validated.append(record)
             continue

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -13,6 +13,7 @@ from excel_grapher.series_bindings.codegen_literals import (
     emit_setter_type_alias_lines,
     py_scalar_literal,
     resolutions_include_datetime,
+    setter_input_annotation,
 )
 from excel_grapher.series_bindings.docstrings import (
     emit_docstring_literal,
@@ -381,7 +382,15 @@ def emit_setter_function(
         lines.append("")
     lines.extend(_emit_key_order_constant(resolved, key_fields))
     scalar_shorthand = _accepts_scalar_shorthand(series, resolved)
-    input_type = "Records | Record | Scalar" if scalar_shorthand else "SeriesInput"
+    concept_scheme = bindings.get("concept_scheme") if bindings is not None else None
+    if not isinstance(concept_scheme, dict):
+        concept_scheme = None
+    measure_dtype = _measure_dtype_for_codegen(series, concept_scheme=concept_scheme)
+    input_type = setter_input_annotation(
+        layout=str(series.get("layout") or "series"),
+        measure_dtype=measure_dtype,
+        scalar_shorthand=scalar_shorthand,
+    )
     lines.append(f"def {fn_name}(")
     lines.append("    ctx: EvalContext,")
     lines.append(f"    records: {input_type},")
@@ -415,9 +424,6 @@ def emit_setter_function(
     if doc is not None:
         lines.extend(emit_docstring_literal(doc))
     leaf_index_arg = "{}" if requires_address else index_name
-    concept_scheme = bindings.get("concept_scheme") if bindings is not None else None
-    if not isinstance(concept_scheme, dict):
-        concept_scheme = None
     coerced_records = _coerce_setter_input_call(
         series,
         resolved,
@@ -471,7 +477,14 @@ def emit_setters_block(
         export_addresses=export_addresses,
     )
     lines: list[str] = ["# --- Series binding setters (Records API) ---", ""]
-    include_datetime = resolutions_include_datetime(report["series"])
+    concept_scheme = bindings.get("concept_scheme")
+    if not isinstance(concept_scheme, dict):
+        concept_scheme = None
+    include_datetime = resolutions_include_datetime(report["series"]) or any(
+        _measure_dtype_for_codegen(series, concept_scheme=concept_scheme) == "datetime"
+        for series in bindings.get("series", [])
+        if isinstance(series, dict) and has_input_direction(series)
+    )
     if include_helpers:
         lines.extend(emit_input_coerce_helpers())
         if include_type_aliases:

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -45,6 +45,20 @@ def _measure_concept(series: dict[str, Any]) -> str:
     return str(measure.get("concept") or "OBS_VALUE")
 
 
+def _measure_dtype_for_codegen(series: dict[str, Any]) -> str | None:
+    """Return the measure dtype to enforce in generated setters, if any."""
+    measure = (series.get("structure") or {}).get("measure") or {}
+    dtype = measure.get("dtype")
+    if dtype is not None:
+        return str(dtype)
+    raw_bind = measure.get("bind")
+    bind: dict[str, Any] = raw_bind if isinstance(raw_bind, dict) else {}
+    read = bind.get("read")
+    if read is not None and read != "auto":
+        return str(read)
+    return None
+
+
 def _accepts_scalar_shorthand(
     series: dict[str, Any],
     resolved: SeriesResolution,
@@ -229,6 +243,7 @@ def _coerce_setter_input_call(
         _key_order_constant_name(resolved["series_id"]) if key_order is not None else "None"
     )
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
+    measure_dtype = _measure_dtype_for_codegen(series)
     parts = [
         "coerce_setter_input(",
         "            records,",
@@ -242,6 +257,8 @@ def _coerce_setter_input_call(
     ]
     if key_dtypes:
         parts.append(f"            key_dtypes={key_dtypes!r},")
+    if measure_dtype is not None:
+        parts.append(f"            measure_dtype={measure_dtype!r},")
     parts.append("        )")
     return "\n".join(parts)
 
@@ -395,7 +412,21 @@ def emit_setter_function(
         lines.extend(emit_docstring_literal(doc))
     leaf_index_arg = "{}" if requires_address else index_name
     if scalar_shorthand:
-        coerced_records = f"_coerce_records(records, {measure_concept!r}, allow_scalar=True)"
+        measure_dtype = _measure_dtype_for_codegen(series)
+        measure_dtype_arg = (
+            f",\n            measure_dtype={measure_dtype!r}" if measure_dtype is not None else ""
+        )
+        coerced_records = (
+            "coerce_setter_input(\n"
+            "            records,\n"
+            "            layout='scalar',\n"
+            "            key_fields=(),\n"
+            f"            measure_field={measure_concept!r},\n"
+            "            key_order=None,\n"
+            "            strict=strict"
+            f"{measure_dtype_arg},\n"
+            "        )"
+        )
     else:
         coerced_records = _coerce_setter_input_call(
             series,

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -20,6 +20,7 @@ from excel_grapher.series_bindings.docstrings import (
 )
 from excel_grapher.series_bindings.normalize import effective_dimension_id, has_input_direction
 from excel_grapher.series_bindings.resolve import (
+    _lookup_concept_dtype,
     resolve_series_bindings,
     warn_series_resolution_issues,
 )
@@ -45,12 +46,20 @@ def _measure_concept(series: dict[str, Any]) -> str:
     return str(measure.get("concept") or "OBS_VALUE")
 
 
-def _measure_dtype_for_codegen(series: dict[str, Any]) -> str | None:
-    """Return the measure dtype to enforce in generated setters, if any."""
+def _measure_dtype_for_codegen(
+    series: dict[str, Any],
+    concept_scheme: dict[str, Any] | None = None,
+) -> str | None:
+    """Return the measure dtype to enforce in generated setters, if any.
+
+    Precedence matches resolve/docstrings: explicit `structure.measure.dtype`, then
+    `concept_scheme` for the measure concept, then a non-`auto` measure `bind.read`.
+    """
     measure = (series.get("structure") or {}).get("measure") or {}
-    dtype = measure.get("dtype")
-    if dtype is not None:
-        return str(dtype)
+    concept_name = str(measure.get("concept") or "OBS_VALUE")
+    inferred = _lookup_concept_dtype(concept_scheme, series, concept_name)
+    if inferred is not None:
+        return inferred
     raw_bind = measure.get("bind")
     bind: dict[str, Any] = raw_bind if isinstance(raw_bind, dict) else {}
     read = bind.get("read")
@@ -234,8 +243,10 @@ def _coerce_setter_input_call(
     key_fields: list[str],
     measure_concept: str,
     strict_kwarg: str,
-    empty_measure_kwarg: str,
+    empty_measure_kwarg: str | None,
     requires_address: bool,
+    concept_scheme: dict[str, Any] | None = None,
+    emit_requires_address: bool = True,
 ) -> str:
     layout = str(series.get("layout") or "series")
     key_order = _canonical_key_order(resolved, key_fields)
@@ -243,7 +254,7 @@ def _coerce_setter_input_call(
         _key_order_constant_name(resolved["series_id"]) if key_order is not None else "None"
     )
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
-    measure_dtype = _measure_dtype_for_codegen(series)
+    measure_dtype = _measure_dtype_for_codegen(series, concept_scheme=concept_scheme)
     parts = [
         "coerce_setter_input(",
         "            records,",
@@ -252,9 +263,11 @@ def _coerce_setter_input_call(
         f"            measure_field={measure_concept!r},",
         f"            key_order={key_order_expr},",
         f"            strict={strict_kwarg},",
-        f"            empty_measure={empty_measure_kwarg},",
-        f"            requires_address={requires_address!r},",
     ]
+    if empty_measure_kwarg is not None:
+        parts.append(f"            empty_measure={empty_measure_kwarg},")
+    if emit_requires_address:
+        parts.append(f"            requires_address={requires_address!r},")
     if key_dtypes:
         parts.append(f"            key_dtypes={key_dtypes!r},")
     if measure_dtype is not None:
@@ -266,15 +279,6 @@ def _coerce_setter_input_call(
 def emit_setter_helpers() -> list[str]:
     """Emit shared private helpers used by generated `set_*` functions."""
     return [
-        "def _coerce_records(records, measure_field, *, allow_scalar=False) -> Records:",
-        "    if not allow_scalar:",
-        "        return records",
-        "    if not isinstance(records, list):",
-        "        if isinstance(records, dict):",
-        "            return [records]",
-        "        return [{measure_field: records}]",
-        "    return records",
-        "",
         "def _apply_series_records(",
         "    ctx,",
         "    records,",
@@ -411,32 +415,20 @@ def emit_setter_function(
     if doc is not None:
         lines.extend(emit_docstring_literal(doc))
     leaf_index_arg = "{}" if requires_address else index_name
-    if scalar_shorthand:
-        measure_dtype = _measure_dtype_for_codegen(series)
-        measure_dtype_arg = (
-            f",\n            measure_dtype={measure_dtype!r}" if measure_dtype is not None else ""
-        )
-        coerced_records = (
-            "coerce_setter_input(\n"
-            "            records,\n"
-            "            layout='scalar',\n"
-            "            key_fields=(),\n"
-            f"            measure_field={measure_concept!r},\n"
-            "            key_order=None,\n"
-            "            strict=strict"
-            f"{measure_dtype_arg},\n"
-            "        )"
-        )
-    else:
-        coerced_records = _coerce_setter_input_call(
-            series,
-            resolved,
-            key_fields=key_fields,
-            measure_concept=measure_concept,
-            strict_kwarg="strict",
-            empty_measure_kwarg="empty_measure",
-            requires_address=requires_address,
-        )
+    concept_scheme = bindings.get("concept_scheme") if bindings is not None else None
+    if not isinstance(concept_scheme, dict):
+        concept_scheme = None
+    coerced_records = _coerce_setter_input_call(
+        series,
+        resolved,
+        key_fields=key_fields,
+        measure_concept=measure_concept,
+        strict_kwarg="strict",
+        empty_measure_kwarg=None if scalar_shorthand else "empty_measure",
+        requires_address=requires_address,
+        concept_scheme=concept_scheme,
+        emit_requires_address=not scalar_shorthand,
+    )
     lines.append("    _apply_series_records(")
     lines.append("        ctx,")
     lines.append(f"        {coerced_records},")

--- a/tests/unit/series_bindings/test_codegen_literals.py
+++ b/tests/unit/series_bindings/test_codegen_literals.py
@@ -9,7 +9,9 @@ from excel_grapher.series_bindings.codegen_literals import (
     emit_compute_preamble_lines,
     emit_setter_type_alias_lines,
     py_scalar_literal,
+    python_annotation_for_dtype,
     resolution_includes_datetime,
+    setter_input_annotation,
 )
 from excel_grapher.series_bindings.types import SeriesResolution
 
@@ -50,6 +52,49 @@ def test_emit_compute_preamble_lines_include_datetime_when_needed() -> None:
     lines = emit_compute_preamble_lines(include_datetime=True)
     assert lines[0] == "import datetime"
     assert lines[-1] == ""
+
+
+def test_python_annotation_for_dtype() -> None:
+    assert python_annotation_for_dtype("float") == "float"
+    assert python_annotation_for_dtype("number") == "int | float"
+    assert python_annotation_for_dtype("datetime") == "datetime"
+    assert python_annotation_for_dtype("auto") is None
+    assert python_annotation_for_dtype(None) is None
+
+
+def test_setter_input_annotation_narrows_by_layout_and_dtype() -> None:
+    assert (
+        setter_input_annotation(
+            layout="scalar",
+            measure_dtype="float",
+            scalar_shorthand=True,
+        )
+        == "Records | Record | float"
+    )
+    assert (
+        setter_input_annotation(
+            layout="series",
+            measure_dtype="float",
+            scalar_shorthand=False,
+        )
+        == "Records | Record | Sequence[float] | DataFrameInput"
+    )
+    assert (
+        setter_input_annotation(
+            layout="matrix",
+            measure_dtype="float",
+            scalar_shorthand=False,
+        )
+        == "Records | Record | DataFrameInput"
+    )
+    assert (
+        setter_input_annotation(
+            layout="series",
+            measure_dtype=None,
+            scalar_shorthand=False,
+        )
+        == "SeriesInput"
+    )
 
 
 def test_resolution_includes_datetime() -> None:

--- a/tests/unit/series_bindings/test_coerce.py
+++ b/tests/unit/series_bindings/test_coerce.py
@@ -9,6 +9,7 @@ import pytest
 from excel_grapher.series_bindings.coerce import (
     coerce_constant,
     coerce_scalar,
+    validate_binding_scalar,
 )
 
 _EXCEL_EPOCH = datetime(1899, 12, 30)
@@ -118,3 +119,60 @@ def test_coerce_module_does_not_depend_on_codegen_literals() -> None:
     from excel_grapher.series_bindings import coerce as coerce_module
 
     assert "py_scalar_literal" not in coerce_module.__all__
+
+
+def test_validate_binding_scalar_float_accepts_int_and_float() -> None:
+    assert validate_binding_scalar(1.5, "float") == 1.5
+    assert validate_binding_scalar(2, "float") == 2.0
+
+
+def test_validate_binding_scalar_float_rejects_string() -> None:
+    with pytest.raises(TypeError, match="float"):
+        validate_binding_scalar("not-a-number", "float")
+
+
+def test_validate_binding_scalar_float_rejects_bool() -> None:
+    with pytest.raises(TypeError, match="float"):
+        validate_binding_scalar(True, "float")
+
+
+def test_validate_binding_scalar_number_preserves_int() -> None:
+    assert validate_binding_scalar(3, "number") == 3
+    assert validate_binding_scalar(3.5, "number") == 3.5
+
+
+def test_validate_binding_scalar_number_rejects_string() -> None:
+    with pytest.raises(TypeError, match="number"):
+        validate_binding_scalar("not-a-number", "number")
+
+
+def test_validate_binding_scalar_int_rejects_float() -> None:
+    with pytest.raises(TypeError, match="int"):
+        validate_binding_scalar(4.0, "int")
+
+
+def test_validate_binding_scalar_bool_rejects_int() -> None:
+    with pytest.raises(TypeError, match="bool"):
+        validate_binding_scalar(1, "bool")
+
+
+def test_validate_binding_scalar_string_rejects_int() -> None:
+    with pytest.raises(TypeError, match="string"):
+        validate_binding_scalar(1, "string")
+
+
+def test_validate_binding_scalar_datetime_accepts_date() -> None:
+    assert validate_binding_scalar(date(2024, 1, 15), "datetime") == datetime(2024, 1, 15)
+
+
+def test_validate_binding_scalar_datetime_rejects_string() -> None:
+    with pytest.raises(TypeError, match="datetime"):
+        validate_binding_scalar("2024-01-15", "datetime")
+
+
+def test_validate_binding_scalar_none_passthrough() -> None:
+    assert validate_binding_scalar(None, "float") is None
+
+
+def test_validate_binding_scalar_auto_passthrough() -> None:
+    assert validate_binding_scalar("x", "auto") == "x"

--- a/tests/unit/series_bindings/test_coerce.py
+++ b/tests/unit/series_bindings/test_coerce.py
@@ -176,3 +176,28 @@ def test_validate_binding_scalar_none_passthrough() -> None:
 
 def test_validate_binding_scalar_auto_passthrough() -> None:
     assert validate_binding_scalar("x", "auto") == "x"
+
+
+def test_validate_binding_scalar_accepts_numpy_numeric_scalars() -> None:
+    np = pytest.importorskip("numpy")
+    assert validate_binding_scalar(np.float64(1.5), "float") == 1.5
+    assert validate_binding_scalar(np.int64(3), "float") == 3.0
+    assert validate_binding_scalar(np.int64(3), "number") == 3
+    assert validate_binding_scalar(np.float64(3.5), "number") == 3.5
+    assert validate_binding_scalar(np.int64(3), "int") == 3
+    assert isinstance(validate_binding_scalar(np.int64(3), "int"), int)
+    assert validate_binding_scalar(np.bool_(True), "bool") is True
+
+
+def test_validate_binding_scalar_rejects_numpy_bool_for_numeric() -> None:
+    np = pytest.importorskip("numpy")
+    with pytest.raises(TypeError, match="float"):
+        validate_binding_scalar(np.bool_(True), "float")
+    with pytest.raises(TypeError, match="int"):
+        validate_binding_scalar(np.bool_(False), "int")
+
+
+def test_validate_binding_scalar_rejects_multi_element_numpy_array() -> None:
+    np = pytest.importorskip("numpy")
+    with pytest.raises(TypeError, match="float"):
+        validate_binding_scalar(np.array([1.0, 2.0]), "float")

--- a/tests/unit/series_bindings/test_input_coerce.py
+++ b/tests/unit/series_bindings/test_input_coerce.py
@@ -403,3 +403,55 @@ def test_requires_address_dataframe_rejected() -> None:
             **_SERIES_KWARGS,
             requires_address=True,
         )
+
+
+def test_measure_dtype_float_coerces_int_and_rejects_string() -> None:
+    result = coerce_setter_input(
+        [{"TIME_PERIOD": 4, "OBS_VALUE": 7}],
+        measure_dtype="float",
+        **_SERIES_KWARGS,
+    )
+    assert result == [{"TIME_PERIOD": 4, "OBS_VALUE": 7.0}]
+
+    with pytest.raises(TypeError, match="OBS_VALUE"):
+        coerce_setter_input(
+            [{"TIME_PERIOD": 4, "OBS_VALUE": "not-a-number"}],
+            measure_dtype="float",
+            **_SERIES_KWARGS,
+        )
+
+
+def test_measure_dtype_scalar_layout_rejects_wrong_type() -> None:
+    with pytest.raises(TypeError, match="OBS_VALUE"):
+        coerce_setter_input(
+            "not-a-number",
+            layout="scalar",
+            key_fields=(),
+            measure_field="OBS_VALUE",
+            key_order=None,
+            strict=True,
+            measure_dtype="float",
+        )
+
+
+def test_measure_dtype_scalar_layout_accepts_number() -> None:
+    result = coerce_setter_input(
+        1.25,
+        layout="scalar",
+        key_fields=(),
+        measure_field="OBS_VALUE",
+        key_order=None,
+        strict=True,
+        measure_dtype="number",
+    )
+    assert result == [{"OBS_VALUE": 1.25}]
+
+
+def test_measure_dtype_allows_none_for_empty_measure_policy() -> None:
+    result = coerce_setter_input(
+        [{"TIME_PERIOD": 4, "OBS_VALUE": None}],
+        measure_dtype="float",
+        empty_measure="skip",
+        **_SERIES_KWARGS,
+    )
+    assert result == []

--- a/tests/unit/series_bindings/test_input_coerce.py
+++ b/tests/unit/series_bindings/test_input_coerce.py
@@ -455,3 +455,20 @@ def test_measure_dtype_allows_none_for_empty_measure_policy() -> None:
         **_SERIES_KWARGS,
     )
     assert result == []
+
+
+def test_measure_dtype_accepts_numpy_int_positional_array() -> None:
+    np = pytest.importorskip("numpy")
+    result = coerce_setter_input(
+        np.array([1, 2, 3, 4, 5]),
+        measure_dtype="float",
+        **_SERIES_KWARGS,
+    )
+    assert result == [
+        {"TIME_PERIOD": 1, "OBS_VALUE": 1.0},
+        {"TIME_PERIOD": 2, "OBS_VALUE": 2.0},
+        {"TIME_PERIOD": 3, "OBS_VALUE": 3.0},
+        {"TIME_PERIOD": 4, "OBS_VALUE": 4.0},
+        {"TIME_PERIOD": 5, "OBS_VALUE": 5.0},
+    ]
+    assert all(isinstance(record["OBS_VALUE"], float) for record in result)

--- a/tests/unit/series_bindings/test_input_coerce.py
+++ b/tests/unit/series_bindings/test_input_coerce.py
@@ -472,3 +472,15 @@ def test_measure_dtype_accepts_numpy_int_positional_array() -> None:
         {"TIME_PERIOD": 5, "OBS_VALUE": 5.0},
     ]
     assert all(isinstance(record["OBS_VALUE"], float) for record in result)
+
+
+def test_measure_dtype_timezone_aware_datetime_includes_record_context() -> None:
+    from datetime import UTC, datetime
+
+    with pytest.raises(ValueError, match=r"record\[0\]: OBS_VALUE:.*Timezone-aware") as exc_info:
+        coerce_setter_input(
+            [{"TIME_PERIOD": 4, "OBS_VALUE": datetime(2024, 1, 1, tzinfo=UTC)}],
+            measure_dtype="datetime",
+            **_SERIES_KWARGS,
+        )
+    assert "Timezone-aware" in str(exc_info.value)

--- a/tests/unit/series_bindings/test_input_coerce_codegen_parity.py
+++ b/tests/unit/series_bindings/test_input_coerce_codegen_parity.py
@@ -20,6 +20,7 @@ from excel_grapher.series_bindings.input_coerce import coerce_setter_input
 from excel_grapher.series_bindings.setter_codegen import (
     _canonical_key_order,
     _key_dtypes_for_codegen,
+    _measure_dtype_for_codegen,
     emit_input_coerce_helpers,
     emit_setter_function,
     emit_setter_helpers,
@@ -35,6 +36,7 @@ class _SeriesCoerceKwargs(TypedDict, total=False):
     key_order: tuple[object, ...] | None
     strict: bool
     key_dtypes: dict[str, str]
+    measure_dtype: str
 
 
 def _write_borvelia_workbook(path: Path) -> None:
@@ -63,6 +65,7 @@ def _borvelia_series_kwargs(tmp_path: Path) -> _SeriesCoerceKwargs:
     resolved = resolve_series_binding(graph, wb_path, series)
     key_fields = [str(c) for c in (series.get("key") or [])]
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
+    measure_dtype = _measure_dtype_for_codegen(series)
     kwargs: _SeriesCoerceKwargs = {
         "layout": "series",
         "key_fields": tuple(key_fields),
@@ -72,6 +75,8 @@ def _borvelia_series_kwargs(tmp_path: Path) -> _SeriesCoerceKwargs:
     }
     if key_dtypes:
         kwargs["key_dtypes"] = key_dtypes
+    if measure_dtype is not None:
+        kwargs["measure_dtype"] = measure_dtype
     return kwargs
 
 
@@ -114,6 +119,7 @@ def _macro_matrix_coerce_kwargs(tmp_path: Path) -> _SeriesCoerceKwargs:
     series = bindings["series"][0]
     key_fields = [str(c) for c in (series.get("key") or [])]
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
+    measure_dtype = _measure_dtype_for_codegen(series)
     kwargs: _SeriesCoerceKwargs = {
         "layout": "matrix",
         "key_fields": tuple(key_fields),
@@ -123,6 +129,8 @@ def _macro_matrix_coerce_kwargs(tmp_path: Path) -> _SeriesCoerceKwargs:
     }
     if key_dtypes:
         kwargs["key_dtypes"] = key_dtypes
+    if measure_dtype is not None:
+        kwargs["measure_dtype"] = measure_dtype
     return kwargs
 
 
@@ -157,6 +165,7 @@ def test_generated_setter_matches_library_coercion_for_positional_input(tmp_path
 
     key_fields = [str(c) for c in (series.get("key") or [])]
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
+    measure_dtype = _measure_dtype_for_codegen(series)
     kwargs: dict[str, Any] = {
         "layout": "series",
         "key_fields": tuple(key_fields),
@@ -166,6 +175,8 @@ def test_generated_setter_matches_library_coercion_for_positional_input(tmp_path
     }
     if key_dtypes:
         kwargs["key_dtypes"] = key_dtypes
+    if measure_dtype is not None:
+        kwargs["measure_dtype"] = measure_dtype
     values = [-2.0, -1.0, 0.0, 7.5, 8.0]
     records = coerce_setter_input(values, **kwargs)
 

--- a/tests/unit/series_bindings/test_input_coerce_codegen_parity.py
+++ b/tests/unit/series_bindings/test_input_coerce_codegen_parity.py
@@ -65,7 +65,11 @@ def _borvelia_series_kwargs(tmp_path: Path) -> _SeriesCoerceKwargs:
     resolved = resolve_series_binding(graph, wb_path, series)
     key_fields = [str(c) for c in (series.get("key") or [])]
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
-    measure_dtype = _measure_dtype_for_codegen(series)
+    concept_scheme = bindings.get("concept_scheme")
+    measure_dtype = _measure_dtype_for_codegen(
+        series,
+        concept_scheme=concept_scheme if isinstance(concept_scheme, dict) else None,
+    )
     kwargs: _SeriesCoerceKwargs = {
         "layout": "series",
         "key_fields": tuple(key_fields),
@@ -119,7 +123,11 @@ def _macro_matrix_coerce_kwargs(tmp_path: Path) -> _SeriesCoerceKwargs:
     series = bindings["series"][0]
     key_fields = [str(c) for c in (series.get("key") or [])]
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
-    measure_dtype = _measure_dtype_for_codegen(series)
+    concept_scheme = bindings.get("concept_scheme")
+    measure_dtype = _measure_dtype_for_codegen(
+        series,
+        concept_scheme=concept_scheme if isinstance(concept_scheme, dict) else None,
+    )
     kwargs: _SeriesCoerceKwargs = {
         "layout": "matrix",
         "key_fields": tuple(key_fields),
@@ -165,7 +173,11 @@ def test_generated_setter_matches_library_coercion_for_positional_input(tmp_path
 
     key_fields = [str(c) for c in (series.get("key") or [])]
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
-    measure_dtype = _measure_dtype_for_codegen(series)
+    concept_scheme = bindings.get("concept_scheme")
+    measure_dtype = _measure_dtype_for_codegen(
+        series,
+        concept_scheme=concept_scheme if isinstance(concept_scheme, dict) else None,
+    )
     kwargs: dict[str, Any] = {
         "layout": "series",
         "key_fields": tuple(key_fields),

--- a/tests/unit/series_bindings/test_keyless_scalar.py
+++ b/tests/unit/series_bindings/test_keyless_scalar.py
@@ -177,4 +177,4 @@ def test_keyless_scalar_codegen_signature_uses_scalar_alias(tmp_path: Path) -> N
 
     assert "Scalar: TypeAlias = str | int | float | bool | None" in code
     assert "Scalar: TypeAlias = str | int | float | bool | datetime | None" not in code
-    assert "records: Records | Record | Scalar," in code
+    assert "records: Records | Record | str," in code

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -975,3 +975,79 @@ def test_emit_setter_empty_measure_skip_drops_nan_rows(tmp_path: Path) -> None:
     setter(ctx, df, empty_measure="skip")
     assert ctx.inputs["Inputs!I5"] == 7.5
     assert ctx.inputs["Inputs!J5"] == 2.0
+
+
+def test_emit_setter_rejects_measure_dtype_mismatch(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(series, resolved)
+    code = "\n".join(lines)
+    assert "measure_dtype='float'" in code or 'measure_dtype="float"' in code
+
+    ns = _exec_setters(lines)
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_borvelia_primary_balance"],
+    )
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    with pytest.raises(TypeError, match="OBS_VALUE"):
+        setter(ctx, [{"TIME_PERIOD": 3, "OBS_VALUE": "not-a-number"}])
+
+
+def test_emit_setter_coerces_int_measure_to_float(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    ns = _exec_setters(emit_setter_function(series, resolved))
+    setter = cast(
+        Callable[[EvalContext, list[dict[str, object]]], None],
+        ns["set_borvelia_primary_balance"],
+    )
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    setter(ctx, [{"TIME_PERIOD": 3, "OBS_VALUE": 42}])
+    assert ctx.inputs["Inputs!H5"] == 42.0
+
+
+def test_emit_scalar_setter_rejects_measure_dtype_mismatch(tmp_path: Path) -> None:
+    wb_path = tmp_path / "rate.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write_number("B2", 1.0)
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Inputs!B2"], load_values=True)
+    series = {
+        "id": "rate",
+        "sheet": "Inputs",
+        "data_range": "Inputs!B2",
+        "layout": "scalar",
+        "input": {"setter": {"name": "set_rate"}},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "number"},
+            },
+            "dimensions": [],
+        },
+        "key": [],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    lines = emit_setter_function(series, resolved)
+    code = "\n".join(lines)
+    assert "measure_dtype=" in code
+
+    ns = _exec_setters(lines)
+    setter = cast(Callable[..., None], ns["set_rate"])
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    with pytest.raises(TypeError, match="OBS_VALUE"):
+        setter(ctx, "not-a-number")
+    setter(ctx, 3)
+    assert ctx.inputs["Inputs!B2"] == 3.0

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -701,16 +701,46 @@ def test_emit_setters_block_calendar_year_setter_round_trips(tmp_path: Path) -> 
     assert ctx.inputs["Inputs!C2"] == 22.0
 
 
-def test_emit_setter_series_signature_uses_series_input(tmp_path: Path) -> None:
+def test_emit_setter_series_signature_narrows_measure_sequence(tmp_path: Path) -> None:
     wb_path = tmp_path / "lic_inputs.xlsx"
     _write_borvelia_workbook(wb_path)
     graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
     bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
     series = bindings["series"][0]
     resolved = resolve_series_binding(graph, wb_path, series)
-    code = "\n".join(emit_setter_function(series, resolved))
-    assert "records: SeriesInput," in code
+    code = "\n".join(emit_setter_function(series, resolved, bindings=bindings))
+    assert "records: Records | Record | Sequence[float] | DataFrameInput," in code
     assert 'empty_measure: EmptyMeasure = "write"' in code
+
+
+def test_emit_setter_scalar_signature_narrows_measure_dtype(tmp_path: Path) -> None:
+    wb_path = tmp_path / "rate.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write_number("B2", 1.0)
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Inputs!B2"], load_values=True)
+    series = {
+        "id": "rate",
+        "sheet": "Inputs",
+        "data_range": "Inputs!B2",
+        "layout": "scalar",
+        "input": {"setter": {"name": "set_rate"}},
+        "structure": {
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "number"},
+            },
+            "dimensions": [],
+        },
+        "key": [],
+    }
+    resolved = resolve_series_binding(graph, wb_path, series)
+    code = "\n".join(emit_setter_function(series, resolved))
+    assert "records: Records | Record | float," in code
+    assert "Scalar," not in code.split("records:")[1].split("\n")[0]
 
 
 def test_emit_setter_scalar_omits_empty_measure_kwarg(tmp_path: Path) -> None:
@@ -1104,6 +1134,32 @@ def test_emit_setter_measure_dtype_from_concept_scheme(tmp_path: Path) -> None:
     ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
     with pytest.raises(TypeError, match="OBS_VALUE"):
         setter(ctx, "not-a-number")
+
+
+def test_emit_matrix_setter_signature_omits_positional_sequence(tmp_path: Path) -> None:
+    from tests.fixtures.series_bindings.matrix_helpers import (
+        MATRIX_EXPLICIT_BINDINGS,
+        write_matrix_explicit_workbook,
+    )
+
+    wb_path = tmp_path / "matrix_inputs.xlsx"
+    write_matrix_explicit_workbook(wb_path)
+    bindings = load_series_bindings(MATRIX_EXPLICIT_BINDINGS)
+    series = bindings["series"][0]
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range(str(series["data_range"])),
+        load_values=True,
+    )
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+    )
+    code = "\n".join(emit_setter_function(series, resolved, bindings=bindings))
+    assert "records: Records | Record | DataFrameInput," in code
+    assert "Sequence[" not in code.split("def ")[1].split(") -> None:")[0]
 
 
 def test_emit_matrix_setter_rejects_measure_dtype_mismatch(tmp_path: Path) -> None:

--- a/tests/unit/series_bindings/test_setter_codegen.py
+++ b/tests/unit/series_bindings/test_setter_codegen.py
@@ -230,7 +230,7 @@ def test_emit_setters_block_emits_helpers_once(tmp_path: Path) -> None:
     code = "\n".join(emit_setters_block(graph, wb_path, bindings))
 
     assert code.count("def _apply_series_records(") == 1
-    assert code.count("def _coerce_records(") == 1
+    assert code.count("def _coerce_records(") == 0
     assert code.count("def coerce_setter_input(") == 1
     assert code.count("if TYPE_CHECKING:") == 1
     assert "SeriesInput: TypeAlias = Records | Record | Sequence[Scalar] | DataFrameInput" in code
@@ -1051,3 +1051,97 @@ def test_emit_scalar_setter_rejects_measure_dtype_mismatch(tmp_path: Path) -> No
         setter(ctx, "not-a-number")
     setter(ctx, 3)
     assert ctx.inputs["Inputs!B2"] == 3.0
+
+
+def test_emit_setter_measure_dtype_from_concept_scheme(tmp_path: Path) -> None:
+    wb_path = tmp_path / "rate.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write_number("B2", 1.0)
+    wb.close()
+
+    graph = create_dependency_graph(wb_path, ["Inputs!B2"], load_values=True)
+    bindings: WorkbookSeriesBindings = {
+        "schema_version": "1.8.0",
+        "workbook": "rate.xlsx",
+        "concept_scheme": {
+            "id": "demo",
+            "concepts": [
+                {"id": "OBS_VALUE", "name": "Observation value", "dtype": "float"},
+            ],
+        },
+        "series": [
+            {
+                "id": "rate",
+                "sheet": "Inputs",
+                "data_range": "Inputs!B2",
+                "layout": "scalar",
+                "input": {"setter": {"name": "set_rate"}},
+                "structure": {
+                    "measure": {
+                        "concept": "OBS_VALUE",
+                        "bind": {"kind": "data_cell", "read": "auto"},
+                    },
+                    "dimensions": [],
+                },
+                "key": [],
+            }
+        ],
+    }
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+    )
+    lines = emit_setter_function(series, resolved, bindings=bindings)
+    code = "\n".join(lines)
+    assert "measure_dtype='float'" in code or 'measure_dtype="float"' in code
+
+    ns = _exec_setters(lines)
+    setter = cast(Callable[..., None], ns["set_rate"])
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    with pytest.raises(TypeError, match="OBS_VALUE"):
+        setter(ctx, "not-a-number")
+
+
+def test_emit_matrix_setter_rejects_measure_dtype_mismatch(tmp_path: Path) -> None:
+    from tests.fixtures.series_bindings.matrix_helpers import (
+        MATRIX_EXPLICIT_BINDINGS,
+        write_matrix_explicit_workbook,
+    )
+
+    wb_path = tmp_path / "matrix_inputs.xlsx"
+    write_matrix_explicit_workbook(wb_path)
+    bindings = load_series_bindings(MATRIX_EXPLICIT_BINDINGS)
+    series = bindings["series"][0]
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range(str(series["data_range"])),
+        load_values=True,
+    )
+    resolved = resolve_series_binding(
+        graph,
+        wb_path,
+        series,
+        concept_scheme=bindings.get("concept_scheme"),
+    )
+    lines = emit_setter_function(series, resolved, bindings=bindings)
+    ns = _exec_setters(lines)
+    setter_name = str(((series.get("input") or {}).get("setter") or {}).get("name") or "")
+    if not setter_name:
+        setter_name = str((series.get("setter") or {}).get("name") or f"set_{series['id']}")
+    setter = cast(Callable[..., None], ns[setter_name])
+    ctx = EvalContext(inputs=coerce_inputs_dict({}), resolver=lambda _a: None)
+    with pytest.raises(TypeError, match="OBS_VALUE"):
+        setter(
+            ctx,
+            [
+                {
+                    "INDICATOR": "GDP growth",
+                    "TIME_PERIOD": 2025,
+                    "OBS_VALUE": "not-a-number",
+                }
+            ],
+        )

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -309,6 +309,14 @@ Generated setters accept `empty_measure: Literal["skip", "write", "error"] = "wr
 Empty **key** fields always raise, regardless of `empty_measure`. A zero-row DataFrame with valid
 columns is a no-op (partial update with zero cells).
 
+**Measure `dtype` is enforced at runtime.** Generated setters validate each measure value against
+`structure.measure.dtype` (falling back to the measure concept’s `concept_scheme` dtype, then a
+non-`auto` measure `bind.read`). Mismatches raise `TypeError`. Safe coercions are applied where
+appropriate (for example `int` → `float`, `date` → `datetime`, and 0-d numpy numeric scalars via
+`.item()`). `None` and NaN remain subject to `empty_measure` rather than dtype rejection. Key
+fields still use soft `key_dtypes` coercion for leaf matching — they are not subject to the same
+strict isinstance checks as measures.
+
 **Key types must match resolved Python types.** Resolution coerces workbook and manifest values according to each bind’s `read` mode (and `concept_scheme` dtypes for constants and `series_context` entries). Generated setters index records by the same types — callers must not pass strings when resolution produced `datetime` or `bool` objects:
 
 | Binding | Resolved key type | Correct record value | Incorrect (will not match) |

--- a/user_guide/05-series-bindings.qmd
+++ b/user_guide/05-series-bindings.qmd
@@ -317,6 +317,10 @@ appropriate (for example `int` → `float`, `date` → `datetime`, and 0-d numpy
 fields still use soft `key_dtypes` coercion for leaf matching — they are not subject to the same
 strict isinstance checks as measures.
 
+Setter signatures also narrow from the measure dtype: scalar shorthand parameters are annotated
+`Records | Record | float` (for example), and series setters use `Sequence[float]` for positional
+measure iterables instead of a catch-all `Scalar` sequence when the dtype is known.
+
 **Key types must match resolved Python types.** Resolution coerces workbook and manifest values according to each bind’s `read` mode (and `concept_scheme` dtypes for constants and `series_context` entries). Generated setters index records by the same types — callers must not pass strings when resolution produced `datetime` or `bool` objects:
 
 | Binding | Resolved key type | Correct record value | Incorrect (will not match) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #384.

## Summary

Series bindings already declare measure `dtype`, but generated `set_*` functions treated it as documentation only. Callers could pass values like `"not-a-number"` for a float measure and have them written into `EvalContext`.

This adds runtime enforcement from binding dtype metadata:

- New `validate_binding_scalar` for isinstance-style checks with safe coercions (`int` → `float`, `date` → `datetime`)
- `coerce_setter_input(..., measure_dtype=...)` validates measure fields for scalar, series, and matrix layouts
- Codegen emits `measure_dtype` from `structure.measure.dtype` (falling back to non-`auto` `bind.read`)
- Scalar shorthand setters now go through `coerce_setter_input` so they get the same checks

Mismatches raise `TypeError` (e.g. `OBS_VALUE must be float, got str: 'not-a-number'`). Key fields continue to use existing soft `key_dtypes` coercion for leaf matching.

## Tests

- Unit coverage for `validate_binding_scalar`, measure dtype in `coerce_setter_input`, and generated setters (series + scalar)
- Existing series-bindings unit suite + library/inlined coerce parity tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e59276f-96e5-49fc-ba05-66ee52781271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e59276f-96e5-49fc-ba05-66ee52781271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

