### PR TITLE
feat(evaluator): lazy Grid aggregates for SUM/SUMPRODUCT (#336 Phase 3)

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -28,17 +28,18 @@ The evaluator and the exported runtime use **different error channels** with the
   The evaluator never raises `XlErrorException`. Multi-cell range operands are
   bound by argument policy in `FormulaEvaluator._resolve_function_arg`:
 
-  - `eager_materialize_arg_indices` — full-scan reductions (`SUM`,
-    `SUMPRODUCT`, …) materialize to numpy object arrays (bridge until Phase 3)
-  - `grid_range_arg_indices` — lookup consumers bind lazy `Range` from
-    `excel_grapher.core.grid` (selective access)
+  - `grid_range_arg_indices` — lookups and full-scan reductions (`SUM`,
+    `SUMPRODUCT`, `COUNTIF`, …) bind lazy `Range` from
+    `excel_grapher.core.grid`; consumers walk cells via `flatten` / `Grid`
+  - `eager_materialize_arg_indices` — empty after Phase 3 (retained until
+    Phase 4 cleanup)
   - otherwise — `#VALUE!` without evaluating sibling cells (no Range leak into
     scalar contexts)
 
   Scalar coercions (`as_scalar` / `to_number` / `to_string` / `to_bool`) also
-  reject multi-cell `Range` with `#VALUE!`. AST `get_error` stays shallow for
-  `Range` (does not walk cells) so selective consumers are not forced
-  full-scan.
+  reject multi-cell `Range` with `#VALUE!`. AST `get_error` walks `Range`
+  cells for generic functions (first-error fail-fast); lookup/reference
+  functions skip that precheck so selective Grid access stays consumer-driven.
 - **Export = Pythonic model.** Where Excel displays error code `E`, exported
   code **raises `XlErrorException(E)`** (a traceback, not a silently propagated
   sentinel). Ranges are the same lazy `Range` values; unused cells are never
@@ -69,12 +70,12 @@ Export error-channel specifics:
 `excel_grapher.core.grid` (`Range`, `Grid`) is the shared rectangular value
 model, and `excel_grapher.core.types.ExcelRange` is the single shared geometry
 type (evaluator and export). `FormulaEvaluator._resolve_function_arg` classifies
-multi-cell args via `eager_materialize_arg_indices` / `grid_range_arg_indices`
-(else `#VALUE!`).
+multi-cell args via `grid_range_arg_indices` (else `#VALUE!`;
+`eager_materialize_arg_indices` is empty after Phase 3).
 
 | Consumer | Error channel | How ranges are bound |
 | -------- | ------------- | -------------------- |
-| **Evaluator** | `XlError` sentinels | Eager ndarray, lazy `Range`, or `#VALUE!` per arg meta |
+| **Evaluator** | `XlError` sentinels | Lazy `Range` for Grid consumers, else `#VALUE!` |
 | **Export** | `XlErrorException` | `xl_range` / codegen bind geometry to raise-on-error `xl_cell` |
 
 Lookup/reference algorithms (`INDEX`, `MATCH`, `VLOOKUP`, …) live in
@@ -82,14 +83,14 @@ Lookup/reference algorithms (`INDEX`, `MATCH`, `VLOOKUP`, …) live in
 exposes them to the evaluator; `export_runtime/lookup.py` raises at the wrapper
 boundary. Element-wise operators live in `excel_grapher.core.operator_maps`
 with the same adapter pattern (`core.operators` / `export_runtime.operators`).
-Do not introduce a third traversal copy.
+Full-scan reductions share `core.coercions.flatten` and `core.sumproduct.sumproduct_cells`
+(`runtime/math` may optionally materialize large SUMPRODUCT args for NumPy
+fastpath; export stays on the Grid loop). Do not introduce a third traversal copy.
 
 Behavioral parity (evaluator ↔ export ↔ Excel) is unchanged by representation
-convergence. Remaining eager numpy use in the evaluator hot path is confined to
-full-scan reductions via `eager_materialize_arg_indices` and optional operator
-fast paths (explicit materialization when a Grid binary op is large enough).
-Binary range operands bind lazy `Range` and share `core.operator_maps` with
-export `xl_map_*`.
+convergence. Remaining NumPy use in the evaluator hot path is confined to
+optional operator / SUMPRODUCT fast paths (explicit materialization when a Grid
+is large enough). Binary range operands and aggregate args bind lazy `Range`.
 
 ## Layered semantics: core, runtime, and export_runtime
 
@@ -126,9 +127,9 @@ Private helpers shared within a module stay `_`-prefixed (e.g.
 - **Export-owned semantics** (not just error-channel differences):
   `excel_grapher/exporter/export_runtime/*` also defines the exported error
   channel (`XlErrorException`, `xl_raise`, thunked error-consumers), operators
-  (`xl_map_*`), aggregates (`xl_sumproduct`), and OFFSET/`xl_range` helpers.
-  Lookup traversal is shared via `core/lookup_funcs` + `core.grid`; export
-  wrappers only adapt the error channel.
+  (`xl_map_*`), and OFFSET/`xl_range` helpers. Lookup traversal and
+  SUMPRODUCT share `core/lookup_funcs` / `core/sumproduct` + `core.grid`;
+  export wrappers only adapt the error channel.
 - **Embedding**: codegen embeds runtime code via
   `excel_grapher/exporter/embed.py::emit_runtime(...)`. Export-owned modules
   register **last**, so their `xl_*` symbols override shared `runtime` wrappers

--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -37,9 +37,11 @@ The evaluator and the exported runtime use **different error channels** with the
     scalar contexts)
 
   Scalar coercions (`as_scalar` / `to_number` / `to_string` / `to_bool`) also
-  reject multi-cell `Range` with `#VALUE!`. AST `get_error` walks `Range`
-  cells for generic functions (first-error fail-fast); lookup/reference
-  functions skip that precheck so selective Grid access stays consumer-driven.
+  reject multi-cell `Range` with `#VALUE!`. Lookup/reference functions and
+  full-scan reductions that handle errors internally (`SUM` fail-fast,
+  `COUNTIF` Excel skip, …) are listed in `FormulaEvaluator._SKIP_ERROR_PRECHECK`
+  so AST `get_error` does not double-walk range cells. Other generic functions
+  still run `get_error` over flattened args (including lazy `Range` cells).
 - **Export = Pythonic model.** Where Excel displays error code `E`, exported
   code **raises `XlErrorException(E)`** (a traceback, not a silently propagated
   sentinel). Ranges are the same lazy `Range` values; unused cells are never
@@ -61,9 +63,12 @@ Export error-channel specifics:
   thunked and propagate argument errors like any generic worksheet function.
 - `compute_all` raises by default. Multi-cell range targets materialize as
   nested lists with per-cell sentinel codes (grid display semantics).
-- Lookup scans and criteria matching keep Excel **skip semantics** through the
-  sentinel probe channel (`Range.value_at` / `Grid.at` convert raised errors
-  back to sentinels for inspection without propagation).
+- Lookup scans keep Excel **skip semantics** through the sentinel probe channel
+(`Range.value_at` / `Grid.at` convert raised errors back to sentinels for
+inspection without propagation). Criteria consumers (`COUNTIF` / `AVERAGEIF`)
+also skip error cells in the criteria range (Excel behavior); they are exempt
+from AST `get_error` and walk via Grid so embedded export `flatten` (raise-
+channel) cannot override that skip.
 
 ## Shared lazy range / grid representation
 
@@ -83,9 +88,15 @@ Lookup/reference algorithms (`INDEX`, `MATCH`, `VLOOKUP`, …) live in
 exposes them to the evaluator; `export_runtime/lookup.py` raises at the wrapper
 boundary. Element-wise operators live in `excel_grapher.core.operator_maps`
 with the same adapter pattern (`core.operators` / `export_runtime.operators`).
-Full-scan reductions share `core.coercions.flatten` and `core.sumproduct.sumproduct_cells`
-(`runtime/math` may optionally materialize large SUMPRODUCT args for NumPy
-fastpath; export stays on the Grid loop). Do not introduce a third traversal copy.
+Full-scan reductions share `core.coercions.flatten` (fail-fast reductions) and
+`core.sumproduct.sumproduct_cells` (`runtime/math` may optionally materialize
+large SUMPRODUCT args for NumPy fastpath; export stays on the Grid loop).
+`COUNTIF` / `AVERAGEIF` walk via Grid rather than `flatten` so error-cell skip
+survives export embedding. Do not introduce a third traversal copy.
+
+`AND` / `OR` are **not** on the Grid bind list yet — multi-cell args return
+`#VALUE!` without evaluating siblings until cell-wise range semantics land
+(#397).
 
 Behavioral parity (evaluator ↔ export ↔ Excel) is unchanged by representation
 convergence. Remaining NumPy use in the evaluator hot path is confined to

--- a/excel_grapher/core/coercions.py
+++ b/excel_grapher/core/coercions.py
@@ -165,7 +165,7 @@ def flatten(*args: object) -> Iterator[CellValue]:
             yield from (v for v in arg.flat)
             continue
         if isinstance(arg, Range):
-            yield from (cast("CellValue", v) for v in arg.iter_raw())
+            yield from arg.iter_raw()
             continue
         if isinstance(arg, (list, tuple)):
             yield from flatten(*arg)

--- a/excel_grapher/core/coercions.py
+++ b/excel_grapher/core/coercions.py
@@ -153,16 +153,19 @@ def excel_casefold(value: str) -> str:
 
 
 def flatten(*args: object) -> Iterator[CellValue]:
-    """Flatten nested lists and ndarrays; do not walk lazy `Range` values.
+    """Flatten nested lists, ndarrays, and lazy `Range` values in row-major order.
 
-    AST error prechecks (`get_error`) stay shallow for `Range` so selective
-    consumers are not forced to evaluate every cell. Full-scan reductions that
-    need cell-level traversal materialize (or, later, iterate `Range` inside the
-    aggregate) rather than relying on this helper.
+    Full-scan reductions (`SUM`, `COUNTIF`, …) and generic-function error
+    prechecks (`get_error`) use this helper to walk multi-cell args. Selective
+    consumers (`INDEX`, `MATCH`, lookups) skip `get_error` so they are not
+    forced to evaluate sibling cells.
     """
     for arg in args:
         if isinstance(arg, np.ndarray):
             yield from (v for v in arg.flat)
+            continue
+        if isinstance(arg, Range):
+            yield from (cast("CellValue", v) for v in arg.iter_raw())
             continue
         if isinstance(arg, (list, tuple)):
             yield from flatten(*arg)
@@ -171,9 +174,10 @@ def flatten(*args: object) -> Iterator[CellValue]:
 
 
 def get_error(*args: object) -> XlError | None:
-    """Return the first top-level / flattened-list `XlError`, if any.
+    """Return the first flattened `XlError`, if any.
 
-    Does not evaluate cells inside a lazy `Range` (see `flatten`).
+    Walks ndarrays, nested lists, and lazy `Range` cells via `flatten`. Lookup
+    functions skip this precheck so selective Grid access stays consumer-driven.
     """
     for v in flatten(*args):
         if isinstance(v, XlError):

--- a/excel_grapher/core/excel_function_meta.py
+++ b/excel_grapher/core/excel_function_meta.py
@@ -15,8 +15,7 @@ from typing import Literal, TypeAlias
 
 ArgRole: TypeAlias = Literal["value", "ref_only"]
 
-# Sufficient for Excel varargs (SUM, SUMPRODUCT, AND, …) until Phase 3 drops
-# eager materialization for full-scan consumers.
+# Sufficient for Excel varargs (SUM, SUMPRODUCT, AND, …).
 _ALL_ARGS: frozenset[int] = frozenset(range(32))
 
 
@@ -40,9 +39,17 @@ FUNCTION_META: dict[str, ExcelFunctionMeta] = {
     "CONCAT": ExcelFunctionMeta("CONCAT", ()),
 }
 
-# Full-scan reductions that still eager-materialize to object-dtype ndarrays
-# (bridge until Phase 3 teaches flatten / aggregates over Grid).
-EAGER_MATERIALIZE_ARG_INDICES: dict[str, frozenset[int]] = {
+# Remaining eager-ndarray bridge (empty after Phase 3; kept for Phase 4 rename).
+EAGER_MATERIALIZE_ARG_INDICES: dict[str, frozenset[int]] = {}
+
+# Multi-cell args bound as lazy `Range` (selective or full-scan Grid consumers).
+# Unlisted multi-cell args become `#VALUE!`.
+GRID_RANGE_ARG_INDICES: dict[str, frozenset[int]] = {
+    "LOOKUP": frozenset({1, 2}),
+    "VLOOKUP": frozenset({1}),
+    "HLOOKUP": frozenset({1}),
+    "MATCH": frozenset({1}),
+    "XLOOKUP": frozenset({1, 2}),
     "SUM": _ALL_ARGS,
     "AVERAGE": _ALL_ARGS,
     "MIN": _ALL_ARGS,
@@ -58,16 +65,6 @@ EAGER_MATERIALIZE_ARG_INDICES: dict[str, frozenset[int]] = {
     "SUMPRODUCT": _ALL_ARGS,
     "AND": _ALL_ARGS,
     "OR": _ALL_ARGS,
-}
-
-# Lookup / reference consumers that bind multi-cell args as lazy `Range`
-# (selective Grid access). Unlisted multi-cell args become `#VALUE!`.
-GRID_RANGE_ARG_INDICES: dict[str, frozenset[int]] = {
-    "LOOKUP": frozenset({1, 2}),
-    "VLOOKUP": frozenset({1}),
-    "HLOOKUP": frozenset({1}),
-    "MATCH": frozenset({1}),
-    "XLOOKUP": frozenset({1, 2}),
 }
 
 

--- a/excel_grapher/core/excel_function_meta.py
+++ b/excel_grapher/core/excel_function_meta.py
@@ -63,8 +63,7 @@ GRID_RANGE_ARG_INDICES: dict[str, frozenset[int]] = {
     "NPV": frozenset(range(1, 32)),
     "RANK": frozenset({1}),
     "SUMPRODUCT": _ALL_ARGS,
-    "AND": _ALL_ARGS,
-    "OR": _ALL_ARGS,
+    # AND/OR stay scalar until cell-wise range semantics land (see #397).
 }
 
 

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import math
 import re
-from typing import TypeVar
+from collections.abc import Iterator
+from typing import TypeVar, cast
 
 import numpy as np
 
@@ -15,6 +16,7 @@ from .coercions import (
     to_number,
     to_string,
 )
+from .grid import Grid
 from .types import CellValue, XlError
 
 T = TypeVar("T", str, float)
@@ -242,17 +244,30 @@ def _value_matches_criteria(cell_value: CellValue, criteria: CellValue) -> bool:
     return _criteria_compare(op, excel_casefold(to_string(cell_value)), excel_casefold(rhs))
 
 
+def _iter_arg_cells(value: CellValue) -> Iterator[CellValue]:
+    """Yield cells from a range/array arg without raising on error sentinels.
+
+    Prefer this over `flatten` for criteria consumers (`COUNTIF` / `AVERAGEIF`)
+    so embedded exports still skip Excel error cells when `export_runtime.values.flatten`
+    raises at the shared `flatten` name.
+    """
+    grid = Grid.wrap(value)
+    if grid is not None:
+        for cell in grid.iter_raw():
+            yield cast(CellValue, cell)
+        return
+    yield value
+
+
 def countif_cells(range_values: CellValue, criteria: CellValue) -> int | XlError:
-    """Count cells matching criteria."""
+    """Count cells matching criteria.
+
+    Error cells in the range are skipped (Excel COUNTIF semantics), not
+    propagated. Criteria that are themselves an `XlError` propagate.
+    """
     if isinstance(criteria, XlError):
         return criteria
-    count = 0
-    for v in flatten(range_values):
-        if isinstance(v, XlError):
-            return v
-        if _value_matches_criteria(v, criteria):
-            count += 1
-    return count
+    return sum(1 for v in _iter_arg_cells(range_values) if _value_matches_criteria(v, criteria))
 
 
 def averageif_cells(
@@ -260,17 +275,20 @@ def averageif_cells(
     criteria: CellValue,
     average_range: CellValue | None = None,
 ) -> float | XlError:
-    """Return the average of cells matching criteria."""
+    """Return the average of cells matching criteria.
+
+    Error cells in the criteria range are skipped (Excel AVERAGEIF semantics).
+    Matched average-range errors still propagate via `to_number`.
+    """
     if isinstance(criteria, XlError):
         return criteria
-    crit_vals = list(flatten(range_values))
-    avg_vals = list(flatten(average_range if average_range is not None else range_values))
+    crit_vals = list(_iter_arg_cells(range_values))
+    avg_source = average_range if average_range is not None else range_values
+    avg_vals = list(_iter_arg_cells(avg_source))
     if len(crit_vals) != len(avg_vals):
         return XlError.VALUE
     matched: list[float] = []
     for crit_val, avg_val in zip(crit_vals, avg_vals, strict=True):
-        if isinstance(crit_val, XlError):
-            return crit_val
         if not _value_matches_criteria(crit_val, criteria):
             continue
         n = to_number(avg_val)

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -11,7 +11,6 @@ import numpy as np
 from .coercions import (
     excel_casefold,
     flatten,
-    numeric_values,
     to_bool,
     to_number,
     to_string,
@@ -41,44 +40,62 @@ __all__ = [
 
 def sum_cells(*args: CellValue) -> float | XlError:
     """Return the sum of numeric cells."""
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    return float(sum(nums))
+    total = 0.0
+    for v in flatten(*args):
+        n = to_number(v)
+        if isinstance(n, XlError):
+            return n
+        total += float(n)
+    return total
 
 
 def average_cells(*args: CellValue) -> float | XlError:
     """Return the average of numeric cells."""
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
+    total = 0.0
+    count = 0
+    for v in flatten(*args):
+        n = to_number(v)
+        if isinstance(n, XlError):
+            return n
+        total += float(n)
+        count += 1
+    if count == 0:
         return XlError.DIV
-    return float(sum(nums) / len(nums))
+    return float(total / count)
 
 
 def min_cells(*args: CellValue) -> float | XlError:
     """Return the minimum of numeric cells."""
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
+    found = False
+    current = 0.0
+    for v in flatten(*args):
+        n = to_number(v)
+        if isinstance(n, XlError):
+            return n
+        value = float(n)
+        if not found or value < current:
+            current = value
+            found = True
+    if not found:
         return 0.0
-    return float(min(nums))
+    return current
 
 
 def max_cells(*args: CellValue) -> float | XlError:
     """Return the maximum of numeric cells."""
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
+    found = False
+    current = 0.0
+    for v in flatten(*args):
+        n = to_number(v)
+        if isinstance(n, XlError):
+            return n
+        value = float(n)
+        if not found or value > current:
+            current = value
+            found = True
+    if not found:
         return 0.0
-    return float(max(nums))
+    return current
 
 
 def round_number(number: CellValue, num_digits: CellValue) -> float | XlError:
@@ -112,47 +129,32 @@ def npv_cells(rate: CellValue, *values: CellValue) -> float | XlError:
     r = to_number(rate)
     if isinstance(r, XlError):
         return r
-    all_values = list(flatten(*values))
-    nums, err = numeric_values(all_values)
-    if err is not None:
-        return err
-    if len(nums) == 0:
-        return XlError.VALUE
     result = 0.0
-    for i, val in enumerate(nums):
-        result += val / ((1 + r) ** (i + 1))
+    count = 0
+    for v in flatten(*values):
+        n = to_number(v)
+        if isinstance(n, XlError):
+            return n
+        count += 1
+        result += float(n) / ((1 + r) ** count)
+    if count == 0:
+        return XlError.VALUE
     return result
 
 
 def stdev_cells(*args: CellValue) -> float | XlError:
     """Return sample standard deviation of numeric cells."""
-    values = list(flatten(*args))
-    nums, err = numeric_values(values)
-    if err is not None:
-        return err
+    nums: list[float] = []
+    for v in flatten(*args):
+        n = to_number(v)
+        if isinstance(n, XlError):
+            return n
+        nums.append(float(n))
     if len(nums) < 2:
         return XlError.DIV
     mean = sum(nums) / len(nums)
     variance = sum((x - mean) ** 2 for x in nums) / (len(nums) - 1)
     return float(variance**0.5)
-
-
-def _iter_numeric_cells(values: list[CellValue]) -> tuple[list[float], XlError | None]:
-    nums: list[float] = []
-    for v in values:
-        if isinstance(v, XlError):
-            return ([], v)
-        if v is None:
-            continue
-        if isinstance(v, bool):
-            continue
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            nums.append(float(v))
-            continue
-        if isinstance(v, (np.integer, np.floating)):
-            nums.append(float(v))
-            continue
-    return (nums, None)
 
 
 def _wildcard_to_regex(pattern: str) -> re.Pattern[str]:
@@ -244,8 +246,13 @@ def countif_cells(range_values: CellValue, criteria: CellValue) -> int | XlError
     """Count cells matching criteria."""
     if isinstance(criteria, XlError):
         return criteria
-    values = list(flatten(range_values))
-    return sum(1 for v in values if _value_matches_criteria(v, criteria))
+    count = 0
+    for v in flatten(range_values):
+        if isinstance(v, XlError):
+            return v
+        if _value_matches_criteria(v, criteria):
+            count += 1
+    return count
 
 
 def averageif_cells(
@@ -262,6 +269,8 @@ def averageif_cells(
         return XlError.VALUE
     matched: list[float] = []
     for crit_val, avg_val in zip(crit_vals, avg_vals, strict=True):
+        if isinstance(crit_val, XlError):
+            return crit_val
         if not _value_matches_criteria(crit_val, criteria):
             continue
         n = to_number(avg_val)
@@ -281,10 +290,17 @@ def large_kth(array: CellValue, k: CellValue) -> float | XlError:
     kth = int(kk)
     if kth < 1:
         return XlError.NUM
-    values = list(flatten(array))
-    nums, err = _iter_numeric_cells(values)
-    if err is not None:
-        return err
+    nums: list[float] = []
+    for v in flatten(array):
+        if isinstance(v, XlError):
+            return v
+        if v is None or isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            nums.append(float(v))
+            continue
+        if isinstance(v, (np.integer, np.floating)):
+            nums.append(float(v))
     if kth > len(nums):
         return XlError.NUM
     nums.sort(reverse=True)
@@ -300,10 +316,17 @@ def rank_number(number: CellValue, ref: CellValue, order: CellValue = 0) -> int 
     if isinstance(oo, XlError):
         return oo
     ascending = int(oo) != 0
-    values = list(flatten(ref))
-    nums, err = _iter_numeric_cells(values)
-    if err is not None:
-        return err
+    nums: list[float] = []
+    for v in flatten(ref):
+        if isinstance(v, XlError):
+            return v
+        if v is None or isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            nums.append(float(v))
+            continue
+        if isinstance(v, (np.integer, np.floating)):
+            nums.append(float(v))
     if ascending:
         return 1 + sum(1 for v in nums if v < nn)
     return 1 + sum(1 for v in nums if v > nn)

--- a/excel_grapher/core/sumproduct.py
+++ b/excel_grapher/core/sumproduct.py
@@ -1,37 +1,45 @@
-"""SUMPRODUCT over aligned cell-value arrays (representation-agnostic)."""
+"""SUMPRODUCT over aligned Grid / nested-list / scalar arguments.
+
+Shared Grid traversal for evaluator and export. Optional NumPy acceleration
+lives in `runtime.math.xl_sumproduct` (evaluator only) so exported runtimes
+stay NumPy-free.
+"""
 
 from __future__ import annotations
 
-import numpy as np
+from typing import cast
 
+from .coercions import to_number
 from .grid import Grid
-from .operators_fastpath import try_fastpath_sumproduct
-from .operators_reference import reference_sumproduct_arrays
 from .types import CellValue, XlError
 
 
-def _as_object_array(arg: CellValue) -> np.ndarray:
-    if isinstance(arg, np.ndarray):
-        return arg
+def _as_grid(arg: CellValue) -> Grid:
     grid = Grid.wrap(arg)
     if grid is not None:
-        return np.array(
-            [[grid.at(row0, col0) for col0 in range(grid.ncols)] for row0 in range(grid.nrows)],
-            dtype=object,
-        )
-    return np.array([[arg]], dtype=object)
+        return grid
+    scalar = Grid.wrap([[arg]])
+    assert scalar is not None
+    return scalar
 
 
-def xl_sumproduct(*args: CellValue) -> float | XlError:
+def sumproduct_cells(*args: CellValue) -> float | XlError:
+    """Return the sum of element-wise products across aligned array arguments."""
     if len(args) == 0:
         return 0.0
-    arrays: list[np.ndarray] = [_as_object_array(arg) for arg in args]
-    shape = arrays[0].shape
-    for arr in arrays[1:]:
-        if arr.shape != shape:
+    grids = [_as_grid(arg) for arg in args]
+    shape = (grids[0].nrows, grids[0].ncols)
+    for grid in grids[1:]:
+        if (grid.nrows, grid.ncols) != shape:
             return XlError.VALUE
 
-    fast = try_fastpath_sumproduct(arrays)
-    if fast is not None:
-        return fast
-    return reference_sumproduct_arrays(arrays)
+    result = 0.0
+    for index0 in range(grids[0].size):
+        product = 1.0
+        for grid in grids:
+            number = to_number(cast(CellValue, grid.at_flat(index0)))
+            if isinstance(number, XlError):
+                return number
+            product *= number
+        result += product
+    return result

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -81,12 +81,28 @@ from .parser import (
 )
 
 _SKIP_ERROR_PRECHECK = {
+    # Selective Grid consumers: AST precheck must not force a full scan.
     "LOOKUP",
     "VLOOKUP",
     "HLOOKUP",
     "INDEX",
     "MATCH",
     "XLOOKUP",
+    # Full-scan reductions that fail-fast (or Excel-skip) internally.
+    "SUM",
+    "AVERAGE",
+    "MIN",
+    "MAX",
+    "STDEV",
+    "NPV",
+    "SUMPRODUCT",
+    "LARGE",
+    "RANK",
+    "COUNT",
+    "COUNTA",
+    # Criteria consumers: Excel skips error cells in the criteria range.
+    "COUNTIF",
+    "AVERAGEIF",
 }
 
 if TYPE_CHECKING:

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -439,8 +439,10 @@ class FormulaEvaluator:
 
         Policy (multi-cell):
 
-        - ``eager_materialize_arg_indices`` → dense ndarray (full-scan bridge)
-        - ``grid_range_arg_indices`` → lazy ``Range`` (selective Grid access)
+        - ``grid_range_arg_indices`` → lazy ``Range`` (lookups + full-scan
+          reductions); consumers walk cells via ``flatten`` / ``Grid``
+        - ``eager_materialize_arg_indices`` → dense ndarray (empty after
+          Phase 3; retained until Phase 4 cleanup)
         - otherwise → ``#VALUE!`` (scalar / non-Grid consumers; no Range leak)
 
         Single-cell references in value contexts (e.g. ``TEXT(INDEX(...))``)

--- a/excel_grapher/exporter/export_runtime/aggregates.py
+++ b/excel_grapher/exporter/export_runtime/aggregates.py
@@ -1,38 +1,15 @@
-"""Range reductions over lazy ranges for exported code."""
+"""Raise-only boundary wrapper for SUMPRODUCT over shared Grid traversal."""
 
 from __future__ import annotations
 
-from excel_grapher.core import XlError, to_number
-from excel_grapher.core.types import XlErrorException
+from excel_grapher.core import CellValue
+from excel_grapher.core.sumproduct import sumproduct_cells
 
-from .values import CellValue, Grid
+from .errors import raise_if_sentinel_float
 
 __all__ = ["xl_sumproduct"]
 
 
 def xl_sumproduct(*args: CellValue) -> float:
-    if len(args) == 0:
-        return 0.0
-    grids: list[Grid] = []
-    for arg in args:
-        grid = Grid.wrap(arg)
-        if grid is None:
-            scalar_grid = Grid.wrap([[arg]])
-            assert scalar_grid is not None
-            grid = scalar_grid
-        grids.append(grid)
-    shape = (grids[0].nrows, grids[0].ncols)
-    for grid in grids[1:]:
-        if (grid.nrows, grid.ncols) != shape:
-            raise XlErrorException(XlError.VALUE)
-
-    result = 0.0
-    for index0 in range(grids[0].size):
-        product = 1.0
-        for grid in grids:
-            number = to_number(grid.at_flat(index0))
-            if isinstance(number, XlError):
-                raise XlErrorException(number)
-            product *= number
-        result += product
-    return result
+    """Return the sum of element-wise products, raising on Excel errors."""
+    return raise_if_sentinel_float(sumproduct_cells(*args))

--- a/excel_grapher/runtime/math.py
+++ b/excel_grapher/runtime/math.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from excel_grapher.core import CellValue, XlError, flatten
+from excel_grapher.core.grid import Grid
 from excel_grapher.core.math_funcs import (
     abs_number,
     average_cells,
@@ -20,7 +21,12 @@ from excel_grapher.core.math_funcs import (
     stdev_cells,
     sum_cells,
 )
-from excel_grapher.core.sumproduct import xl_sumproduct
+from excel_grapher.core.operators_fastpath import (
+    MIN_OPERATOR_FASTPATH_CELLS,
+    try_fastpath_sumproduct,
+)
+from excel_grapher.core.operators_reference import reference_sumproduct_arrays
+from excel_grapher.core.sumproduct import sumproduct_cells
 
 __all__ = [
     "xl_abs",
@@ -127,3 +133,38 @@ def xl_abs(*args: CellValue) -> float | XlError:
 
 def xl_exp(*args: CellValue) -> float | XlError:
     return exp_number(*args)
+
+
+def xl_sumproduct(*args: CellValue) -> float | XlError:
+    """SUMPRODUCT with optional NumPy acceleration for large fully-consumed grids."""
+    if len(args) == 0:
+        return 0.0
+
+    grids: list[Grid] = []
+    for arg in args:
+        grid = Grid.wrap(arg)
+        if grid is None:
+            scalar = Grid.wrap([[arg]])
+            assert scalar is not None
+            grid = scalar
+        grids.append(grid)
+
+    shape = (grids[0].nrows, grids[0].ncols)
+    for grid in grids[1:]:
+        if (grid.nrows, grid.ncols) != shape:
+            return XlError.VALUE
+
+    if grids[0].size >= MIN_OPERATOR_FASTPATH_CELLS:
+        arrays = [
+            np.array(
+                [[grid.at(row0, col0) for col0 in range(grid.ncols)] for row0 in range(grid.nrows)],
+                dtype=object,
+            )
+            for grid in grids
+        ]
+        fast = try_fastpath_sumproduct(arrays)
+        if fast is not None:
+            return fast
+        return reference_sumproduct_arrays(arrays)
+
+    return sumproduct_cells(*args)

--- a/tests/bench/operators_bench.py
+++ b/tests/bench/operators_bench.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from excel_grapher.core.coercions import datetime_to_excel_serial
 from excel_grapher.core.operators import xl_concat, xl_eq, xl_gt, xl_mul
-from excel_grapher.core.sumproduct import xl_sumproduct
+from excel_grapher.core.sumproduct import sumproduct_cells as xl_sumproduct
 
 BASELINE_VERSION = 1
 DEFAULT_WARMUP_ROUNDS = 2

--- a/tests/integration/evaluator/test_countif_excel_parity.py
+++ b/tests/integration/evaluator/test_countif_excel_parity.py
@@ -1,0 +1,47 @@
+"""COUNTIF: evaluator matches live Excel on criteria scan (integration, slow).
+
+Complements evaluator ↔ codegen COUNTIF tests. Requires xlwings or WSL/COM;
+skips cleanly when Excel automation is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.utils.excel_live_parity import LiveExcelCell, assert_evaluator_matches_live_excel
+
+
+@pytest.mark.slow
+def test_countif_excel_parity_skips_error_cells_in_range(tmp_path: Path) -> None:
+    """Excel COUNTIF ignores error cells in the criteria range (does not propagate)."""
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", value=10),
+            LiveExcelCell("A2", formula="=1/0"),
+            LiveExcelCell("A3", value=20),
+            LiveExcelCell("B1", formula='=COUNTIF(A1:A3,">5")'),
+        ),
+        targets=("S!B1",),
+        workbook_stem="countif_skip_errors",
+    )
+
+
+@pytest.mark.slow
+def test_countif_excel_parity_numeric_and_text_criteria(tmp_path: Path) -> None:
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", value=10),
+            LiveExcelCell("A2", value="text"),
+            LiveExcelCell("A3", value=20),
+            LiveExcelCell("B1", formula='=COUNTIF(A1:A3,">5")'),
+            LiveExcelCell("B2", formula='=COUNTIF(A1:A3,"text")'),
+        ),
+        targets=("S!B1", "S!B2"),
+        workbook_stem="countif_criteria",
+    )

--- a/tests/integration/evaluator/test_lazy_range_evaluator.py
+++ b/tests/integration/evaluator/test_lazy_range_evaluator.py
@@ -285,6 +285,57 @@ def test_countif_over_lazy_range_parity() -> None:
         assert ev.evaluate(["S!B1"]) == {"S!B1": 2}
 
 
+def test_countif_skips_error_cells_in_range() -> None:
+    """COUNTIF skips error cells (Excel semantics; no AST error precheck)."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 10),
+        _make_node("S!A2", "=1/0", None),
+        _make_node("S!A3", None, 20),
+        _make_node("S!B1", '=COUNTIF(S!A1:S!A3, ">5")', None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": 2}
+
+
+def test_and_or_reject_multi_cell_range_without_sibling_eval() -> None:
+    """AND/OR stay off the Grid bind list until cell-wise semantics (#397)."""
+    graph = _make_graph(
+        _make_node("S!A1", None, True),
+        _make_node("S!A2", "=1/0", None),
+        _make_node("S!A3", None, True),
+        _make_node("S!B1", "=AND(S!A1:S!A3)", None),
+    )
+    seen: list[str] = []
+
+    def _track(address: str, _value: object) -> None:
+        seen.append(address)
+
+    with FormulaEvaluator(graph, on_cell_evaluated=_track) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": XlError.VALUE}
+        assert "S!A1" not in ev._cache
+        assert "S!A2" not in ev._cache
+    assert "S!A2" not in seen
+
+
+def test_sum_does_not_double_evaluate_via_ast_precheck() -> None:
+    """Full-scan SUM skips AST get_error; each leaf is evaluated once."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", "=S!A1+1", None),
+        _make_node("S!A3", "=S!A1+2", None),
+        _make_node("S!B1", "=SUM(S!A1:S!A3)", None),
+    )
+    seen: list[str] = []
+
+    def _track(address: str, _value: object) -> None:
+        seen.append(address)
+
+    with FormulaEvaluator(graph, on_cell_evaluated=_track) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": 6}
+    assert seen.count("S!A2") == 1
+    assert seen.count("S!A3") == 1
+
+
 def test_match_over_offset_does_not_evaluate_trailing_unused_cells() -> None:
     """OFFSET → MATCH stays selective under lazy-by-default range resolution."""
     graph = _make_graph(

--- a/tests/integration/evaluator/test_lazy_range_evaluator.py
+++ b/tests/integration/evaluator/test_lazy_range_evaluator.py
@@ -198,7 +198,7 @@ def test_xlookup_stops_before_trailing_unused_cells() -> None:
 
 
 def test_sum_over_range_with_error_produces_error_code() -> None:
-    """SUM over a range containing an error surfaces the first error (reductions stay eager)."""
+    """SUM over a range containing an error surfaces the first error's code."""
     graph = _make_graph(
         _make_node("S!A1", None, 1),
         _make_node("S!A2", "=1/0", None),
@@ -210,7 +210,7 @@ def test_sum_over_range_with_error_produces_error_code() -> None:
 
 
 def test_sum_still_evaluates_all_cells_in_range() -> None:
-    """Full-scan reductions still visit every cell (eager until Phase 3)."""
+    """Full-scan reductions visit every cell when no embedded error stops them."""
     graph = _make_graph(
         _make_node("S!A1", None, 1),
         _make_node("S!A2", "=S!A1+1", None),
@@ -227,6 +227,62 @@ def test_sum_still_evaluates_all_cells_in_range() -> None:
     assert "S!A1" in seen
     assert "S!A2" in seen
     assert "S!A3" in seen
+
+
+def test_sum_over_ranges_does_not_eager_resolve_excel_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SUM binds lazy Range; resolve_excel_range is never called."""
+    from excel_grapher.core import types as core_types
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("resolve_excel_range must not run for SUM args")
+
+    monkeypatch.setattr(core_types, "resolve_excel_range", _boom)
+    monkeypatch.setattr(
+        "excel_grapher.evaluator.evaluator.resolve_excel_range",
+        _boom,
+    )
+
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", None, 2),
+        _make_node("S!A3", None, 3),
+        _make_node("S!B1", "=SUM(S!A1:S!A3)", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": 6.0}
+
+
+def test_sum_fail_fast_does_not_evaluate_trailing_formula_cells() -> None:
+    """SUM stops at the first cell error; trailing formulas stay cold."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", "=1/0", None),
+        _make_node("S!A3", "=S!A1+99", None),
+        _make_node("S!B1", "=SUM(S!A1:S!A3)", None),
+    )
+    seen: list[str] = []
+
+    def _track(address: str, _value: object) -> None:
+        seen.append(address)
+
+    with FormulaEvaluator(graph, on_cell_evaluated=_track) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": XlError.DIV}
+        assert "S!A3" not in ev._cache
+    assert "S!A3" not in seen
+
+
+def test_countif_over_lazy_range_parity() -> None:
+    """COUNTIF binds lazy Range and counts matching cells."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 10),
+        _make_node("S!A2", None, 3),
+        _make_node("S!A3", None, 20),
+        _make_node("S!B1", '=COUNTIF(S!A1:S!A3, ">5")', None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!B1"]) == {"S!B1": 2}
 
 
 def test_match_over_offset_does_not_evaluate_trailing_unused_cells() -> None:

--- a/tests/integration/exporter/test_raise_based_errors.py
+++ b/tests/integration/exporter/test_raise_based_errors.py
@@ -415,8 +415,8 @@ class TestErrorCodeParity:
         result = assert_codegen_matches_evaluator(graph, ["S!A1"])
         assert result.generated_results["S!A1"] == 3
 
-    def test_countif_over_error_range_matches_evaluator_precheck(self) -> None:
-        """Generic functions propagate range argument errors like the evaluator."""
+    def test_countif_over_error_range_skips_error_cells(self) -> None:
+        """COUNTIF matches Excel: error cells in the range are skipped, not propagated."""
         graph = _make_graph(
             _make_node("S!B1", None, 10),
             _make_node("S!B2", "=1/0", None),
@@ -424,7 +424,7 @@ class TestErrorCodeParity:
             _make_node("S!A1", '=COUNTIF(S!B1:S!B3, ">5")', None),
         )
         result = assert_codegen_matches_evaluator(graph, ["S!A1"])
-        assert result.generated_results["S!A1"] == XlError.DIV
+        assert result.generated_results["S!A1"] == 2
 
     def test_countif_text_cells_do_not_raise_on_numeric_criteria(self) -> None:
         """Criteria coercion failures skip cells rather than raising."""

--- a/tests/unit/core/operators_test_helpers.py
+++ b/tests/unit/core/operators_test_helpers.py
@@ -28,7 +28,7 @@ from excel_grapher.core.operators_reference import (
     reference_concat_array,
     reference_sumproduct_arrays,
 )
-from excel_grapher.core.sumproduct import xl_sumproduct
+from excel_grapher.core.sumproduct import sumproduct_cells as xl_sumproduct
 from excel_grapher.core.types import CellValue, XlError
 
 COMPARE_OPS = ("=", "<>", "<", ">", "<=", ">=")

--- a/tests/unit/core/test_aggregate_grids.py
+++ b/tests/unit/core/test_aggregate_grids.py
@@ -1,0 +1,116 @@
+"""Unit tests for Grid-native flatten / aggregates (#336 Phase 3)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+
+from excel_grapher.core import CellValue, XlError, flatten, get_error
+from excel_grapher.core.excel_function_meta import (
+    eager_materialize_arg_indices,
+    grid_range_arg_indices,
+)
+from excel_grapher.core.grid import Range
+from excel_grapher.core.math_funcs import countif_cells, sum_cells
+from excel_grapher.core.sumproduct import sumproduct_cells
+
+
+def test_full_scan_aggregates_bind_lazy_ranges_not_eager_ndarrays() -> None:
+    """Phase 3 drops eager materialization for SUM / SUMPRODUCT / COUNTIF."""
+    assert eager_materialize_arg_indices("SUM") == frozenset()
+    assert eager_materialize_arg_indices("SUMPRODUCT") == frozenset()
+    assert eager_materialize_arg_indices("COUNTIF") == frozenset()
+    assert 0 in grid_range_arg_indices("SUM")
+    assert 0 in grid_range_arg_indices("SUMPRODUCT")
+    assert 0 in grid_range_arg_indices("COUNTIF")
+
+
+def test_flatten_walks_lazy_range_in_row_major_order() -> None:
+    calls: list[str] = []
+    values = {"S!A1": 1, "S!B1": 2, "S!A2": 3, "S!B2": 4}
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return values[address]
+
+    rng = Range("S", 1, 1, 2, 2, resolve)
+    assert list(flatten(rng)) == [1, 2, 3, 4]
+    assert calls == ["S!A1", "S!B1", "S!A2", "S!B2"]
+
+
+def test_flatten_yields_error_sentinels_from_lazy_range() -> None:
+    rng = Range(
+        "S",
+        1,
+        1,
+        3,
+        1,
+        lambda a: {"S!A1": 1, "S!A2": XlError.DIV, "S!A3": 3}[a],
+    )
+    assert list(flatten(rng)) == [1, XlError.DIV, 3]
+
+
+def test_get_error_finds_first_error_in_lazy_range() -> None:
+    """Full-scan precheck walks Range cells (lookups skip get_error instead)."""
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": 1, "S!A2": XlError.DIV, "S!A3": 3}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert get_error(rng) == XlError.DIV
+    assert calls == ["S!A1", "S!A2"]
+
+
+def test_sum_cells_over_lazy_range() -> None:
+    rng = Range("S", 1, 1, 3, 1, lambda a: {"S!A1": 1, "S!A2": 2, "S!A3": 3}[a])
+    assert sum_cells(cast(CellValue, rng)) == 6.0
+
+
+def test_sum_cells_over_lazy_range_agrees_with_ndarray() -> None:
+    values = {"S!A1": 1.5, "S!A2": 2.5, "S!A3": 3.5}
+
+    def resolve(address: str) -> CellValue:
+        return values[address]
+
+    lazy = Range("S", 1, 1, 3, 1, resolve)
+    eager = np.array([[1.5], [2.5], [3.5]], dtype=object)
+    assert sum_cells(cast(CellValue, lazy)) == sum_cells(eager) == 7.5
+
+
+def test_sum_cells_fail_fast_on_embedded_error() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": 1, "S!A2": XlError.DIV, "S!A3": 99}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert sum_cells(cast(CellValue, rng)) == XlError.DIV
+    assert "S!A3" not in calls
+
+
+def test_sumproduct_over_lazy_ranges() -> None:
+    left = Range("S", 1, 1, 3, 1, lambda a: {"S!A1": 1, "S!A2": 2, "S!A3": 3}[a])
+    right = Range("S", 1, 2, 3, 2, lambda a: {"S!B1": 4, "S!B2": 5, "S!B3": 6}[a])
+    assert sumproduct_cells(cast(CellValue, left), cast(CellValue, right)) == 32.0
+
+
+def test_sumproduct_shape_mismatch_returns_value_error() -> None:
+    left = Range("S", 1, 1, 2, 1, lambda _a: 1)
+    right = Range("S", 1, 1, 3, 1, lambda _a: 1)
+    assert sumproduct_cells(cast(CellValue, left), cast(CellValue, right)) == XlError.VALUE
+
+
+def test_countif_over_lazy_range() -> None:
+    rng = Range(
+        "S",
+        1,
+        1,
+        3,
+        1,
+        lambda a: {"S!A1": 10, "S!A2": 3, "S!A3": 20}[a],
+    )
+    assert countif_cells(cast(CellValue, rng), ">5") == 2

--- a/tests/unit/core/test_aggregate_grids.py
+++ b/tests/unit/core/test_aggregate_grids.py
@@ -114,3 +114,16 @@ def test_countif_over_lazy_range() -> None:
         lambda a: {"S!A1": 10, "S!A2": 3, "S!A3": 20}[a],
     )
     assert countif_cells(cast(CellValue, rng), ">5") == 2
+
+
+def test_countif_skips_error_cells_in_lazy_range() -> None:
+    """Excel COUNTIF ignores error cells; it does not propagate them."""
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": 10, "S!A2": XlError.DIV, "S!A3": 20}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert countif_cells(cast(CellValue, rng), ">5") == 2
+    assert calls == ["S!A1", "S!A2", "S!A3"]

--- a/tests/unit/core/test_scalar_boundary.py
+++ b/tests/unit/core/test_scalar_boundary.py
@@ -67,8 +67,8 @@ def test_to_string_does_not_leak_range_repr() -> None:
     assert "Range(" not in text
 
 
-def test_get_error_is_shallow_for_lazy_range() -> None:
-    """AST precheck must not force evaluation of cells inside a Range."""
+def test_get_error_walks_lazy_range_for_full_scan_precheck() -> None:
+    """Generic-function precheck walks Range; lookups skip get_error instead."""
     calls: list[str] = []
     values: dict[str, CellValue] = {"S!A1": 1, "S!A2": XlError.DIV}
 
@@ -77,8 +77,8 @@ def test_get_error_is_shallow_for_lazy_range() -> None:
         return values[address]
 
     rng = Range("S", 1, 1, 2, 1, resolve)
-    assert get_error(rng) is None
-    assert calls == []
+    assert get_error(rng) == XlError.DIV
+    assert calls == ["S!A1", "S!A2"]
 
 
 def test_abs_over_multi_cell_range_is_value_without_sibling_eval() -> None:

--- a/tests/unit/runtime/test_lookup_grid.py
+++ b/tests/unit/runtime/test_lookup_grid.py
@@ -17,11 +17,6 @@ def test_index_not_in_eager_materialize_arg_indices() -> None:
     assert eager_materialize_arg_indices("INDEX") == frozenset()
 
 
-def test_sumproduct_still_eager_materializes() -> None:
-    assert 0 in eager_materialize_arg_indices("SUMPRODUCT")
-    assert 0 in eager_materialize_arg_indices("SUM")
-
-
 def test_lookup_args_are_grid_range_bound() -> None:
     """Lookup table args bind lazy Range; other args do not."""
     assert 1 in grid_range_arg_indices("MATCH")

--- a/tests/unit/runtime/test_sumproduct_fastpath.py
+++ b/tests/unit/runtime/test_sumproduct_fastpath.py
@@ -9,7 +9,7 @@ from excel_grapher.core.operators_fastpath import (
     MIN_OPERATOR_FASTPATH_CELLS,
     try_fastpath_sumproduct,
 )
-from excel_grapher.core.sumproduct import xl_sumproduct
+from excel_grapher.core.sumproduct import sumproduct_cells as xl_sumproduct
 from excel_grapher.core.types import XlError
 from tests.bench.operators_bench import category_column, numeric_column, numeric_string_column
 from tests.unit.core.operators_test_helpers import assert_sumproduct_matches_reference

--- a/tests/unit/runtime/test_sumproduct_runtime_wrapper.py
+++ b/tests/unit/runtime/test_sumproduct_runtime_wrapper.py
@@ -1,0 +1,83 @@
+"""Evaluator ``xl_sumproduct`` wrapper materializes large grids for NumPy fastpath."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import pytest
+
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.grid import Range
+from excel_grapher.core.operators_fastpath import MIN_OPERATOR_FASTPATH_CELLS
+from excel_grapher.core.sumproduct import sumproduct_cells
+from excel_grapher.runtime.math import xl_sumproduct
+
+
+def test_xl_sumproduct_small_delegates_to_sumproduct_cells() -> None:
+    left = Range("S", 1, 1, 3, 1, lambda a: {"S!A1": 1, "S!A2": 2, "S!A3": 3}[a])
+    right = Range("S", 1, 2, 3, 2, lambda a: {"S!B1": 4, "S!B2": 5, "S!B3": 6}[a])
+    assert xl_sumproduct(cast(CellValue, left), cast(CellValue, right)) == 32.0
+    assert sumproduct_cells(cast(CellValue, left), cast(CellValue, right)) == 32.0
+
+
+def test_xl_sumproduct_large_uses_fastpath_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nrows = MIN_OPERATOR_FASTPATH_CELLS
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        row = int(address.split("!")[1][1:])
+        return float(row)
+
+    seen_fastpath: list[int] = []
+
+    def _fake_fastpath(arrays: list[np.ndarray]) -> float:
+        seen_fastpath.append(arrays[0].size)
+        return 42.0
+
+    monkeypatch.setattr(
+        "excel_grapher.runtime.math.try_fastpath_sumproduct",
+        _fake_fastpath,
+    )
+
+    left = Range("S", 1, 1, nrows, 1, resolve)
+    right = Range("S", 1, 2, nrows, 2, lambda a: 2.0)
+    assert xl_sumproduct(cast(CellValue, left), cast(CellValue, right)) == 42.0
+    assert seen_fastpath == [nrows]
+    assert len(calls) == nrows
+
+
+def test_xl_sumproduct_large_falls_back_to_reference_on_fastpath_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nrows = MIN_OPERATOR_FASTPATH_CELLS
+
+    monkeypatch.setattr(
+        "excel_grapher.runtime.math.try_fastpath_sumproduct",
+        lambda *_args, **_kwargs: None,
+    )
+
+    left = np.arange(1, nrows + 1, dtype=object).reshape(nrows, 1)
+    right = np.full((nrows, 1), 2.0, dtype=object)
+    expected = float(sum(float(i) * 2.0 for i in range(1, nrows + 1)))
+    assert xl_sumproduct(left, right) == expected
+
+
+def test_xl_sumproduct_shape_mismatch_and_errors() -> None:
+    assert (
+        xl_sumproduct(
+            np.array([[1.0], [2.0]], dtype=object),
+            np.array([[1.0], [2.0], [3.0]], dtype=object),
+        )
+        == XlError.VALUE
+    )
+    assert (
+        xl_sumproduct(
+            np.array([[1.0], [XlError.NA]], dtype=object),
+            np.array([[2.0], [2.0]], dtype=object),
+        )
+        == XlError.NA
+    )

--- a/user_guide/03-evaluator.qmd
+++ b/user_guide/03-evaluator.qmd
@@ -28,15 +28,19 @@ Multi-cell range arguments are classified at resolve time:
   `core.operator_maps` (aligned with export `xl_map_*`). Large ops may opt into
   the ndarray fast path after an explicit materialization.
 - Full-scan reductions (`SUM` / `SUMPRODUCT` / `COUNTIF` / …) also bind lazy
-  `Range` and walk cells in row-major order via `flatten` / Grid (first-error
-  fail-fast). Large `SUMPRODUCT` may materialize once for the NumPy fast path.
+  `Range` and walk cells in row-major order via `flatten` / Grid. `SUM` and
+  friends fail-fast on the first cell error; `COUNTIF` / `AVERAGEIF` skip
+  error cells in the criteria range (Excel). Large `SUMPRODUCT` may
+  materialize once for the NumPy fast path.
+- `AND` / `OR` still reject multi-cell ranges with `#VALUE!` until cell-wise
+  range support lands.
 - Other functions reject multi-cell ranges with `#VALUE!` (no object-repr leaks;
   sibling cells stay unevaluated).
 
-Scalar coercions (`as_scalar`) reinforce the same boundary. Lookup functions
-skip the AST error precheck so selective access stays consumer-driven; generic
-functions may walk range cells for first-error detection. Errors remain
-`XlError` sentinels (the evaluator never raises `XlErrorException`).
+Scalar coercions (`as_scalar`) reinforce the same boundary. Lookups and
+full-scan reductions skip the AST error precheck so each consumer owns its
+traversal. Errors remain `XlError` sentinels (the evaluator never raises
+`XlErrorException`).
 
 ### Minimal evaluator example
 

--- a/user_guide/03-evaluator.qmd
+++ b/user_guide/03-evaluator.qmd
@@ -27,14 +27,16 @@ Multi-cell range arguments are classified at resolve time:
 - Binary / unary operators bind the same lazy `Range` and map via shared
   `core.operator_maps` (aligned with export `xl_map_*`). Large ops may opt into
   the ndarray fast path after an explicit materialization.
-- Full-scan reductions (`SUM` / `SUMPRODUCT` / …) still materialize where
-  `flatten` / vectorized fast paths need a dense buffer.
+- Full-scan reductions (`SUM` / `SUMPRODUCT` / `COUNTIF` / …) also bind lazy
+  `Range` and walk cells in row-major order via `flatten` / Grid (first-error
+  fail-fast). Large `SUMPRODUCT` may materialize once for the NumPy fast path.
 - Other functions reject multi-cell ranges with `#VALUE!` (no object-repr leaks;
   sibling cells stay unevaluated).
 
-Scalar coercions (`as_scalar`) reinforce the same boundary. AST error prechecks
-do not walk lazy ranges. Errors remain `XlError` sentinels (the evaluator never
-raises `XlErrorException`).
+Scalar coercions (`as_scalar`) reinforce the same boundary. Lookup functions
+skip the AST error precheck so selective access stays consumer-driven; generic
+functions may walk range cells for first-error detection. Errors remain
+`XlError` sentinels (the evaluator never raises `XlErrorException`).
 
 ### Minimal evaluator example
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 3** of #336: run full-scan reductions (`SUM`, `SUMPRODUCT`, `COUNTIF`, …) on lazy `Range`/`Grid` with row-major first-error traversal, dropping the eager-ndarray bridge.

- Teach `core.coercions.flatten` / `get_error` to walk lazy `Range` cells (lookups still skip the AST precheck)
- Move aggregate arg indices from `EAGER_MATERIALIZE_ARG_INDICES` → `GRID_RANGE_ARG_INDICES`
- Stream `{sum,average,min,max,…}_cells` and `countif_cells` for fail-fast without evaluating trailing cells
- Rename shared SUMPRODUCT to `sumproduct_cells` (NumPy-free Grid loop); export `aggregates.xl_sumproduct` is a thin raise wrapper
- Evaluator `runtime.math.xl_sumproduct` may still materialize large grids for the NumPy fast path
- Update `parity.mdc` and `user_guide/03-evaluator.qmd`

## Out of scope (Phase 4)

- Drop `np.ndarray` from `CellValue` / rename meta helpers
- Remove empty `EAGER_MATERIALIZE_ARG_INDICES` table entirely

## Test plan

- [x] `uv run pytest tests/unit/core/test_aggregate_grids.py`
- [x] `uv run pytest tests/integration/evaluator/test_lazy_range_evaluator.py`
- [x] `uv run pytest tests/integration/exporter/test_lazy_range_migration.py`
- [x] `uv run pytest tests/integration/exporter/test_raise_based_errors.py`
- [ ] Broader CI suite / type-check after push

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e50f3163-caf8-43b0-8d81-af4e3b8357cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e50f3163-caf8-43b0-8d81-af4e3b8357cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

