### PR TITLE
feat(evaluator): cell-wise AND/OR over lazy Range (#397)

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -94,9 +94,8 @@ large SUMPRODUCT args for NumPy fastpath; export stays on the Grid loop).
 `COUNTIF` / `AVERAGEIF` walk via Grid rather than `flatten` so error-cell skip
 survives export embedding. Do not introduce a third traversal copy.
 
-`AND` / `OR` are **not** on the Grid bind list yet — multi-cell args return
-`#VALUE!` without evaluating siblings until cell-wise range semantics land
-(#397).
+`AND` / `OR` walk cells via `Grid` with blank skip, first-error propagation,
+and short-circuit semantics (#397).
 
 Behavioral parity (evaluator ↔ export ↔ Excel) is unchanged by representation
 convergence. Remaining NumPy use in the evaluator hot path is confined to

--- a/excel_grapher/core/excel_function_meta.py
+++ b/excel_grapher/core/excel_function_meta.py
@@ -63,7 +63,8 @@ GRID_RANGE_ARG_INDICES: dict[str, frozenset[int]] = {
     "NPV": frozenset(range(1, 32)),
     "RANK": frozenset({1}),
     "SUMPRODUCT": _ALL_ARGS,
-    # AND/OR stay scalar until cell-wise range semantics land (see #397).
+    "AND": _ALL_ARGS,
+    "OR": _ALL_ARGS,
 }
 
 

--- a/excel_grapher/core/logic_funcs.py
+++ b/excel_grapher/core/logic_funcs.py
@@ -2,38 +2,61 @@
 
 from __future__ import annotations
 
-from .coercions import get_error, to_bool
+from collections.abc import Iterator
+from typing import cast
+
+from .coercions import to_bool
+from .grid import Grid
 from .types import CellValue, XlError
 
 __all__ = ["logical_and", "logical_not", "logical_or"]
 
 
+def _iter_logical_cells(arg: CellValue) -> Iterator[CellValue]:
+    """Yield scalar cells from a range/array argument in row-major order."""
+    grid = Grid.wrap(arg)
+    if grid is not None:
+        for cell in grid.iter_raw():
+            yield cast(CellValue, cell)
+        return
+    yield arg
+
+
+def _consume_logical_cells(
+    args: tuple[CellValue, ...],
+    *,
+    short_circuit_true: bool,
+) -> bool | XlError:
+    """Walk logical cells across arguments with Excel AND/OR semantics."""
+    found_logical = False
+    for arg in args:
+        for cell in _iter_logical_cells(arg):
+            if cell is None:
+                continue
+            if isinstance(cell, XlError):
+                return cell
+            found_logical = True
+            b = to_bool(cell)
+            if isinstance(b, XlError):
+                return b
+            if short_circuit_true:
+                if b:
+                    return True
+            elif not b:
+                return False
+    if not found_logical:
+        return XlError.VALUE
+    return not short_circuit_true
+
+
 def logical_and(*args: CellValue) -> bool | XlError:
-    """Return logical AND across arguments."""
-    err = get_error(*args)
-    if err is not None:
-        return err
-    for a in args:
-        b = to_bool(a)
-        if isinstance(b, XlError):
-            return b
-        if not b:
-            return False
-    return True
+    """Return logical AND across scalar and range arguments."""
+    return _consume_logical_cells(args, short_circuit_true=False)
 
 
 def logical_or(*args: CellValue) -> bool | XlError:
-    """Return logical OR across arguments."""
-    err = get_error(*args)
-    if err is not None:
-        return err
-    for a in args:
-        b = to_bool(a)
-        if isinstance(b, XlError):
-            return b
-        if b:
-            return True
-    return False
+    """Return logical OR across scalar and range arguments."""
+    return _consume_logical_cells(args, short_circuit_true=True)
 
 
 def logical_not(arg: CellValue) -> bool | XlError:

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -103,6 +103,9 @@ _SKIP_ERROR_PRECHECK = {
     # Criteria consumers: Excel skips error cells in the criteria range.
     "COUNTIF",
     "AVERAGEIF",
+    # Logical reductions: short-circuit and fail-fast over lazy ranges.
+    "AND",
+    "OR",
 }
 
 if TYPE_CHECKING:

--- a/tests/integration/evaluator/test_and_or_excel_parity.py
+++ b/tests/integration/evaluator/test_and_or_excel_parity.py
@@ -1,0 +1,35 @@
+"""AND/OR: evaluator matches live Excel on range scans (integration, slow).
+
+Complements evaluator ↔ codegen AND/OR tests. Requires xlwings or WSL/COM;
+skips cleanly when Excel automation is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.utils.excel_live_parity import LiveExcelCell, assert_evaluator_matches_live_excel
+
+
+@pytest.mark.slow
+def test_and_or_excel_parity_over_ranges_with_blanks_and_errors(tmp_path: Path) -> None:
+    assert_evaluator_matches_live_excel(
+        tmp_path=tmp_path,
+        sheet="S",
+        cells=(
+            LiveExcelCell("A1", value=True),
+            LiveExcelCell("A2", formula="=1/0"),
+            LiveExcelCell("A3", value=False),
+            LiveExcelCell("B1", formula="=AND(A1:A3)"),
+            LiveExcelCell("B2", formula="=OR(A1:A3)"),
+            LiveExcelCell("C1", value=None),
+            LiveExcelCell("C2", value=True),
+            LiveExcelCell("C3", value=None),
+            LiveExcelCell("D1", formula="=AND(C1:C3)"),
+            LiveExcelCell("D2", formula="=OR(C1:C3)"),
+        ),
+        targets=("S!B1", "S!B2", "S!D1", "S!D2"),
+        workbook_stem="and_or_ranges",
+    )

--- a/tests/integration/evaluator/test_lazy_range_evaluator.py
+++ b/tests/integration/evaluator/test_lazy_range_evaluator.py
@@ -297,13 +297,18 @@ def test_countif_skips_error_cells_in_range() -> None:
         assert ev.evaluate(["S!B1"]) == {"S!B1": 2}
 
 
-def test_and_or_reject_multi_cell_range_without_sibling_eval() -> None:
-    """AND/OR stay off the Grid bind list until cell-wise semantics (#397)."""
+def test_and_or_over_lazy_range_with_short_circuit_and_error() -> None:
+    """AND/OR bind lazy Range and short-circuit without evaluating trailing cells."""
     graph = _make_graph(
         _make_node("S!A1", None, True),
         _make_node("S!A2", "=1/0", None),
-        _make_node("S!A3", None, True),
+        _make_node("S!A3", None, False),
         _make_node("S!B1", "=AND(S!A1:S!A3)", None),
+        _make_node("S!B2", "=OR(S!A1:S!A3)", None),
+        _make_node("S!C1", None, False),
+        _make_node("S!C2", "=1/0", None),
+        _make_node("S!C3", None, True),
+        _make_node("S!D1", "=OR(S!C1:S!C3)", None),
     )
     seen: list[str] = []
 
@@ -311,10 +316,25 @@ def test_and_or_reject_multi_cell_range_without_sibling_eval() -> None:
         seen.append(address)
 
     with FormulaEvaluator(graph, on_cell_evaluated=_track) as ev:
-        assert ev.evaluate(["S!B1"]) == {"S!B1": XlError.VALUE}
-        assert "S!A1" not in ev._cache
-        assert "S!A2" not in ev._cache
-    assert "S!A2" not in seen
+        assert ev.evaluate(["S!B1", "S!B2", "S!D1"]) == {
+            "S!B1": XlError.DIV,
+            "S!B2": True,
+            "S!D1": XlError.DIV,
+        }
+    assert "S!A3" not in seen
+    assert "S!C3" not in seen
+
+
+def test_and_or_skip_blanks_in_range() -> None:
+    graph = _make_graph(
+        _make_node("S!A1", None, None),
+        _make_node("S!A2", None, True),
+        _make_node("S!A3", None, None),
+        _make_node("S!B1", "=AND(S!A1:S!A3)", None),
+        _make_node("S!B2", "=OR(S!A1:S!A3)", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!B1", "S!B2"]) == {"S!B1": True, "S!B2": True}
 
 
 def test_sum_does_not_double_evaluate_via_ast_precheck() -> None:

--- a/tests/integration/exporter/test_lazy_range_migration.py
+++ b/tests/integration/exporter/test_lazy_range_migration.py
@@ -100,6 +100,20 @@ def test_sum_over_range_with_error_produces_error_code() -> None:
     assert result.generated_results["S!B1"] == XlError.DIV
 
 
+def test_and_or_over_lazy_range_codegen_parity() -> None:
+    """AND/OR over ranges stay aligned between evaluator and exported code."""
+    graph = _make_graph(
+        _make_node("S!A1", None, True),
+        _make_node("S!A2", None, False),
+        _make_node("S!A3", None, True),
+        _make_node("S!B1", "=AND(S!A1:S!A3)", None),
+        _make_node("S!B2", "=OR(S!A1:S!A3)", None),
+    )
+    result = assert_codegen_matches_evaluator(graph, ["S!B1", "S!B2"])
+    assert result.generated_results["S!B1"] is False
+    assert result.generated_results["S!B2"] is True
+
+
 def test_dynamic_offset_range_consumed_by_sum() -> None:
     """Dynamic OFFSET returns a lazy range consumed by SUM."""
     graph = _make_graph(

--- a/tests/unit/core/test_aggregate_grids.py
+++ b/tests/unit/core/test_aggregate_grids.py
@@ -17,13 +17,15 @@ from excel_grapher.core.sumproduct import sumproduct_cells
 
 
 def test_full_scan_aggregates_bind_lazy_ranges_not_eager_ndarrays() -> None:
-    """Phase 3 drops eager materialization for SUM / SUMPRODUCT / COUNTIF."""
+    """Phase 3 drops eager materialization for SUM / SUMPRODUCT / COUNTIF / AND / OR."""
     assert eager_materialize_arg_indices("SUM") == frozenset()
     assert eager_materialize_arg_indices("SUMPRODUCT") == frozenset()
     assert eager_materialize_arg_indices("COUNTIF") == frozenset()
     assert 0 in grid_range_arg_indices("SUM")
     assert 0 in grid_range_arg_indices("SUMPRODUCT")
     assert 0 in grid_range_arg_indices("COUNTIF")
+    assert 0 in grid_range_arg_indices("AND")
+    assert 0 in grid_range_arg_indices("OR")
 
 
 def test_flatten_walks_lazy_range_in_row_major_order() -> None:

--- a/tests/unit/core/test_logic_funcs.py
+++ b/tests/unit/core/test_logic_funcs.py
@@ -1,0 +1,137 @@
+"""Unit tests for cell-wise AND/OR over lazy Range (#397)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.excel_function_meta import grid_range_arg_indices
+from excel_grapher.core.grid import Range
+from excel_grapher.core.logic_funcs import logical_and, logical_or
+
+
+def test_and_or_bind_lazy_ranges() -> None:
+    assert 0 in grid_range_arg_indices("AND")
+    assert 0 in grid_range_arg_indices("OR")
+
+
+def test_logical_and_over_lazy_range() -> None:
+    rng = Range("S", 1, 1, 3, 1, lambda a: {"S!A1": True, "S!A2": True, "S!A3": True}[a])
+    assert logical_and(cast(CellValue, rng)) is True
+
+
+def test_logical_and_short_circuits_on_false_without_trailing_cells() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": True, "S!A2": False, "S!A3": True}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert logical_and(cast(CellValue, rng)) is False
+    assert calls == ["S!A1", "S!A2"]
+
+
+def test_logical_or_short_circuits_on_true_without_trailing_cells() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": False, "S!A2": True, "S!A3": False}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert logical_or(cast(CellValue, rng)) is True
+    assert calls == ["S!A1", "S!A2"]
+
+
+def test_logical_and_propagates_first_error_in_range() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": True, "S!A2": XlError.DIV, "S!A3": False}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert logical_and(cast(CellValue, rng)) == XlError.DIV
+    assert calls == ["S!A1", "S!A2"]
+
+
+def test_logical_or_propagates_first_error_in_range() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": False, "S!A2": XlError.DIV, "S!A3": True}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert logical_or(cast(CellValue, rng)) == XlError.DIV
+    assert calls == ["S!A1", "S!A2"]
+
+
+def test_logical_and_skips_blank_cells() -> None:
+    rng = Range(
+        "S",
+        1,
+        1,
+        3,
+        1,
+        lambda a: {"S!A1": None, "S!A2": True, "S!A3": None}[a],
+    )
+    assert logical_and(cast(CellValue, rng)) is True
+
+
+def test_logical_or_skips_blank_cells() -> None:
+    rng = Range(
+        "S",
+        1,
+        1,
+        3,
+        1,
+        lambda a: {"S!A1": None, "S!A2": False, "S!A3": None}[a],
+    )
+    assert logical_or(cast(CellValue, rng)) is False
+
+
+def test_logical_and_all_blanks_returns_value_error() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda _a: None)
+    assert logical_and(cast(CellValue, rng)) == XlError.VALUE
+
+
+def test_logical_or_all_blanks_returns_value_error() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda _a: None)
+    assert logical_or(cast(CellValue, rng)) == XlError.VALUE
+
+
+def test_logical_and_invalid_text_returns_value_error() -> None:
+    rng = Range("S", 1, 1, 1, 1, lambda _a: "not-a-bool")
+    assert logical_and(cast(CellValue, rng)) == XlError.VALUE
+
+
+def test_logical_and_coerces_numbers() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 1, "S!A2": 0}[a])
+    assert logical_and(cast(CellValue, rng)) is False
+
+
+def test_logical_or_coerces_numbers() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 0, "S!A2": 5}[a])
+    assert logical_or(cast(CellValue, rng)) is True
+
+
+def test_logical_and_scalar_args_unchanged() -> None:
+    assert logical_and(True, True) is True
+    assert logical_and(True, False) is False
+    assert logical_or(True, False) is True
+    assert logical_or(False, False) is False
+
+
+def test_logical_and_over_ndarray_matches_range() -> None:
+    values = {"S!A1": 1, "S!A2": 0, "S!A3": 2}
+
+    def resolve(address: str) -> CellValue:
+        return values[address]
+
+    lazy = Range("S", 1, 1, 3, 1, resolve)
+    eager = np.array([[1], [0], [2]], dtype=object)
+    assert logical_and(cast(CellValue, lazy)) == logical_and(eager) is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #397.

## Summary

Implements Excel-correct cell-wise `AND`/`OR` over lazy `Range`, nested lists, and ndarrays, completing the #336 Phase 3 follow-up for logical functions.

## Changes

- **`core/logic_funcs.py`**: Walk cells in row-major order via `Grid`; skip blanks; propagate the first error; coerce numbers/text with `to_bool`; short-circuit on first decisive FALSE (AND) or TRUE (OR); return `#VALUE!` when no logical values remain.
- **`excel_function_meta.py`**: Re-add `AND`/`OR` to `GRID_RANGE_ARG_INDICES`.
- **`evaluator.py`**: Add `AND`/`OR` to `_SKIP_ERROR_PRECHECK` so the AST does not force a full range scan before the function runs.
- **Tests**: Unit coverage in `test_logic_funcs.py`, lazy-range evaluator/codegen parity, and a run-if-available live-Excel parity test (`@pytest.mark.slow`).

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest` — 2071 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9ebaf1f-6501-4464-9dc5-651ceb0304e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9ebaf1f-6501-4464-9dc5-651ceb0304e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

