### PR TITLE
docs(export): clarify INDEX/OFFSET ref vs value contract

### DIFF
--- a/excel_grapher/exporter/export_runtime/offset.py
+++ b/excel_grapher/exporter/export_runtime/offset.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TypeAlias, cast
 
 import fastpyxl.utils.cell
 
@@ -15,7 +15,18 @@ from excel_grapher.runtime.cache import EvalContext, _parse_range_address, xl_ce
 from .ranges import Range
 from .values import CellValue, ExcelRange, Scalar, as_scalar
 
-__all__ = ["xl_index_ref", "xl_offset", "xl_offset_ref", "xl_range", "xl_range_rows"]
+__all__ = [
+    "OffsetRefInfo",
+    "xl_index_ref",
+    "xl_offset",
+    "xl_offset_ref",
+    "xl_range",
+    "xl_range_rows",
+]
+
+# Address metadata for the INDEX/OFFSET reference pair, not a worksheet value.
+# Single-cell: (sheet, row, col). Rectangle: (sheet, r1, c1, r2, c2).
+OffsetRefInfo: TypeAlias = tuple[str, int, int] | tuple[str, int, int, int, int]
 
 
 def _format_address(sheet: str, row: int, col: int) -> str:
@@ -39,9 +50,7 @@ def _ctx_range(ctx: EvalContext, sheet: str, r1: int, c1: int, r2: int, c2: int)
     return Range(sheet, r1, c1, r2, c2, resolve)
 
 
-def _range_from_ref_info(
-    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
-) -> ExcelRange:
+def _range_from_ref_info(ref: ExcelRange | OffsetRefInfo) -> ExcelRange:
     """Normalize generated reference metadata into an `ExcelRange`."""
     if isinstance(ref, ExcelRange):
         return ref
@@ -87,11 +96,18 @@ def _export_range_from_geometry(
 
 
 def xl_index_ref(
-    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
+    ref: ExcelRange | OffsetRefInfo,
     row_num: CellValue | None,
     col_num: CellValue | None,
-) -> tuple[str, int, int] | tuple[str, int, int, int, int]:
-    """Return INDEX reference metadata, raising on Excel reference errors."""
+) -> OffsetRefInfo:
+    """Return INDEX address metadata for OFFSET, not a cell value.
+
+    Pass the result to `xl_offset` (or `xl_offset_ref`). Scalar INDEX reads are
+    emitted as `xl_offset(ctx, xl_index_ref(...), 0, 0)`.
+
+    Raises:
+        XlErrorException: On Excel reference errors such as `#REF!`.
+    """
     out = index_excel_range(
         _range_from_ref_info(ref),
         _as_addressing_scalar(row_num),
@@ -105,13 +121,21 @@ def xl_index_ref(
 
 
 def xl_offset_ref(
-    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
+    ref: ExcelRange | OffsetRefInfo,
     rows: CellValue,
     cols: CellValue,
     height: CellValue | None = None,
     width: CellValue | None = None,
 ) -> ExcelRange:
-    """Return OFFSET reference metadata, raising on Excel reference errors."""
+    """Return OFFSET address metadata, raising on Excel reference errors.
+
+    Unlike `xl_offset`, this does not evaluate cells — it only relocates the
+    reference rectangle. `ref` is typically an `OffsetRefInfo` from
+    `xl_index_ref` or a literal range tuple.
+
+    Raises:
+        XlErrorException: On Excel reference errors such as `#REF!`.
+    """
     base_range = _range_from_ref_info(ref)
 
     class _UnboundedSheet:
@@ -138,17 +162,22 @@ def xl_offset_ref(
 
 def xl_offset(
     ctx: EvalContext,
-    ref_info: tuple[str, int, int] | tuple[str, int, int, int, int] | XlError,
+    ref_info: OffsetRefInfo,
     rows: CellValue,
     cols: CellValue,
     height: CellValue | None = None,
     width: CellValue | None = None,
 ) -> CellValue:
+    """Evaluate OFFSET from `ref_info`, returning a cell value or range.
+
+    `ref_info` is typically produced by `xl_index_ref`. For a scalar INDEX
+    result use `rows=0`, `cols=0`.
+
+    Raises:
+        XlErrorException: On Excel reference or coercion errors.
+    """
     rr = _number_or_raise(rows)
     cc = _number_or_raise(cols)
-
-    if isinstance(ref_info, XlError):
-        raise XlErrorException(ref_info)
 
     match ref_info:
         case (sheet, base_row, base_col):

--- a/excel_grapher/runtime/offset_runtime.py
+++ b/excel_grapher/runtime/offset_runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import TypeAlias, cast
 
 import fastpyxl.utils.cell
 
@@ -9,7 +9,11 @@ from excel_grapher.core.addressing import index_excel_range, offset_range
 
 from .cache import EvalContext, xl_cell
 
-__all__ = ["xl_index_ref", "xl_offset", "xl_offset_ref"]
+__all__ = ["OffsetRefInfo", "xl_index_ref", "xl_offset", "xl_offset_ref"]
+
+# Address metadata for the INDEX/OFFSET reference pair, not a worksheet value.
+# Single-cell: (sheet, row, col). Rectangle: (sheet, r1, c1, r2, c2).
+OffsetRefInfo: TypeAlias = tuple[str, int, int] | tuple[str, int, int, int, int]
 
 
 def _quote_sheet_if_needed(sheet: str) -> str:
@@ -25,12 +29,17 @@ def _format_address(sheet: str, row: int, col: int) -> str:
 
 
 def xl_offset_ref(
-    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
+    ref: ExcelRange | OffsetRefInfo,
     rows: CellValue,
     cols: CellValue,
     height: CellValue | None = None,
     width: CellValue | None = None,
 ) -> ExcelRange | XlError:
+    """Return OFFSET address metadata without evaluating cells.
+
+    `ref` is typically an `OffsetRefInfo` from `xl_index_ref` or a literal
+    range tuple. Returns `XlError` on reference errors.
+    """
     if isinstance(ref, ExcelRange):
         base_range = ref
     else:
@@ -74,11 +83,16 @@ def xl_offset_ref(
 
 
 def xl_index_ref(
-    ref: ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int],
+    ref: ExcelRange | OffsetRefInfo,
     row_num: CellValue | None,
     col_num: CellValue | None,
-) -> ExcelRange | tuple[str, int, int] | tuple[str, int, int, int, int] | XlError:
-    """INDEX semantics that return a reference suitable for OFFSET."""
+) -> OffsetRefInfo | XlError:
+    """Return INDEX address metadata for OFFSET, not a cell value.
+
+    Pass the result to `xl_offset` (or `xl_offset_ref`). Scalar INDEX reads use
+    `xl_offset(ctx, xl_index_ref(...), 0, 0)`. Returns `XlError` on reference
+    errors.
+    """
     if isinstance(ref, ExcelRange):
         base = ref
     else:
@@ -100,12 +114,18 @@ def xl_index_ref(
 
 def xl_offset(
     ctx: EvalContext,
-    ref_info: tuple[str, int, int] | tuple[str, int, int, int, int] | XlError,
+    ref_info: OffsetRefInfo | XlError,
     rows: CellValue,
     cols: CellValue,
     height: CellValue | None = None,
     width: CellValue | None = None,
 ) -> CellValue:
+    """Evaluate OFFSET from `ref_info`, returning a cell value or nested grid.
+
+    `ref_info` is typically produced by `xl_index_ref`. For a scalar INDEX
+    result use `rows=0`, `cols=0`. Propagates `XlError` from `ref_info` or
+    argument coercion.
+    """
     rr = to_number(rows)
     if isinstance(rr, XlError):
         return rr

--- a/tests/unit/exporter/test_offset_ref_contract.py
+++ b/tests/unit/exporter/test_offset_ref_contract.py
@@ -1,0 +1,60 @@
+"""Contract tests for INDEX/OFFSET reference pairing in export runtime."""
+
+from __future__ import annotations
+
+import typing
+
+from excel_grapher.exporter.export_runtime.offset import (
+    OffsetRefInfo,
+    xl_index_ref,
+    xl_offset,
+    xl_offset_ref,
+)
+from excel_grapher.exporter.export_runtime.values import ExcelRange
+from excel_grapher.runtime.cache import EvalContext
+
+
+def test_xl_index_ref_returns_address_metadata_not_cell_value() -> None:
+    values = {
+        "Sheet1!B2": 42.0,
+        "Sheet1!B3": 99.0,
+        "Sheet1!C2": 7.0,
+    }
+
+    def resolver(address: str):
+        if address in values:
+            return lambda ctx: values[address]
+        return None
+
+    ctx = EvalContext(inputs={}, resolver=resolver)
+
+    ref = xl_index_ref(("Sheet1", 2, 2, 3, 3), 1.0, 1.0)
+    assert ref == ("Sheet1", 2, 2)
+    assert xl_offset(ctx, ref, 0.0, 0.0) == 42.0
+
+
+def test_xl_index_ref_and_xl_offset_docstrings_describe_pairing() -> None:
+    assert xl_index_ref.__doc__ is not None
+    assert "not a cell value" in xl_index_ref.__doc__.lower()
+    assert "xl_offset" in xl_index_ref.__doc__
+
+    assert xl_offset.__doc__ is not None
+    assert "xl_index_ref" in xl_offset.__doc__
+    assert "cell value" in xl_offset.__doc__.lower()
+
+
+def test_offset_ref_info_annotations_use_named_alias_not_cell_value() -> None:
+    index_hints = typing.get_type_hints(xl_index_ref)
+    offset_hints = typing.get_type_hints(xl_offset)
+    offset_ref_hints = typing.get_type_hints(xl_offset_ref)
+
+    assert index_hints["return"] is OffsetRefInfo
+    assert offset_hints["ref_info"] is OffsetRefInfo
+    assert offset_hints["return"] is not OffsetRefInfo
+    assert xl_offset.__annotations__["return"] == "CellValue"
+    assert offset_ref_hints["return"] is ExcelRange
+
+    # Raise-only export API: refs are address metadata, not error sentinels or values.
+    assert "XlError" not in xl_index_ref.__annotations__["return"]
+    assert "XlError" not in xl_offset.__annotations__["ref_info"]
+    assert "CellValue" not in xl_index_ref.__annotations__["return"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #405.

## Summary

Scalar INDEX exports are `xl_offset(ctx, xl_index_ref(...), 0, 0)`. The public stubs understated that `xl_index_ref` returns address metadata (not a cell value), and `xl_offset` had no docstring — enough for LLM refactor tooling to emit bare `return xl_index_ref(...)` and fail parity.

## Changes

- Introduce `OffsetRefInfo` alias for `(sheet, row, col)` / `(sheet, r1, c1, r2, c2)` metadata
- Document `xl_index_ref` → `xl_offset` / `xl_offset_ref` pairing (export + grapher runtimes)
- Tighten annotations: export `xl_offset.ref_info` is `OffsetRefInfo` (drop vestigial `XlError`); grapher `xl_index_ref` no longer claims an unused `ExcelRange` return
- Contract tests for docs, annotations, and the MCVE pairing

No behavioral change intended — types and docs only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4033babd-6143-4797-88ec-df6cdd8b8e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4033babd-6143-4797-88ec-df6cdd8b8e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

