### PR TITLE
perf(runtime): stream AVERAGEIF via Grid.at_flat pairing (#398)

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -93,6 +93,9 @@ Full-scan reductions share `core.coercions.flatten` (fail-fast reductions) and
 large SUMPRODUCT args for NumPy fastpath; export stays on the Grid loop).
 `COUNTIF` / `AVERAGEIF` walk via Grid rather than `flatten` so error-cell skip
 survives export embedding. Do not introduce a third traversal copy.
+`AVERAGEIF` pairs criteria/average grids with `at_flat` (no dual list
+materialization). Bare `Grid` values are **not** unwrapped by `flatten` — use
+`_iter_arg_cells` / `Grid.wrap` for selective cell walks (decision A in #398).
 
 `AND` / `OR` are **not** on the Grid bind list yet — multi-cell args return
 `#VALUE!` without evaluating siblings until cell-wise range semantics land

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -282,8 +282,35 @@ def averageif_cells(
     """
     if isinstance(criteria, XlError):
         return criteria
-    crit_vals = list(_iter_arg_cells(range_values))
     avg_source = average_range if average_range is not None else range_values
+    crit_grid = Grid.wrap(range_values)
+    avg_grid = Grid.wrap(avg_source)
+    if crit_grid is not None and avg_grid is not None:
+        if crit_grid.size != avg_grid.size:
+            return XlError.VALUE
+        paired_same_source = avg_source is range_values
+        total = 0.0
+        count = 0
+        for index0 in range(crit_grid.size):
+            if paired_same_source:
+                cell = cast(CellValue, crit_grid.at_flat(index0))
+                if not _value_matches_criteria(cell, criteria):
+                    continue
+                n = to_number(cell)
+            else:
+                crit_val = cast(CellValue, crit_grid.at_flat(index0))
+                if not _value_matches_criteria(crit_val, criteria):
+                    continue
+                n = to_number(cast(CellValue, avg_grid.at_flat(index0)))
+            if isinstance(n, XlError):
+                return n
+            total += float(n)
+            count += 1
+        if count == 0:
+            return XlError.DIV
+        return total / count
+
+    crit_vals = list(_iter_arg_cells(range_values))
     avg_vals = list(_iter_arg_cells(avg_source))
     if len(crit_vals) != len(avg_vals):
         return XlError.VALUE

--- a/tests/unit/core/test_aggregate_grids.py
+++ b/tests/unit/core/test_aggregate_grids.py
@@ -12,7 +12,7 @@ from excel_grapher.core.excel_function_meta import (
     grid_range_arg_indices,
 )
 from excel_grapher.core.grid import Range
-from excel_grapher.core.math_funcs import countif_cells, sum_cells
+from excel_grapher.core.math_funcs import averageif_cells, countif_cells, sum_cells
 from excel_grapher.core.sumproduct import sumproduct_cells
 
 
@@ -24,6 +24,7 @@ def test_full_scan_aggregates_bind_lazy_ranges_not_eager_ndarrays() -> None:
     assert 0 in grid_range_arg_indices("SUM")
     assert 0 in grid_range_arg_indices("SUMPRODUCT")
     assert 0 in grid_range_arg_indices("COUNTIF")
+    assert 0 in grid_range_arg_indices("AVERAGEIF")
 
 
 def test_flatten_walks_lazy_range_in_row_major_order() -> None:
@@ -127,3 +128,68 @@ def test_countif_skips_error_cells_in_lazy_range() -> None:
     rng = Range("S", 1, 1, 3, 1, resolve)
     assert countif_cells(cast(CellValue, rng), ">5") == 2
     assert calls == ["S!A1", "S!A2", "S!A3"]
+
+
+def test_averageif_over_lazy_range() -> None:
+    crit = Range(
+        "S",
+        1,
+        1,
+        3,
+        1,
+        lambda a: {"S!A1": "A", "S!A2": "B", "S!A3": "A"}[a],
+    )
+    avg = Range(
+        "S",
+        1,
+        2,
+        3,
+        2,
+        lambda a: {"S!B1": 10.0, "S!B2": 20.0, "S!B3": 30.0}[a],
+    )
+    assert averageif_cells(cast(CellValue, crit), "A", cast(CellValue, avg)) == 20.0
+
+
+def test_averageif_shared_range_not_walked_twice() -> None:
+    """Omitted average_range must not materialize the criteria range twice."""
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": 10, "S!A2": 3, "S!A3": 20}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert averageif_cells(cast(CellValue, rng), ">5") == 15.0
+    assert calls == ["S!A1", "S!A2", "S!A3"]
+
+
+def test_averageif_skips_error_cells_in_criteria_range() -> None:
+    crit = Range(
+        "S",
+        1,
+        1,
+        3,
+        1,
+        lambda a: {"S!A1": 10, "S!A2": XlError.DIV, "S!A3": 20}[a],
+    )
+    avg = Range("S", 1, 2, 3, 2, lambda a: {"S!B1": 1.0, "S!B2": 2.0, "S!B3": 3.0}[a])
+    assert averageif_cells(cast(CellValue, crit), ">5", cast(CellValue, avg)) == 2.0
+
+
+def test_averageif_propagates_error_in_average_range_for_match() -> None:
+    crit = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 10, "S!A2": 20}[a])
+    avg = Range(
+        "S",
+        1,
+        2,
+        2,
+        2,
+        lambda a: {"S!B1": XlError.DIV, "S!B2": 100.0}[a],
+    )
+    assert averageif_cells(cast(CellValue, crit), ">5", cast(CellValue, avg)) == XlError.DIV
+
+
+def test_averageif_length_mismatch_returns_value_error() -> None:
+    crit = Range("S", 1, 1, 2, 1, lambda _a: 1)
+    avg = Range("S", 1, 1, 3, 1, lambda _a: 1)
+    assert averageif_cells(cast(CellValue, crit), ">0", cast(CellValue, avg)) == XlError.VALUE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #398 — stream `AVERAGEIF` without dual list materialization and records the bare-`Grid` / `flatten` decision.

## Changes

### Stream `averageif_cells`

When both the criteria and average arguments wrap as `Grid` with matching `size`, the function now pairs cells via `at_flat` instead of:

```python
crit_vals = list(_iter_arg_cells(range_values))
avg_vals = list(_iter_arg_cells(avg_source))
```

- Criteria-range error cells are still skipped (`_value_matches_criteria`)
- Matched average-range errors still fail-fast via `to_number`
- When `average_range` is omitted (same source as criteria), each cell is fetched once per index
- Length mismatch still returns `#VALUE!`
- Scalar / non-grid fallback keeps the previous list+zip path

### `flatten` / bare `Grid` decision (A)

Documented in `parity.mdc`: bare `Grid` values are **not** unwrapped by `flatten`; selective cell walks use `_iter_arg_cells` / `Grid.wrap`. No change to `flatten` itself.

## Tests

Added unit tests in `tests/unit/core/test_aggregate_grids.py` covering:
- Lazy Range AVERAGEIF with separate criteria/average ranges
- Shared criteria range not walked twice when average range is omitted
- Criteria error skip semantics
- Average-range error propagation for matched cells
- Length mismatch → `#VALUE!`

Merged `main` (includes #397 AND/OR grid binding); resolved conflict in `test_aggregate_grids.py` by keeping assertions for `AVERAGEIF`, `AND`, and `OR`.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest` — 2076 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2c445a3-d48d-43b3-854e-c80eb0dfed19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2c445a3-d48d-43b3-854e-c80eb0dfed19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

