### PR TITLE
feat(evaluator): lazy Grid maps for binary/unary operators (#336 Phase 2)

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -80,12 +80,16 @@ multi-cell args via `eager_materialize_arg_indices` / `grid_range_arg_indices`
 Lookup/reference algorithms (`INDEX`, `MATCH`, `VLOOKUP`, …) live in
 `excel_grapher.core.lookup_funcs` (sentinel returns). `runtime/lookup.py`
 exposes them to the evaluator; `export_runtime/lookup.py` raises at the wrapper
-boundary. Do not introduce a third traversal copy.
+boundary. Element-wise operators live in `excel_grapher.core.operator_maps`
+with the same adapter pattern (`core.operators` / `export_runtime.operators`).
+Do not introduce a third traversal copy.
 
 Behavioral parity (evaluator ↔ export ↔ Excel) is unchanged by representation
 convergence. Remaining eager numpy use in the evaluator hot path is confined to
-full-scan reductions / optional operator fast paths
-(`eager_materialize_arg_indices` plus `_resolve_binary_operand`).
+full-scan reductions via `eager_materialize_arg_indices` and optional operator
+fast paths (explicit materialization when a Grid binary op is large enough).
+Binary range operands bind lazy `Range` and share `core.operator_maps` with
+export `xl_map_*`.
 
 ## Layered semantics: core, runtime, and export_runtime
 

--- a/excel_grapher/core/grid/grid.py
+++ b/excel_grapher/core/grid/grid.py
@@ -13,6 +13,24 @@ __all__ = ["Grid", "Scalar"]
 Scalar: TypeAlias = float | int | str | bool | XlError | None
 
 
+def _as_nested_rows_from_ndarray(value: object) -> list[list[CellValue]] | None:
+    """Convert an ndarray-like value to nested lists without importing NumPy.
+
+    Duck-types via ``ndim`` / ``tolist`` so the grid module stays import-light
+    for standalone exports that must remain NumPy-free.
+    """
+    ndim = getattr(value, "ndim", None)
+    tolist = getattr(value, "tolist", None)
+    if not isinstance(ndim, int) or not callable(tolist):
+        return None
+    if ndim == 0:
+        return None
+    raw = tolist()
+    if ndim == 1:
+        return [[cast(CellValue, cell)] for cell in raw]
+    return cast("list[list[CellValue]]", raw)
+
+
 class Grid:
     """Positional raw-value access over a lazy `Range` or nested-list array."""
 
@@ -36,6 +54,11 @@ class Grid:
         if isinstance(value, Range):
             nrows, ncols = value.shape
             return Grid(nrows, ncols, value, None)
+        ndarray_rows = _as_nested_rows_from_ndarray(value)
+        if ndarray_rows is not None:
+            if not ndarray_rows:
+                ndarray_rows = [[None]]
+            return Grid(len(ndarray_rows), len(ndarray_rows[0]), None, ndarray_rows)
         if isinstance(value, (list, tuple)):
             rows = [
                 list(row) if isinstance(row, (list, tuple)) else [row]

--- a/excel_grapher/core/operator_maps.py
+++ b/excel_grapher/core/operator_maps.py
@@ -1,0 +1,170 @@
+"""Shared element-wise operator maps over lazy `Grid` values.
+
+Implementations return `XlError` sentinels. Evaluator operators call these
+directly; `export_runtime.operators` wrappers raise `XlErrorException`.
+"""
+
+from __future__ import annotations
+
+from excel_grapher.core.coercions import to_number
+from excel_grapher.core.grid import Grid, Scalar
+from excel_grapher.core.operators_reference import (
+    apply_arithmetic,
+    compare_scalars,
+    concat_scalars,
+)
+from excel_grapher.core.types import CellValue, XlError
+
+__all__ = [
+    "map_arithmetic",
+    "map_compare",
+    "map_concat",
+    "map_unary",
+]
+
+
+def _broadcast_grids(left: object, right: object) -> tuple[Grid, Grid] | None | XlError:
+    """Wrap array operands as aligned grids; `None` when both operands are scalar.
+
+    Named distinctly from ``operators._broadcast_pair`` so flattened export
+    embeddings do not collide on the private helper name.
+    """
+    left_grid = Grid.wrap(left)
+    right_grid = Grid.wrap(right)
+    if left_grid is None and right_grid is None:
+        return None
+    if left_grid is not None and right_grid is not None:
+        if (left_grid.nrows, left_grid.ncols) != (right_grid.nrows, right_grid.ncols):
+            return XlError.VALUE
+        return left_grid, right_grid
+    if left_grid is not None:
+        scalar_right = Grid.wrap([[right] * left_grid.ncols for _ in range(left_grid.nrows)])
+        assert scalar_right is not None
+        return left_grid, scalar_right
+    assert right_grid is not None
+    scalar_left = Grid.wrap([[left] * right_grid.ncols for _ in range(right_grid.nrows)])
+    assert scalar_left is not None
+    return scalar_left, right_grid
+
+
+def _apply_arithmetic_cell(op: str, left: Scalar, right: Scalar) -> CellValue:
+    if isinstance(left, XlError):
+        return left
+    if isinstance(right, XlError):
+        return right
+    ln = to_number(left)
+    rn = to_number(right)
+    if isinstance(ln, XlError):
+        return ln
+    if isinstance(rn, XlError):
+        return rn
+    return apply_arithmetic(op, ln, rn)
+
+
+def map_arithmetic(op: str, left: object, right: object) -> CellValue:
+    """Element-wise arithmetic over scalar or broadcast array operands."""
+    pair = _broadcast_grids(left, right)
+    if isinstance(pair, XlError):
+        return pair
+    if pair is None:
+        return _apply_arithmetic_cell(op, left, right)  # type: ignore[arg-type]
+
+    arr_left, arr_right = pair
+    result: list[list[CellValue]] = []
+    for row0 in range(arr_left.nrows):
+        out_row: list[CellValue] = []
+        for col0 in range(arr_left.ncols):
+            cell = _apply_arithmetic_cell(op, arr_left.at(row0, col0), arr_right.at(row0, col0))
+            if isinstance(cell, XlError):
+                return cell
+            out_row.append(cell)
+        result.append(out_row)
+    return result
+
+
+def map_compare(op: str, left: object, right: object) -> CellValue:
+    """Element-wise comparison over scalar or broadcast array operands."""
+    pair = _broadcast_grids(left, right)
+    if isinstance(pair, XlError):
+        return pair
+    if pair is None:
+        return compare_scalars(op, left, right)  # type: ignore[arg-type]
+
+    arr_left, arr_right = pair
+    result: list[list[CellValue]] = []
+    for row0 in range(arr_left.nrows):
+        out_row: list[CellValue] = []
+        for col0 in range(arr_left.ncols):
+            cell = compare_scalars(op, arr_left.at(row0, col0), arr_right.at(row0, col0))
+            if isinstance(cell, XlError):
+                return cell
+            out_row.append(cell)
+        result.append(out_row)
+    return result
+
+
+def map_concat(left: object, right: object) -> CellValue:
+    """Element-wise string concatenation over scalar or broadcast array operands."""
+    pair = _broadcast_grids(left, right)
+    if isinstance(pair, XlError):
+        return pair
+    if pair is None:
+        if isinstance(left, XlError):
+            return left
+        if isinstance(right, XlError):
+            return right
+        return concat_scalars(left, right)  # type: ignore[arg-type]
+
+    arr_left, arr_right = pair
+    result: list[list[CellValue]] = []
+    for row0 in range(arr_left.nrows):
+        out_row: list[CellValue] = []
+        for col0 in range(arr_left.ncols):
+            lv = arr_left.at(row0, col0)
+            rv = arr_right.at(row0, col0)
+            if isinstance(lv, XlError):
+                return lv
+            if isinstance(rv, XlError):
+                return rv
+            out_row.append(concat_scalars(lv, rv))
+        result.append(out_row)
+    return result
+
+
+def map_unary(op: str, value: object) -> CellValue:
+    """Apply a unary Excel operator over scalar or array operands."""
+    grid = Grid.wrap(value)
+    if grid is None:
+        if isinstance(value, XlError):
+            return value
+        number = to_number(value)  # type: ignore[arg-type]
+        if isinstance(number, XlError):
+            return number
+        if op == "-":
+            return -number
+        if op == "+":
+            return +number
+        if op == "%":
+            return number / 100.0
+        raise ValueError(f"Unknown unary operator: {op}")
+
+    result: list[list[CellValue]] = []
+    for row0 in range(grid.nrows):
+        out_row: list[CellValue] = []
+        for col0 in range(grid.ncols):
+            cell = grid.at(row0, col0)
+            if isinstance(cell, XlError):
+                return cell
+            number = to_number(cell)
+            if isinstance(number, XlError):
+                return number
+            if op == "-":
+                out_row.append(-number)
+            elif op == "+":
+                out_row.append(+number)
+            elif op == "%":
+                out_row.append(number / 100.0)
+            else:
+                raise ValueError(f"Unknown unary operator: {op}")
+        result.append(out_row)
+    return result

--- a/excel_grapher/core/operator_maps.py
+++ b/excel_grapher/core/operator_maps.py
@@ -2,9 +2,15 @@
 
 Implementations return `XlError` sentinels. Evaluator operators call these
 directly; `export_runtime.operators` wrappers raise `XlErrorException`.
+
+Evaluator and export value vocabularies differ slightly (export `CellValue`
+also includes nested lists); shared maps accept opaque objects and narrow at
+use sites — same pattern as `lookup_funcs`.
 """
 
 from __future__ import annotations
+
+from typing import cast
 
 from excel_grapher.core.coercions import to_number
 from excel_grapher.core.grid import Grid, Scalar
@@ -52,8 +58,8 @@ def _apply_arithmetic_cell(op: str, left: Scalar, right: Scalar) -> CellValue:
         return left
     if isinstance(right, XlError):
         return right
-    ln = to_number(left)
-    rn = to_number(right)
+    ln = to_number(cast(CellValue, left))
+    rn = to_number(cast(CellValue, right))
     if isinstance(ln, XlError):
         return ln
     if isinstance(rn, XlError):
@@ -61,13 +67,13 @@ def _apply_arithmetic_cell(op: str, left: Scalar, right: Scalar) -> CellValue:
     return apply_arithmetic(op, ln, rn)
 
 
-def map_arithmetic(op: str, left: object, right: object) -> CellValue:
+def map_arithmetic(op: str, left: object, right: object) -> object:
     """Element-wise arithmetic over scalar or broadcast array operands."""
     pair = _broadcast_grids(left, right)
     if isinstance(pair, XlError):
         return pair
     if pair is None:
-        return _apply_arithmetic_cell(op, left, right)  # type: ignore[arg-type]
+        return _apply_arithmetic_cell(op, cast(Scalar, left), cast(Scalar, right))
 
     arr_left, arr_right = pair
     result: list[list[CellValue]] = []
@@ -82,20 +88,24 @@ def map_arithmetic(op: str, left: object, right: object) -> CellValue:
     return result
 
 
-def map_compare(op: str, left: object, right: object) -> CellValue:
+def map_compare(op: str, left: object, right: object) -> object:
     """Element-wise comparison over scalar or broadcast array operands."""
     pair = _broadcast_grids(left, right)
     if isinstance(pair, XlError):
         return pair
     if pair is None:
-        return compare_scalars(op, left, right)  # type: ignore[arg-type]
+        return compare_scalars(op, cast(CellValue, left), cast(CellValue, right))
 
     arr_left, arr_right = pair
     result: list[list[CellValue]] = []
     for row0 in range(arr_left.nrows):
         out_row: list[CellValue] = []
         for col0 in range(arr_left.ncols):
-            cell = compare_scalars(op, arr_left.at(row0, col0), arr_right.at(row0, col0))
+            cell = compare_scalars(
+                op,
+                cast(CellValue, arr_left.at(row0, col0)),
+                cast(CellValue, arr_right.at(row0, col0)),
+            )
             if isinstance(cell, XlError):
                 return cell
             out_row.append(cell)
@@ -103,7 +113,7 @@ def map_compare(op: str, left: object, right: object) -> CellValue:
     return result
 
 
-def map_concat(left: object, right: object) -> CellValue:
+def map_concat(left: object, right: object) -> object:
     """Element-wise string concatenation over scalar or broadcast array operands."""
     pair = _broadcast_grids(left, right)
     if isinstance(pair, XlError):
@@ -113,7 +123,7 @@ def map_concat(left: object, right: object) -> CellValue:
             return left
         if isinstance(right, XlError):
             return right
-        return concat_scalars(left, right)  # type: ignore[arg-type]
+        return concat_scalars(cast(CellValue, left), cast(CellValue, right))
 
     arr_left, arr_right = pair
     result: list[list[CellValue]] = []
@@ -126,18 +136,18 @@ def map_concat(left: object, right: object) -> CellValue:
                 return lv
             if isinstance(rv, XlError):
                 return rv
-            out_row.append(concat_scalars(lv, rv))
+            out_row.append(concat_scalars(cast(CellValue, lv), cast(CellValue, rv)))
         result.append(out_row)
     return result
 
 
-def map_unary(op: str, value: object) -> CellValue:
+def map_unary(op: str, value: object) -> object:
     """Apply a unary Excel operator over scalar or array operands."""
     grid = Grid.wrap(value)
     if grid is None:
         if isinstance(value, XlError):
             return value
-        number = to_number(value)  # type: ignore[arg-type]
+        number = to_number(cast(CellValue, value))
         if isinstance(number, XlError):
             return number
         if op == "-":
@@ -155,7 +165,7 @@ def map_unary(op: str, value: object) -> CellValue:
             cell = grid.at(row0, col0)
             if isinstance(cell, XlError):
                 return cell
-            number = to_number(cell)
+            number = to_number(cast(CellValue, cell))
             if isinstance(number, XlError):
                 return number
             if op == "-":

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -6,8 +6,9 @@ arrays and failed guards use per-cell reference loops in ``operators_reference``
 Exponent (``^``) stays on a per-cell loop inside the fast path for parity.
 
 Lazy ``Range`` / nested-list operands use shared ``operator_maps`` (same loops as
-export ``xl_map_*``). Large grids may opt into the ndarray fast path after an
-explicit materialization at this boundary.
+export ``xl_map_*``). Large grids materialize once at this boundary and try
+``operators_fastpath``; on a miss the same arrays feed ``reference_*_array``
+rather than walking the ``Range`` a second time.
 """
 
 from __future__ import annotations
@@ -55,14 +56,20 @@ def _materialize_grid(grid: Grid) -> np.ndarray:
     )
 
 
-def _try_fastpath_from_grids(
+def _apply_large_grid_binary(
     op: str | None,
     left: object,
     right: object,
     *,
     kind: str,
 ) -> CellValue | None:
-    """Opt-in ndarray fast path when both sides fully materialize and size >= 64."""
+    """Materialize large grids once, then run fastpath or reference loops.
+
+    Returns `None` when operands are below ``MIN_OPERATOR_FASTPATH_CELLS`` (or
+    cannot form a grid pair) so the caller can use shared ``map_*`` loops.
+    When this path materializes, a fastpath miss reuses the same arrays via
+    ``reference_*_array`` — it does not fall through to a second Range walk.
+    """
     left_grid = Grid.wrap(left)
     right_grid = Grid.wrap(right)
     if left_grid is None and right_grid is None:
@@ -88,11 +95,20 @@ def _try_fastpath_from_grids(
 
     if kind == "compare":
         assert op is not None
-        return try_fastpath_compare_array(op, arr_left, arr_right)
+        fast = try_fastpath_compare_array(op, arr_left, arr_right)
+        if fast is not None:
+            return fast
+        return reference_compare_array(op, arr_left, arr_right)
     if kind == "concat":
-        return try_fastpath_concat_array(arr_left, arr_right)
+        fast = try_fastpath_concat_array(arr_left, arr_right)
+        if fast is not None:
+            return fast
+        return reference_concat_array(arr_left, arr_right)
     assert op is not None
-    return try_fastpath_arithmetic_array(op, arr_left, arr_right)
+    fast = try_fastpath_arithmetic_array(op, arr_left, arr_right)
+    if fast is not None:
+        return fast
+    return reference_arithmetic_array(op, arr_left, arr_right)
 
 
 def _compare_scalars(op: str, left: CellValue, right: CellValue) -> bool | XlError:
@@ -106,9 +122,9 @@ def _xl_compare(op: str, left: CellValue, right: CellValue) -> CellValue:
         return right
 
     if _is_range_or_list(left) or _is_range_or_list(right):
-        fast = _try_fastpath_from_grids(op, left, right, kind="compare")
-        if fast is not None:
-            return fast
+        large = _apply_large_grid_binary(op, left, right, kind="compare")
+        if large is not None:
+            return large
         return cast(CellValue, map_compare(op, left, right))
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
@@ -135,9 +151,9 @@ def _xl_arithmetic(
         return right
 
     if _is_range_or_list(left) or _is_range_or_list(right):
-        fast = _try_fastpath_from_grids(op, left, right, kind="arithmetic")
-        if fast is not None:
-            return fast
+        large = _apply_large_grid_binary(op, left, right, kind="arithmetic")
+        if large is not None:
+            return large
         return cast(CellValue, map_arithmetic(op, left, right))
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
@@ -170,9 +186,9 @@ def _xl_concat(left: CellValue, right: CellValue) -> CellValue:
         return right
 
     if _is_range_or_list(left) or _is_range_or_list(right):
-        fast = _try_fastpath_from_grids(None, left, right, kind="concat")
-        if fast is not None:
-            return fast
+        large = _apply_large_grid_binary(None, left, right, kind="concat")
+        if large is not None:
+            return large
         return cast(CellValue, map_concat(left, right))
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -4,6 +4,10 @@ Array operands try vectorized fast paths in ``operators_fastpath`` first when th
 broadcast array has at least ``MIN_OPERATOR_FASTPATH_CELLS`` (64) elements; smaller
 arrays and failed guards use per-cell reference loops in ``operators_reference``.
 Exponent (``^``) stays on a per-cell loop inside the fast path for parity.
+
+Lazy ``Range`` / nested-list operands use shared ``operator_maps`` (same loops as
+export ``xl_map_*``). Large grids may opt into the ndarray fast path after an
+explicit materialization at this boundary.
 """
 
 from __future__ import annotations
@@ -11,7 +15,10 @@ from __future__ import annotations
 import numpy as np
 
 from .coercions import to_number
+from .grid import Grid, Range
+from .operator_maps import map_arithmetic, map_compare, map_concat, map_unary
 from .operators_fastpath import (
+    MIN_OPERATOR_FASTPATH_CELLS,
     try_fastpath_arithmetic_array,
     try_fastpath_compare_array,
     try_fastpath_concat_array,
@@ -35,6 +42,57 @@ def _broadcast_pair(
     return broadcast_pair(left, right)
 
 
+def _is_range_or_list(value: object) -> bool:
+    return isinstance(value, (Range, list, tuple))
+
+
+def _materialize_grid(grid: Grid) -> np.ndarray:
+    return np.array(
+        [[grid.at(row0, col0) for col0 in range(grid.ncols)] for row0 in range(grid.nrows)],
+        dtype=object,
+    )
+
+
+def _try_fastpath_from_grids(
+    op: str | None,
+    left: object,
+    right: object,
+    *,
+    kind: str,
+) -> CellValue | None:
+    """Opt-in ndarray fast path when both sides fully materialize and size >= 64."""
+    left_grid = Grid.wrap(left)
+    right_grid = Grid.wrap(right)
+    if left_grid is None and right_grid is None:
+        return None
+    if left_grid is not None and right_grid is not None:
+        if (left_grid.nrows, left_grid.ncols) != (right_grid.nrows, right_grid.ncols):
+            return None
+        if left_grid.size < MIN_OPERATOR_FASTPATH_CELLS:
+            return None
+        arr_left = _materialize_grid(left_grid)
+        arr_right = _materialize_grid(right_grid)
+    elif left_grid is not None:
+        if left_grid.size < MIN_OPERATOR_FASTPATH_CELLS:
+            return None
+        arr_left = _materialize_grid(left_grid)
+        arr_right = np.full(arr_left.shape, right, dtype=object)
+    else:
+        assert right_grid is not None
+        if right_grid.size < MIN_OPERATOR_FASTPATH_CELLS:
+            return None
+        arr_right = _materialize_grid(right_grid)
+        arr_left = np.full(arr_right.shape, left, dtype=object)
+
+    if kind == "compare":
+        assert op is not None
+        return try_fastpath_compare_array(op, arr_left, arr_right)
+    if kind == "concat":
+        return try_fastpath_concat_array(arr_left, arr_right)
+    assert op is not None
+    return try_fastpath_arithmetic_array(op, arr_left, arr_right)
+
+
 def _compare_scalars(op: str, left: CellValue, right: CellValue) -> bool | XlError:
     return compare_scalars(op, left, right)
 
@@ -44,6 +102,12 @@ def _xl_compare(op: str, left: CellValue, right: CellValue) -> CellValue:
         return left
     if isinstance(right, XlError):
         return right
+
+    if _is_range_or_list(left) or _is_range_or_list(right):
+        fast = _try_fastpath_from_grids(op, left, right, kind="compare")
+        if fast is not None:
+            return fast
+        return map_compare(op, left, right)
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
         pair = _broadcast_pair(left, right)
@@ -67,6 +131,12 @@ def _xl_arithmetic(
         return left
     if isinstance(right, XlError):
         return right
+
+    if _is_range_or_list(left) or _is_range_or_list(right):
+        fast = _try_fastpath_from_grids(op, left, right, kind="arithmetic")
+        if fast is not None:
+            return fast
+        return map_arithmetic(op, left, right)
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
         pair = _broadcast_pair(left, right)
@@ -96,6 +166,12 @@ def _xl_concat(left: CellValue, right: CellValue) -> CellValue:
         return left
     if isinstance(right, XlError):
         return right
+
+    if _is_range_or_list(left) or _is_range_or_list(right):
+        fast = _try_fastpath_from_grids(None, left, right, kind="concat")
+        if fast is not None:
+            return fast
+        return map_concat(left, right)
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
         pair = _broadcast_pair(left, right)
@@ -164,29 +240,14 @@ def xl_pow(left: CellValue, right: CellValue) -> CellValue:
     return _xl_arithmetic("^", left, right)
 
 
-def xl_neg(value: CellValue) -> float | XlError:
-    if isinstance(value, XlError):
-        return value
-    n = to_number(value)
-    if isinstance(n, XlError):
-        return n
-    return -n
+def xl_neg(value: CellValue) -> CellValue:
+    return map_unary("-", value)
 
 
-def xl_pos(value: CellValue) -> float | XlError:
-    if isinstance(value, XlError):
-        return value
-    n = to_number(value)
-    if isinstance(n, XlError):
-        return n
-    return +n
+def xl_pos(value: CellValue) -> CellValue:
+    return map_unary("+", value)
 
 
-def xl_percent(value: CellValue) -> float | XlError:
+def xl_percent(value: CellValue) -> CellValue:
     """Excel postfix percent operator (%): divide a numeric value by 100."""
-    if isinstance(value, XlError):
-        return value
-    n = to_number(value)
-    if isinstance(n, XlError):
-        return n
-    return n / 100.0
+    return map_unary("%", value)

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -12,6 +12,8 @@ explicit materialization at this boundary.
 
 from __future__ import annotations
 
+from typing import cast
+
 import numpy as np
 
 from .coercions import to_number
@@ -107,7 +109,7 @@ def _xl_compare(op: str, left: CellValue, right: CellValue) -> CellValue:
         fast = _try_fastpath_from_grids(op, left, right, kind="compare")
         if fast is not None:
             return fast
-        return map_compare(op, left, right)
+        return cast(CellValue, map_compare(op, left, right))
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
         pair = _broadcast_pair(left, right)
@@ -136,7 +138,7 @@ def _xl_arithmetic(
         fast = _try_fastpath_from_grids(op, left, right, kind="arithmetic")
         if fast is not None:
             return fast
-        return map_arithmetic(op, left, right)
+        return cast(CellValue, map_arithmetic(op, left, right))
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
         pair = _broadcast_pair(left, right)
@@ -171,7 +173,7 @@ def _xl_concat(left: CellValue, right: CellValue) -> CellValue:
         fast = _try_fastpath_from_grids(None, left, right, kind="concat")
         if fast is not None:
             return fast
-        return map_concat(left, right)
+        return cast(CellValue, map_concat(left, right))
 
     if isinstance(left, np.ndarray) or isinstance(right, np.ndarray):
         pair = _broadcast_pair(left, right)
@@ -241,13 +243,13 @@ def xl_pow(left: CellValue, right: CellValue) -> CellValue:
 
 
 def xl_neg(value: CellValue) -> CellValue:
-    return map_unary("-", value)
+    return cast(CellValue, map_unary("-", value))
 
 
 def xl_pos(value: CellValue) -> CellValue:
-    return map_unary("+", value)
+    return cast(CellValue, map_unary("+", value))
 
 
 def xl_percent(value: CellValue) -> CellValue:
     """Excel postfix percent operator (%): divide a numeric value by 100."""
-    return map_unary("%", value)
+    return cast(CellValue, map_unary("%", value))

--- a/excel_grapher/core/sumproduct.py
+++ b/excel_grapher/core/sumproduct.py
@@ -4,20 +4,28 @@ from __future__ import annotations
 
 import numpy as np
 
+from .grid import Grid
 from .operators_fastpath import try_fastpath_sumproduct
 from .operators_reference import reference_sumproduct_arrays
 from .types import CellValue, XlError
 
 
+def _as_object_array(arg: CellValue) -> np.ndarray:
+    if isinstance(arg, np.ndarray):
+        return arg
+    grid = Grid.wrap(arg)
+    if grid is not None:
+        return np.array(
+            [[grid.at(row0, col0) for col0 in range(grid.ncols)] for row0 in range(grid.nrows)],
+            dtype=object,
+        )
+    return np.array([[arg]], dtype=object)
+
+
 def xl_sumproduct(*args: CellValue) -> float | XlError:
     if len(args) == 0:
         return 0.0
-    arrays: list[np.ndarray] = []
-    for arg in args:
-        if isinstance(arg, np.ndarray):
-            arrays.append(arg)
-        else:
-            arrays.append(np.array([[arg]], dtype=object))
+    arrays: list[np.ndarray] = [_as_object_array(arg) for arg in args]
     shape = arrays[0].shape
     for arr in arrays[1:]:
         if arr.shape != shape:

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -56,6 +56,7 @@ from .helpers import (
     xl_lt,
     xl_mul,
     xl_ne,
+    xl_neg,
     xl_offset_ref,
     xl_percent,
     xl_pow,
@@ -481,9 +482,9 @@ class FormulaEvaluator:
         return value
 
     def _resolve_binary_operand(self, value: CellValue) -> CellValue:
-        """Resolve range references to arrays for element-wise binary operators."""
+        """Bind range geometry to a lazy `Range` for element-wise operators."""
         if isinstance(value, ExcelRange):
-            return self._resolve_range(value)
+            return cast(CellValue, self._as_lazy_range(value))
         return value
 
     def _eval_binary_op(self, node: BinaryOpNode) -> CellValue:
@@ -529,15 +530,12 @@ class FormulaEvaluator:
         raise ValueError(f"Unknown binary operator: {op}")
 
     def _eval_unary_op(self, node: UnaryOpNode) -> CellValue:
-        operand = self._evaluate_ast(node.operand)
+        operand = self._resolve_binary_operand(self._evaluate_ast(node.operand))
         if isinstance(operand, XlError):
             return operand
 
         if node.op == "-":
-            n = to_number(operand)
-            if isinstance(n, XlError):
-                return n
-            return -n
+            return xl_neg(operand)
 
         if node.op == "%":
             return xl_percent(operand)

--- a/excel_grapher/exporter/embed.py
+++ b/excel_grapher/exporter/embed.py
@@ -30,6 +30,7 @@ def _core_modules(*, include_operators_fastpath: bool) -> list[tuple[str, Path]]
         ("core.coercions", _CORE_DIR / "coercions.py"),
         ("core.operators_reference", _CORE_DIR / "operators_reference.py"),
         ("core.operators_fastpath", fastpath_path),
+        ("core.operator_maps", _CORE_DIR / "operator_maps.py"),
         ("core.operators", _CORE_DIR / "operators.py"),
         ("core.sumproduct", _CORE_DIR / "sumproduct.py"),
         ("core.addressing", _CORE_DIR / "addressing.py"),

--- a/excel_grapher/exporter/export_runtime/operators.py
+++ b/excel_grapher/exporter/export_runtime/operators.py
@@ -2,20 +2,25 @@
 
 Scalar formulas emit native Python operators in generated code; these helpers
 cover coercion, Excel-specific error semantics, and lazy-range array broadcast.
+
+Element-wise maps delegate to shared `excel_grapher.core.operator_maps` (sentinel
+returns) and raise `XlErrorException` at this boundary.
 """
 
 from __future__ import annotations
 
 from excel_grapher.core import XlError, to_bool, to_int, to_number
-from excel_grapher.core.operators_reference import (
-    apply_arithmetic,
-    compare_scalars,
-    concat_scalars,
+from excel_grapher.core.operator_maps import (
+    map_arithmetic,
+    map_compare,
+    map_concat,
+    map_unary,
 )
+from excel_grapher.core.operators_reference import compare_scalars
 from excel_grapher.core.types import XlErrorException
 
 from .ranges import Range
-from .values import CellValue, ExcelRange, Grid, Scalar, as_scalar
+from .values import CellValue, ExcelRange, as_scalar
 
 __all__ = [
     "xl_compare",
@@ -34,6 +39,12 @@ __all__ = [
 def _raise_error(code: XlError) -> XlErrorException:
     """Build the exception for an Excel error code (callers raise the result)."""
     return XlErrorException(code)
+
+
+def _raise_if_error(value: object) -> CellValue:
+    if isinstance(value, XlError):
+        raise _raise_error(value)
+    return value  # type: ignore[return-value]
 
 
 def xl_number(value: CellValue) -> float:
@@ -93,137 +104,21 @@ def xl_compare(op: str, left: CellValue, right: CellValue) -> bool:
     return result
 
 
-def _scalar_or_raise(value: CellValue) -> Scalar:
-    """Collapse to a scalar, raising when the value is an Excel error."""
-    scalar = as_scalar(value)
-    if isinstance(scalar, XlError):
-        raise _raise_error(scalar)
-    return scalar
-
-
-def _cell_or_raise(grid: Grid, row0: int, col0: int) -> Scalar:
-    """Read one grid cell, raising when the stored value is an error sentinel."""
-    value = grid.at(row0, col0)
-    if isinstance(value, XlError):
-        raise _raise_error(value)
-    return value
-
-
-def _broadcast_pair(left: CellValue, right: CellValue) -> tuple[Grid, Grid] | None:
-    """Wrap array operands as aligned grids; `None` when both operands are scalar."""
-    left_grid = Grid.wrap(left)
-    right_grid = Grid.wrap(right)
-    if left_grid is None and right_grid is None:
-        return None
-    if left_grid is not None and right_grid is not None:
-        if (left_grid.nrows, left_grid.ncols) != (right_grid.nrows, right_grid.ncols):
-            raise _raise_error(XlError.VALUE)
-        return left_grid, right_grid
-    if left_grid is not None:
-        scalar_right = Grid.wrap([[right] * left_grid.ncols for _ in range(left_grid.nrows)])
-        assert scalar_right is not None
-        return left_grid, scalar_right
-    assert right_grid is not None
-    scalar_left = Grid.wrap([[left] * right_grid.ncols for _ in range(right_grid.nrows)])
-    assert scalar_left is not None
-    return scalar_left, right_grid
-
-
-def _apply_arithmetic_or_raise(op: str, left: CellValue, right: CellValue) -> CellValue:
-    ln = xl_number(left)
-    rn = xl_number(right)
-    if op == "^":
-        return xl_pow_numbers(ln, rn)
-    cell = apply_arithmetic(op, ln, rn)
-    if isinstance(cell, XlError):
-        raise _raise_error(cell)
-    return cell
-
-
 def xl_map_arithmetic(op: str, left: CellValue, right: CellValue) -> CellValue:
     """Element-wise arithmetic over scalar or broadcast array operands."""
-    pair = _broadcast_pair(left, right)
-    if pair is None:
-        return _apply_arithmetic_or_raise(op, left, right)
-
-    arr_left, arr_right = pair
-    result: list[list[CellValue]] = []
-    for row0 in range(arr_left.nrows):
-        out_row: list[CellValue] = []
-        for col0 in range(arr_left.ncols):
-            out_row.append(
-                _apply_arithmetic_or_raise(
-                    op, _cell_or_raise(arr_left, row0, col0), _cell_or_raise(arr_right, row0, col0)
-                )
-            )
-        result.append(out_row)
-    return result
+    return _raise_if_error(map_arithmetic(op, left, right))
 
 
 def xl_map_compare(op: str, left: CellValue, right: CellValue) -> CellValue:
     """Element-wise comparison over scalar or broadcast array operands."""
-    pair = _broadcast_pair(left, right)
-    if pair is None:
-        return xl_compare(op, left, right)
-
-    arr_left, arr_right = pair
-    result: list[list[CellValue]] = []
-    for row0 in range(arr_left.nrows):
-        out_row: list[CellValue] = []
-        for col0 in range(arr_left.ncols):
-            cell = compare_scalars(
-                op, _cell_or_raise(arr_left, row0, col0), _cell_or_raise(arr_right, row0, col0)
-            )
-            if isinstance(cell, XlError):
-                raise _raise_error(cell)
-            out_row.append(cell)
-        result.append(out_row)
-    return result
+    return _raise_if_error(map_compare(op, left, right))
 
 
 def xl_map_concat(left: CellValue, right: CellValue) -> CellValue:
     """Element-wise string concatenation over scalar or broadcast array operands."""
-    pair = _broadcast_pair(left, right)
-    if pair is None:
-        return concat_scalars(_scalar_or_raise(left), _scalar_or_raise(right))
-
-    arr_left, arr_right = pair
-    return [
-        [
-            concat_scalars(
-                _cell_or_raise(arr_left, row0, col0), _cell_or_raise(arr_right, row0, col0)
-            )
-            for col0 in range(arr_left.ncols)
-        ]
-        for row0 in range(arr_left.nrows)
-    ]
+    return _raise_if_error(map_concat(left, right))
 
 
 def xl_map_unary(op: str, value: CellValue) -> CellValue:
     """Apply a unary Excel operator over scalar or array operands."""
-    grid = Grid.wrap(value)
-    if grid is None:
-        number = xl_number(value)
-        if op == "-":
-            return -number
-        if op == "+":
-            return +number
-        if op == "%":
-            return number / 100.0
-        raise ValueError(f"Unknown unary operator: {op}")
-
-    result: list[list[CellValue]] = []
-    for row0 in range(grid.nrows):
-        out_row: list[CellValue] = []
-        for col0 in range(grid.ncols):
-            number = xl_number(_cell_or_raise(grid, row0, col0))
-            if op == "-":
-                out_row.append(-number)
-            elif op == "+":
-                out_row.append(+number)
-            elif op == "%":
-                out_row.append(number / 100.0)
-            else:
-                raise ValueError(f"Unknown unary operator: {op}")
-        result.append(out_row)
-    return result
+    return _raise_if_error(map_unary(op, value))

--- a/excel_grapher/exporter/export_runtime/operators.py
+++ b/excel_grapher/exporter/export_runtime/operators.py
@@ -9,6 +9,8 @@ returns) and raise `XlErrorException` at this boundary.
 
 from __future__ import annotations
 
+from typing import cast
+
 from excel_grapher.core import XlError, to_bool, to_int, to_number
 from excel_grapher.core.operator_maps import (
     map_arithmetic,
@@ -44,7 +46,7 @@ def _raise_error(code: XlError) -> XlErrorException:
 def _raise_if_error(value: object) -> CellValue:
     if isinstance(value, XlError):
         raise _raise_error(value)
-    return value  # type: ignore[return-value]
+    return cast(CellValue, value)
 
 
 def xl_number(value: CellValue) -> float:

--- a/tests/integration/evaluator/test_lazy_range_evaluator.py
+++ b/tests/integration/evaluator/test_lazy_range_evaluator.py
@@ -329,3 +329,27 @@ def test_criteria_product_sum_parity_via_binary_ops() -> None:
     )
     with FormulaEvaluator(graph) as ev:
         assert ev.evaluate(["S!C1"]) == {"S!C1": 40.0}
+
+
+def test_binary_op_fail_fast_does_not_evaluate_trailing_formula_cells() -> None:
+    """Array multiply stops at the first cell error; trailing formulas stay cold."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", "=1/0", None),
+        _make_node("S!A3", "=S!A1+99", None),
+        _make_node("S!B1", None, 2),
+        _make_node("S!B2", None, 3),
+        _make_node("S!B3", "=S!B1+99", None),
+        _make_node("S!C1", "=S!A1:S!A3*S!B1:S!B3", None),
+    )
+    seen: list[str] = []
+
+    def _track(address: str, _value: object) -> None:
+        seen.append(address)
+
+    with FormulaEvaluator(graph, on_cell_evaluated=_track) as ev:
+        assert ev.evaluate(["S!C1"]) == {"S!C1": XlError.DIV}
+        assert "S!A3" not in ev._cache
+        assert "S!B3" not in ev._cache
+    assert "S!A3" not in seen
+    assert "S!B3" not in seen

--- a/tests/integration/evaluator/test_lazy_range_evaluator.py
+++ b/tests/integration/evaluator/test_lazy_range_evaluator.py
@@ -6,6 +6,8 @@ unused sibling cells are never evaluated (via `on_cell_evaluated` / `_cache`).
 
 from __future__ import annotations
 
+import pytest
+
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core.address_keys import parse_address
 from excel_grapher.evaluator import FormulaEvaluator
@@ -272,3 +274,58 @@ def test_vlookup_over_offset_stops_before_trailing_unused_cells() -> None:
         assert "S!B3" not in ev._cache
     assert "S!A3" not in seen
     assert "S!B3" not in seen
+
+
+def test_binary_op_over_ranges_does_not_eager_resolve_excel_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Binary range ops bind lazy Range; resolve_excel_range is never called."""
+    from excel_grapher.core import types as core_types
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("resolve_excel_range must not run for binary operands")
+
+    monkeypatch.setattr(core_types, "resolve_excel_range", _boom)
+    monkeypatch.setattr(
+        "excel_grapher.evaluator.evaluator.resolve_excel_range",
+        _boom,
+    )
+
+    graph = _make_graph(
+        _make_node("S!A1", None, "x"),
+        _make_node("S!A2", None, "y"),
+        _make_node("S!A3", None, "x"),
+        _make_node("S!B1", None, 10),
+        _make_node("S!B2", None, 20),
+        _make_node("S!B3", None, 30),
+        _make_node("S!C1", '=SUMPRODUCT((S!A1:S!A3="x")*S!B1:S!B3)', None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!C1"]) == {"S!C1": 40.0}
+
+
+def test_array_unary_negation_over_range() -> None:
+    """Unary minus over a multi-cell range maps element-wise (export parity)."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", None, 2),
+        _make_node("S!A3", None, 3),
+        _make_node("S!B1", "=SUM(-(S!A1:S!A3))", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": -6.0}
+
+
+def test_criteria_product_sum_parity_via_binary_ops() -> None:
+    """Criteria comparison * values reduces correctly via lazy Grid maps."""
+    graph = _make_graph(
+        _make_node("S!A1", None, "x"),
+        _make_node("S!A2", None, "y"),
+        _make_node("S!A3", None, "x"),
+        _make_node("S!B1", None, 10),
+        _make_node("S!B2", None, 20),
+        _make_node("S!B3", None, 30),
+        _make_node("S!C1", '=SUM((S!A1:S!A3="x")*S!B1:S!B3)', None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!C1"]) == {"S!C1": 40.0}

--- a/tests/unit/core/test_operator_maps.py
+++ b/tests/unit/core/test_operator_maps.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import pytest
+
 from excel_grapher.core import CellValue, XlError
 from excel_grapher.core.grid import Range
 from excel_grapher.core.operator_maps import (
@@ -69,3 +71,33 @@ def test_map_unary_over_lazy_range() -> None:
     rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 4, "S!A2": -6}[a])
     assert map_unary("-", rng) == [[-4], [6]]
     assert map_unary("%", [[50], [25]]) == [[0.5], [0.25]]
+
+
+def test_large_range_fastpath_miss_materializes_cells_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the vectorized fast path declines, reuse the materialized arrays."""
+    from excel_grapher.core import operators as operators_mod
+    from excel_grapher.core.operators_fastpath import MIN_OPERATOR_FASTPATH_CELLS
+
+    nrows = MIN_OPERATOR_FASTPATH_CELLS
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        row = int(address.split("!")[1][1:])
+        return float(row)
+
+    monkeypatch.setattr(
+        operators_mod,
+        "try_fastpath_arithmetic_array",
+        lambda *_args, **_kwargs: None,
+    )
+
+    rng = Range("S", 1, 1, nrows, 1, resolve)
+    result = xl_mul(cast(CellValue, rng), 2.0)
+    expected = [[float(i) * 2.0] for i in range(1, nrows + 1)]
+    actual = cast(Any, result).tolist() if hasattr(result, "tolist") else result
+    assert actual == expected
+    assert len(calls) == nrows
+    assert calls == [f"S!A{i}" for i in range(1, nrows + 1)]

--- a/tests/unit/core/test_operator_maps.py
+++ b/tests/unit/core/test_operator_maps.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from excel_grapher.core import CellValue, XlError
 from excel_grapher.core.grid import Range
 from excel_grapher.core.operator_maps import (
@@ -40,7 +42,8 @@ def test_map_arithmetic_agrees_with_ndarray_xl_mul_when_fully_consumed() -> None
         np.array([[1.5], [2.5]], dtype=object),
         np.array([[3.0], [4.0]], dtype=object),
     )
-    assert mapped == arr.tolist()
+    assert isinstance(arr, np.ndarray)
+    assert mapped == cast(Any, arr).tolist()
 
 
 def test_map_arithmetic_shape_mismatch_returns_value_error() -> None:

--- a/tests/unit/core/test_operator_maps.py
+++ b/tests/unit/core/test_operator_maps.py
@@ -1,0 +1,68 @@
+"""Unit tests for shared Grid operator maps (#336 Phase 2)."""
+
+from __future__ import annotations
+
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.grid import Range
+from excel_grapher.core.operator_maps import (
+    map_arithmetic,
+    map_compare,
+    map_concat,
+    map_unary,
+)
+from excel_grapher.core.operators import xl_mul
+
+
+def test_map_arithmetic_over_lazy_range_visits_each_cell_once() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": 1, "S!A2": 2, "S!A3": 3}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert map_arithmetic("*", rng, 2) == [[2], [4], [6]]
+    assert calls == ["S!A1", "S!A2", "S!A3"]
+
+
+def test_map_arithmetic_agrees_with_ndarray_xl_mul_when_fully_consumed() -> None:
+    values = {"S!A1": 1.5, "S!A2": 2.5, "S!B1": 3.0, "S!B2": 4.0}
+
+    def resolve(address: str) -> CellValue:
+        return values[address]
+
+    left = Range("S", 1, 1, 2, 1, resolve)
+    right = Range("S", 1, 2, 2, 2, resolve)
+    mapped = map_arithmetic("*", left, right)
+    import numpy as np
+
+    arr = xl_mul(
+        np.array([[1.5], [2.5]], dtype=object),
+        np.array([[3.0], [4.0]], dtype=object),
+    )
+    assert mapped == arr.tolist()
+
+
+def test_map_arithmetic_shape_mismatch_returns_value_error() -> None:
+    left = Range("S", 1, 1, 2, 1, lambda _a: 1)
+    right = Range("S", 1, 1, 3, 1, lambda _a: 1)
+    assert map_arithmetic("+", left, right) == XlError.VALUE
+
+
+def test_map_arithmetic_fail_fast_on_embedded_cell_error() -> None:
+    def resolve(address: str) -> CellValue:
+        return {"S!A1": 1, "S!A2": XlError.DIV, "S!A3": 3}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert map_arithmetic("*", rng, 2) == XlError.DIV
+
+
+def test_map_compare_and_concat_over_nested_lists() -> None:
+    assert map_compare("=", [["a"], ["b"]], "b") == [[False], [True]]
+    assert map_concat([["x"], ["y"]], "!") == [["x!"], ["y!"]]
+
+
+def test_map_unary_over_lazy_range() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 4, "S!A2": -6}[a])
+    assert map_unary("-", rng) == [[-4], [6]]
+    assert map_unary("%", [[50], [25]]) == [[0.5], [0.25]]

--- a/tests/unit/core/test_operators_arithmetic_fastpath.py
+++ b/tests/unit/core/test_operators_arithmetic_fastpath.py
@@ -129,7 +129,8 @@ def test_large_in_memory_range_mul_matches_reference() -> None:
     left = np.array([[float(i % 7 + 1)] for i in range(1, 501)], dtype=object)
     right = np.array([[3.0] for _ in range(500)], dtype=object)
     expected = reference_arithmetic_array("*", left, right)
-    actual = result.tolist() if isinstance(result, np.ndarray) else result
+    assert isinstance(expected, np.ndarray)
+    actual = cast(Any, result).tolist() if isinstance(result, np.ndarray) else result
     assert actual == cast(Any, expected).tolist()
 
 

--- a/tests/unit/core/test_operators_arithmetic_fastpath.py
+++ b/tests/unit/core/test_operators_arithmetic_fastpath.py
@@ -129,8 +129,8 @@ def test_large_in_memory_range_mul_matches_reference() -> None:
     left = np.array([[float(i % 7 + 1)] for i in range(1, 501)], dtype=object)
     right = np.array([[3.0] for _ in range(500)], dtype=object)
     expected = reference_arithmetic_array("*", left, right)
-    assert isinstance(result, np.ndarray)
-    assert cast(Any, result).tolist() == cast(Any, expected).tolist()
+    actual = result.tolist() if isinstance(result, np.ndarray) else result
+    assert actual == cast(Any, expected).tolist()
 
 
 def test_large_numeric_sumproduct_eval_codegen_parity(tmp_path: Path) -> None:

--- a/tests/unit/gaps/test_sumproduct_criteria_gaps.py
+++ b/tests/unit/gaps/test_sumproduct_criteria_gaps.py
@@ -7,7 +7,7 @@ Regression coverage for element-wise range comparisons and products inside
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -84,7 +84,7 @@ def test_sumproduct_price_threshold_count_k24(tmp_path: Path) -> None:
 
 
 def test_standalone_range_comparison_returns_elementwise_array() -> None:
-    """Multi-cell range compares at formula top level return ndarrays (not a single scalar)."""
+    """Multi-cell range compares at formula top level return element-wise arrays."""
     graph = DependencyGraph()
     for row, category in enumerate(["Software", "Hardware", "Software"], start=5):
         graph.add_node(_make_node(f"PL!C{row}", None, category))
@@ -93,8 +93,8 @@ def test_standalone_range_comparison_returns_elementwise_array() -> None:
     )
     with FormulaEvaluator(graph) as evaluator:
         result = evaluator.evaluate("PL!D10")
-    assert isinstance(result, np.ndarray)
-    assert cast(np.ndarray, result).tolist() == [[True], [False], [True]]
+    actual = cast(Any, result).tolist() if isinstance(result, np.ndarray) else result
+    assert actual == [[True], [False], [True]]
 
 
 def test_sumproduct_criteria_evaluator_matches_excel_cached_values(tmp_path: Path) -> None:

--- a/user_guide/03-evaluator.qmd
+++ b/user_guide/03-evaluator.qmd
@@ -24,6 +24,9 @@ Multi-cell range arguments are classified at resolve time:
 
 - Lookup consumers (`MATCH` / `VLOOKUP` / …) bind lazy `Range` from
   `excel_grapher.core.grid` and evaluate only the cells they touch.
+- Binary / unary operators bind the same lazy `Range` and map via shared
+  `core.operator_maps` (aligned with export `xl_map_*`). Large ops may opt into
+  the ndarray fast path after an explicit materialization.
 - Full-scan reductions (`SUM` / `SUMPRODUCT` / …) still materialize where
   `flatten` / vectorized fast paths need a dense buffer.
 - Other functions reject multi-cell ranges with `#VALUE!` (no object-repr leaks;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 2** of #336: route `FormulaEvaluator` binary/unary range operands through shared Grid operator maps (aligned with export `xl_map_*`), keeping NumPy fast paths as an optional accelerator.

- Add `excel_grapher.core.operator_maps` (`map_arithmetic` / `map_compare` / `map_concat` / `map_unary`) with sentinel returns
- Thin `export_runtime.operators` wrappers raise `XlErrorException` (same adapter pattern as lookups)
- `_resolve_binary_operand` binds `ExcelRange` → lazy `Range` instead of eager `resolve_excel_range`
- Unary `-` / `%` map over multi-cell ranges for evaluator ↔ export parity
- Large Range/list ops may materialize and hit `operators_fastpath` when size ≥ 64
- `xl_sumproduct` accepts nested-list / Grid intermediate products from binary maps
- Embed `core.operator_maps`; rename private broadcast helper to avoid flattened-namespace collisions
- Update `parity.mdc` and `user_guide/03-evaluator.qmd`

## Out of scope (later #336 phases)

- Aggregates / `SUM` native lazy `Range` (Phase 3) — still use `eager_materialize_arg_indices`
- Dropping `np.ndarray` from `CellValue` / meta rename (Phase 4)

## Test plan

- [x] `uv run pytest tests/unit/core/test_operator_maps.py`
- [x] `uv run pytest tests/integration/evaluator/test_lazy_range_evaluator.py`
- [x] `uv run pytest tests/unit/core/test_operators_arithmetic_fastpath.py`
- [x] `uv run pytest tests/integration/exporter/test_inline_operators.py tests/integration/exporter/test_lazy_range_migration.py`
- [ ] Broader CI suite / type-check after push

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb5a88aa-22df-4b8e-9dd0-a648dee5b285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb5a88aa-22df-4b8e-9dd0-a648dee5b285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

