### PR TITLE
feat: make NumPy an optional fast extra (#403)

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -87,7 +87,8 @@ boundary. Element-wise operators live in `excel_grapher.core.operator_maps`
 with the same adapter pattern (`core.operators` / `export_runtime.operators`).
 Full-scan reductions share `core.coercions.flatten` (fail-fast reductions) and
 `core.sumproduct.sumproduct_cells` (`runtime/math` may optionally materialize
-large SUMPRODUCT args for NumPy fastpath; export stays on the Grid loop).
+large SUMPRODUCT args for the NumPy fastpath when the `fast` extra is installed;
+export stays on the Grid loop).
 `COUNTIF` / `AVERAGEIF` walk via Grid rather than `flatten` so error-cell skip
 survives export embedding. Do not introduce a third traversal copy.
 `AVERAGEIF` pairs criteria/average grids with `at_flat` (no dual list
@@ -98,9 +99,12 @@ materialization). Bare `Grid` values are **not** unwrapped by `flatten` — use
 and short-circuit semantics (#397).
 
 Behavioral parity (evaluator ↔ export ↔ Excel) is unchanged by representation
-convergence. Remaining NumPy use in the evaluator hot path is confined to
-optional operator / SUMPRODUCT fast paths (explicit materialization when a Grid
-is large enough). Binary range operands and aggregate args bind lazy `Range`.
+convergence. NumPy is an optional accelerator (`excel-grapher[fast]`), not part
+of `CellValue`. Remaining NumPy use in the evaluator hot path is confined to
+operator / SUMPRODUCT fast paths (explicit materialization when a Grid is large
+enough and NumPy is installed). Binary range operands and aggregate args bind
+lazy `Range`. Without NumPy, the same semantics use shared Grid / nested-list
+loops.
 
 ## Layered semantics: core, runtime, and export_runtime
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
   test-no-numpy:
     name: Test without NumPy (default install)
     runs-on: ubuntu-latest
+    env:
+      # Isolate from the default venv so pandas/matplotlib (dev) cannot pull NumPy back in.
+      UV_PROJECT_ENVIRONMENT: .venv-no-numpy
 
     steps:
       - uses: actions/checkout@v4
@@ -57,13 +60,13 @@ jobs:
         with:
           python-version-file: pyproject.toml
 
-      - name: Install dependencies without fast extra
-        # Default package path: no NumPy. Keep other optional extras available for
-        # graph/viz tests that are independent of the operator accelerator.
-        run: uv sync --dev --extra networkx --extra viz
+      - name: Install package without NumPy
+        # Default install path: no `fast` / no NumPy-pulling packages (pandas, matplotlib).
+        # `--no-dev` alone is not enough: `uv run` would re-sync the default `dev` group.
+        run: uv sync --no-dev --group test-core --extra networkx --extra viz
 
       - name: Verify NumPy is not installed
-        run: uv run python -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('numpy') is None else 1)"
+        run: uv run --no-sync python -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('numpy') is None else 1)"
 
       - name: Run correctness suite without NumPy
-        run: uv run pytest
+        run: uv run --no-sync pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  test-no-numpy:
+    name: Test without NumPy (default install)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies without fast extra
+        # Default package path: no NumPy. Keep other optional extras available for
+        # graph/viz tests that are independent of the operator accelerator.
+        run: uv sync --dev --extra networkx --extra viz
+
+      - name: Verify NumPy is not installed
+        run: uv run python -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('numpy') is None else 1)"
+
+      - name: Run correctness suite without NumPy
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ Released under the [MIT license](LICENSE). Install from GitHub:
 **Using `uv` (recommended):**
 
 ```bash
-# Basic install
+# Basic install (NumPy-free)
 uv add git+https://github.com/Teal-Insights/excel-grapher
+
+# With vectorized operator / SUMPRODUCT acceleration
+uv add "excel-grapher[fast] @ git+https://github.com/Teal-Insights/excel-grapher"
 
 # With NetworkX support
 uv add "excel-grapher[networkx] @ git+https://github.com/Teal-Insights/excel-grapher"
 
-# With all optional dependencies
+# With all optional dependencies (includes `fast`)
 uv add "excel-grapher[all] @ git+https://github.com/Teal-Insights/excel-grapher"
 ```
 
@@ -58,8 +61,14 @@ uv add "excel-grapher[all] @ git+https://github.com/Teal-Insights/excel-grapher"
 pip install git+https://github.com/Teal-Insights/excel-grapher
 
 # With extras:
+pip install "excel-grapher[fast] @ git+https://github.com/Teal-Insights/excel-grapher"
 pip install "excel-grapher[networkx] @ git+https://github.com/Teal-Insights/excel-grapher"
+pip install "excel-grapher[all] @ git+https://github.com/Teal-Insights/excel-grapher"
 ```
+
+The default install is correct without NumPy. Install the **`fast`** extra when
+evaluating large workbooks and you want vectorized operator / `SUMPRODUCT`
+acceleration. Exported standalone code stays NumPy-free either way.
 
 ---
 

--- a/excel_grapher/core/coercions.py
+++ b/excel_grapher/core/coercions.py
@@ -6,16 +6,28 @@ from collections.abc import Iterable, Iterator
 from datetime import date, datetime
 from typing import TypeVar, cast
 
-import numpy as np
-
 # Imported for isinstance checks; stripped when coercions are embedded (Range is
 # already inlined from core.grid.ranges ahead of this module).
+from excel_grapher.core.grid.grid import _as_nested_rows_from_ndarray
 from excel_grapher.core.grid.ranges import Range
 
 from .types import CellValue, ExcelRange, FormulaValue, XlError
 
 _EXCEL_EPOCH = datetime(1899, 12, 30)
 T = TypeVar("T")
+
+
+def _is_ndarray_like(value: object) -> bool:
+    """Duck-type NumPy ndarrays without importing NumPy.
+
+    Fast-path materialization buffers expose ``ndim`` / ``flat`` / ``tolist``.
+    Matches `Grid.wrap` / `_as_nested_rows_from_ndarray` so coercions stay
+    import-light for NumPy-free installs and exports.
+    """
+    if _as_nested_rows_from_ndarray(value) is not None:
+        return True
+    ndim = getattr(value, "ndim", None)
+    return isinstance(ndim, int) and ndim >= 1 and hasattr(value, "flat")
 
 
 def as_scalar(value: object) -> float | int | str | bool | XlError | None:
@@ -25,7 +37,7 @@ def as_scalar(value: object) -> float | int | str | bool | XlError | None:
     operands. Materialized ndarray buffers (fast-path internals) also collapse
     to `#VALUE!`. Does not evaluate cells inside a `Range`.
     """
-    if isinstance(value, (Range, ExcelRange, list, tuple, np.ndarray)):
+    if isinstance(value, (Range, ExcelRange, list, tuple)) or _is_ndarray_like(value):
         return XlError.VALUE
     return cast("float | int | str | bool | XlError | None", value)
 
@@ -163,8 +175,14 @@ def flatten(*args: object) -> Iterator[FormulaValue]:
     fast-path materialization buffers, not as persisted `CellValue` results.
     """
     for arg in args:
-        if isinstance(arg, np.ndarray):
-            yield from (v for v in arg.flat)
+        if _is_ndarray_like(arg):
+            flat = getattr(arg, "flat", None)
+            if flat is not None:
+                yield from (cast("FormulaValue", v) for v in flat)
+            else:
+                rows = _as_nested_rows_from_ndarray(arg)
+                assert rows is not None
+                yield from flatten(*rows)
             continue
         if isinstance(arg, Range):
             yield from arg.iter_raw()

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import math
+import numbers
 import re
 from collections.abc import Iterator
 from typing import TypeVar, cast
-
-import numpy as np
 
 from .coercions import (
     excel_casefold,
@@ -341,10 +340,7 @@ def large_kth(array: CellValue, k: CellValue) -> float | XlError:
             return v
         if v is None or isinstance(v, bool):
             continue
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            nums.append(float(v))
-            continue
-        if isinstance(v, (np.integer, np.floating)):
+        if isinstance(v, numbers.Real) and not isinstance(v, bool):
             nums.append(float(v))
     if kth > len(nums):
         return XlError.NUM
@@ -367,10 +363,7 @@ def rank_number(number: CellValue, ref: CellValue, order: CellValue = 0) -> int 
             return v
         if v is None or isinstance(v, bool):
             continue
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            nums.append(float(v))
-            continue
-        if isinstance(v, (np.integer, np.floating)):
+        if isinstance(v, numbers.Real) and not isinstance(v, bool):
             nums.append(float(v))
     if ascending:
         return 1 + sum(1 for v in nums if v < nn)

--- a/excel_grapher/core/numpy_support.py
+++ b/excel_grapher/core/numpy_support.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-try:
-    import numpy as np
-
-    HAS_NUMPY = True
-except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
-    np = None  # type: ignore[assignment]
-    HAS_NUMPY = False
+from importlib import import_module
+from types import ModuleType
 
 __all__ = ["HAS_NUMPY", "np"]
+
+
+def _try_import_numpy() -> ModuleType | None:
+    try:
+        return import_module("numpy")
+    except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
+        return None
+
+
+np: ModuleType | None = _try_import_numpy()
+HAS_NUMPY: bool = np is not None

--- a/excel_grapher/core/numpy_support.py
+++ b/excel_grapher/core/numpy_support.py
@@ -1,0 +1,13 @@
+"""Detect whether the optional NumPy accelerator (`fast` extra) is installed."""
+
+from __future__ import annotations
+
+try:
+    import numpy as np
+
+    HAS_NUMPY = True
+except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
+    np = None  # type: ignore[assignment]
+    HAS_NUMPY = False
+
+__all__ = ["HAS_NUMPY", "np"]

--- a/excel_grapher/core/operator_thresholds.py
+++ b/excel_grapher/core/operator_thresholds.py
@@ -1,0 +1,6 @@
+"""Shared size thresholds for optional operator / SUMPRODUCT acceleration."""
+
+from __future__ import annotations
+
+# Arrays with at least this many cells may materialize for the NumPy fast path.
+MIN_OPERATOR_FASTPATH_CELLS = 64

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -9,24 +9,20 @@ Lazy ``Range`` / nested-list operands use shared ``operator_maps`` (same loops a
 export ``xl_map_*``). Large grids materialize once at this boundary and try
 ``operators_fastpath``; on a miss the same arrays feed ``reference_*_array``
 rather than walking the ``Range`` a second time.
+
+When the optional ``fast`` extra (NumPy) is not installed, large-grid
+materialization is skipped and callers fall through to ``operator_maps``.
 """
 
 from __future__ import annotations
 
-from typing import cast
-
-import numpy as np
+from typing import Any, cast
 
 from .coercions import to_number
 from .grid import Grid
 from .grid.grid import _as_nested_rows_from_ndarray
 from .operator_maps import map_arithmetic, map_compare, map_concat, map_unary
-from .operators_fastpath import (
-    MIN_OPERATOR_FASTPATH_CELLS,
-    try_fastpath_arithmetic_array,
-    try_fastpath_compare_array,
-    try_fastpath_concat_array,
-)
+from .operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from .operators_reference import (
     apply_arithmetic,
     compare_scalars,
@@ -36,6 +32,24 @@ from .operators_reference import (
     reference_concat_array,
 )
 from .types import CellValue, FormulaValue, XlError
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
+    np = None  # type: ignore[assignment]
+
+if np is not None:
+    from .operators_fastpath import (
+        try_fastpath_arithmetic_array,
+        try_fastpath_compare_array,
+        try_fastpath_concat_array,
+    )
+else:  # pragma: no cover - exercised when the `fast` extra is absent
+    from .operators_fastpath_stub import (
+        try_fastpath_arithmetic_array,
+        try_fastpath_compare_array,
+        try_fastpath_concat_array,
+    )
 
 
 def _is_grid_operand(value: object) -> bool:
@@ -50,7 +64,8 @@ def _as_cell_result(value: object) -> FormulaValue:
     return cast(FormulaValue, value)
 
 
-def _materialize_grid(grid: Grid) -> np.ndarray:
+def _materialize_grid(grid: Grid) -> Any:
+    assert np is not None
     return np.array(
         [[grid.at(row0, col0) for col0 in range(grid.ncols)] for row0 in range(grid.nrows)],
         dtype=object,
@@ -70,7 +85,13 @@ def _apply_large_grid_binary(
     cannot form a grid pair) so the caller can use shared ``map_*`` loops.
     When this path materializes, a fastpath miss reuses the same arrays via
     ``reference_*_array`` — it does not fall through to a second Range walk.
+
+    Without NumPy (`fast` extra), always returns `None` so callers use
+    ``operator_maps``.
     """
+    if np is None:
+        return None
+
     left_grid = Grid.wrap(left)
     right_grid = Grid.wrap(right)
     if left_grid is None and right_grid is None:

--- a/excel_grapher/core/operators.py
+++ b/excel_grapher/core/operators.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 from .coercions import to_number
 from .grid import Grid
 from .grid.grid import _as_nested_rows_from_ndarray
+from .numpy_support import np
 from .operator_maps import map_arithmetic, map_compare, map_concat, map_unary
 from .operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from .operators_reference import (
@@ -32,11 +33,6 @@ from .operators_reference import (
     reference_concat_array,
 )
 from .types import CellValue, FormulaValue, XlError
-
-try:
-    import numpy as np
-except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
-    np = None  # type: ignore[assignment]
 
 if np is not None:
     from .operators_fastpath import (

--- a/excel_grapher/core/operators_fastpath.py
+++ b/excel_grapher/core/operators_fastpath.py
@@ -13,9 +13,9 @@ from dataclasses import dataclass
 import numpy as np
 
 from .coercions import excel_casefold, to_number, to_string, try_coerce_string_to_float
+from .operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from .types import XlError
 
-MIN_OPERATOR_FASTPATH_CELLS = 64
 _NUMERIC_CELL_TYPES = (int, float, np.integer, np.floating)
 _CASEFOLD_UFUNC = np.frompyfunc(excel_casefold, 1, 1)
 _TO_STRING_UFUNC = np.frompyfunc(to_string, 1, 1)

--- a/excel_grapher/core/operators_fastpath_stub.py
+++ b/excel_grapher/core/operators_fastpath_stub.py
@@ -1,34 +1,43 @@
-"""No-op operator fast-path stubs for exports that omit vectorized code."""
+"""No-op operator fast-path stubs when NumPy is absent or omitted from exports."""
 
 from __future__ import annotations
 
-import numpy as np
+from typing import Any
 
+from .operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from .types import XlError
+
+__all__ = [
+    "MIN_OPERATOR_FASTPATH_CELLS",
+    "try_fastpath_arithmetic_array",
+    "try_fastpath_compare_array",
+    "try_fastpath_concat_array",
+    "try_fastpath_sumproduct",
+]
 
 
 def try_fastpath_compare_array(
     op: str,
-    arr_left: np.ndarray,
-    arr_right: np.ndarray,
-) -> np.ndarray | XlError | None:
+    arr_left: Any,
+    arr_right: Any,
+) -> Any | XlError | None:
     return None
 
 
 def try_fastpath_arithmetic_array(
     op: str,
-    arr_left: np.ndarray,
-    arr_right: np.ndarray,
-) -> np.ndarray | XlError | None:
+    arr_left: Any,
+    arr_right: Any,
+) -> Any | XlError | None:
     return None
 
 
 def try_fastpath_concat_array(
-    arr_left: np.ndarray,
-    arr_right: np.ndarray,
-) -> np.ndarray | None:
+    arr_left: Any,
+    arr_right: Any,
+) -> Any | None:
     return None
 
 
-def try_fastpath_sumproduct(arrays: list[np.ndarray]) -> float | None:
+def try_fastpath_sumproduct(arrays: list[Any]) -> float | None:
     return None

--- a/excel_grapher/core/operators_reference.py
+++ b/excel_grapher/core/operators_reference.py
@@ -2,11 +2,15 @@
 
 These functions preserve the Sprint 0 semantics contract used as the golden
 reference when adding vectorized fast paths in later sprints.
+
+Array helpers lazily import NumPy so the default (no-`fast`) install can load
+this module without the accelerator. Scalar helpers stay NumPy-free and are
+shared with `operator_maps` / export.
 """
 
 from __future__ import annotations
 
-import numpy as np
+from typing import Any
 
 from .coercions import excel_casefold, to_number, to_string
 from .types import CellValue, FormulaValue, XlError
@@ -15,8 +19,10 @@ from .types import CellValue, FormulaValue, XlError
 def broadcast_pair(
     left: CellValue,
     right: CellValue,
-) -> tuple[np.ndarray, np.ndarray] | XlError:
+) -> tuple[Any, Any] | XlError:
     """Broadcast scalar/array operands to matching object ndarrays."""
+    import numpy as np
+
     if isinstance(left, XlError):
         return left
     if isinstance(right, XlError):
@@ -109,10 +115,12 @@ def apply_arithmetic(op: str, ln: float, rn: float) -> float | XlError:
 
 def reference_compare_array(
     op: str,
-    arr_left: np.ndarray,
-    arr_right: np.ndarray,
-) -> np.ndarray | XlError:
+    arr_left: Any,
+    arr_right: Any,
+) -> Any | XlError:
     """Element-wise comparison over broadcast object ndarrays (C-order, fail-fast)."""
+    import numpy as np
+
     result = np.empty(arr_left.shape, dtype=object)
     for indices in np.ndindex(arr_left.shape):
         cell = compare_scalars(op, arr_left[indices], arr_right[indices])
@@ -124,10 +132,12 @@ def reference_compare_array(
 
 def reference_arithmetic_array(
     op: str,
-    arr_left: np.ndarray,
-    arr_right: np.ndarray,
-) -> np.ndarray | XlError:
+    arr_left: Any,
+    arr_right: Any,
+) -> Any | XlError:
     """Element-wise arithmetic over broadcast object ndarrays (C-order, fail-fast)."""
+    import numpy as np
+
     result = np.empty(arr_left.shape, dtype=object)
     for indices in np.ndindex(arr_left.shape):
         ln = to_number(arr_left[indices])
@@ -160,18 +170,22 @@ def reference_arithmetic_array(
 
 
 def reference_concat_array(
-    arr_left: np.ndarray,
-    arr_right: np.ndarray,
-) -> np.ndarray:
+    arr_left: Any,
+    arr_right: Any,
+) -> Any:
     """Element-wise string concatenation over broadcast object ndarrays."""
+    import numpy as np
+
     result = np.empty(arr_left.shape, dtype=object)
     for indices in np.ndindex(arr_left.shape):
         result[indices] = concat_scalars(arr_left[indices], arr_right[indices])
     return result
 
 
-def reference_sumproduct_arrays(arrays: list[np.ndarray]) -> float | XlError:
+def reference_sumproduct_arrays(arrays: list[Any]) -> float | XlError:
     """Element-wise product reduction (C-order, fail-fast on ``to_number`` errors)."""
+    import numpy as np
+
     if not arrays:
         return 0.0
     shape = arrays[0].shape

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -22,7 +22,7 @@ from excel_grapher.core.address_keys import (
 from excel_grapher.core.address_keys import (
     normalize_key as normalize_address,
 )
-from excel_grapher.core.operators_fastpath import MIN_OPERATOR_FASTPATH_CELLS
+from excel_grapher.core.operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from excel_grapher.evaluator.errors import MissingNormalizedFormulaError
 from excel_grapher.evaluator.name_utils import (
     address_to_python_name,

--- a/excel_grapher/exporter/embed.py
+++ b/excel_grapher/exporter/embed.py
@@ -28,6 +28,7 @@ def _core_modules(*, include_operators_fastpath: bool) -> list[tuple[str, Path]]
         ("core.grid.ranges", grid_dir / "ranges.py"),
         ("core.grid.grid", grid_dir / "grid.py"),
         ("core.coercions", _CORE_DIR / "coercions.py"),
+        ("core.operator_thresholds", _CORE_DIR / "operator_thresholds.py"),
         ("core.operators_reference", _CORE_DIR / "operators_reference.py"),
         ("core.operators_fastpath", fastpath_path),
         ("core.operator_maps", _CORE_DIR / "operator_maps.py"),

--- a/excel_grapher/runtime/info.py
+++ b/excel_grapher/runtime/info.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+import numbers
 
 from excel_grapher.core import CellValue, XlError
 
@@ -8,7 +8,7 @@ __all__ = ["xl_isblank", "xl_iserror", "xl_isna", "xl_isnumber", "xl_istext", "x
 
 
 def xl_isnumber(value: CellValue) -> bool:
-    return not isinstance(value, bool) and isinstance(value, (int, float, np.integer, np.floating))
+    return not isinstance(value, bool) and isinstance(value, numbers.Real)
 
 
 def xl_istext(value: CellValue) -> bool:

--- a/excel_grapher/runtime/math.py
+++ b/excel_grapher/runtime/math.py
@@ -21,14 +21,10 @@ from excel_grapher.core.math_funcs import (
     stdev_cells,
     sum_cells,
 )
+from excel_grapher.core.numpy_support import np
 from excel_grapher.core.operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from excel_grapher.core.operators_reference import reference_sumproduct_arrays
 from excel_grapher.core.sumproduct import sumproduct_cells
-
-try:
-    import numpy as np
-except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
-    np = None  # type: ignore[assignment]
 
 if np is not None:
     from excel_grapher.core.operators_fastpath import try_fastpath_sumproduct

--- a/excel_grapher/runtime/math.py
+++ b/excel_grapher/runtime/math.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+import numbers
 
 from excel_grapher.core import CellValue, XlError, flatten
 from excel_grapher.core.grid import Grid
@@ -21,12 +21,19 @@ from excel_grapher.core.math_funcs import (
     stdev_cells,
     sum_cells,
 )
-from excel_grapher.core.operators_fastpath import (
-    MIN_OPERATOR_FASTPATH_CELLS,
-    try_fastpath_sumproduct,
-)
+from excel_grapher.core.operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 from excel_grapher.core.operators_reference import reference_sumproduct_arrays
 from excel_grapher.core.sumproduct import sumproduct_cells
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - exercised when the `fast` extra is absent
+    np = None  # type: ignore[assignment]
+
+if np is not None:
+    from excel_grapher.core.operators_fastpath import try_fastpath_sumproduct
+else:  # pragma: no cover - exercised when the `fast` extra is absent
+    from excel_grapher.core.operators_fastpath_stub import try_fastpath_sumproduct
 
 __all__ = [
     "xl_abs",
@@ -69,7 +76,7 @@ def xl_max(*args: CellValue) -> float | XlError:
 def xl_count(*args: CellValue) -> int:
     count = 0
     for v in flatten(*args):
-        if isinstance(v, (int, float, np.integer, np.floating)) and not isinstance(v, bool):
+        if isinstance(v, numbers.Real) and not isinstance(v, bool):
             count += 1
     return count
 
@@ -154,7 +161,7 @@ def xl_sumproduct(*args: CellValue) -> float | XlError:
         if (grid.nrows, grid.ncols) != shape:
             return XlError.VALUE
 
-    if grids[0].size >= MIN_OPERATOR_FASTPATH_CELLS:
+    if np is not None and grids[0].size >= MIN_OPERATOR_FASTPATH_CELLS:
         arrays = [
             np.array(
                 [[grid.at(row0, col0) for col0 in range(grid.ncols)] for row0 in range(grid.nrows)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,14 @@ upload_to_vcs_release = false
 
 
 [dependency-groups]
+# Minimal test runner for the default (NumPy-free) install CI job.
+# Intentionally excludes pandas/matplotlib/jupyter so NumPy is not pulled transitively.
+test-core = [
+    "pytest>=9.0.2",
+    "ruff>=0.14.0",
+    "ty>=0.0.9",
+    "xlsxwriter>=3.2.0",
+]
 dev = [
     "graphviz>=0.21",
     "great-docs>=0.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,13 @@ classifiers = [
 dependencies = [
     "fastpyxl",
     "jsonschema>=4.26.0",
-    "numpy>=1.24",
     "pyyaml>=6.0.3",
 ]
 
 [project.optional-dependencies]
+fast = [
+    "numpy>=1.24",
+]
 networkx = [
     "networkx>=3.0",
 ]
@@ -37,6 +39,7 @@ viz = [
     "graphviz>=0.20",
 ]
 all = [
+    "numpy>=1.24",
     "networkx>=3.0",
     "graphviz>=0.20",
 ]

--- a/tests/integration/exporter/test_codegen_export_modular.py
+++ b/tests/integration/exporter/test_codegen_export_modular.py
@@ -179,7 +179,7 @@ def test_codegen_generate_modules_has_no_ty_or_ruff_diagnostics(tmp_path: Path) 
         (pkg_root / filename).write_text(content, encoding="utf-8")
 
     ruff_fix = _run(
-        ["uv", "run", "ruff", "check", "--fix", str(pkg_root)],
+        ["uv", "run", "--no-sync", "ruff", "check", "--fix", str(pkg_root)],
         cwd=repo_root,
     )
     assert ruff_fix.returncode == 0, f"ruff --fix failed:\n{ruff_fix.stdout}\n{ruff_fix.stderr}"
@@ -188,6 +188,7 @@ def test_codegen_generate_modules_has_no_ty_or_ruff_diagnostics(tmp_path: Path) 
         [
             "uv",
             "run",
+            "--no-sync",
             "ty",
             "check",
             "--project",
@@ -201,7 +202,7 @@ def test_codegen_generate_modules_has_no_ty_or_ruff_diagnostics(tmp_path: Path) 
     assert ty.returncode == 0, f"ty failed:\n{ty.stdout}\n{ty.stderr}"
     assert ty.stderr.strip() == ""
 
-    ruff = _run(["uv", "run", "ruff", "check", str(pkg_root)], cwd=repo_root)
+    ruff = _run(["uv", "run", "--no-sync", "ruff", "check", str(pkg_root)], cwd=repo_root)
     assert ruff.returncode == 0, f"ruff failed after --fix:\n{ruff.stdout}\n{ruff.stderr}"
     assert ruff.stderr.strip() == ""
 
@@ -230,6 +231,7 @@ def test_codegen_generate_modules_has_no_ty_diagnostics_for_xlookup(tmp_path: Pa
         [
             "uv",
             "run",
+            "--no-sync",
             "ty",
             "check",
             "--project",
@@ -274,6 +276,7 @@ def test_codegen_generate_modules_has_no_ty_diagnostics_for_xludf_xlookup(
         [
             "uv",
             "run",
+            "--no-sync",
             "ty",
             "check",
             "--project",

--- a/tests/integration/exporter/test_codegen_export_no_diagnostics.py
+++ b/tests/integration/exporter/test_codegen_export_no_diagnostics.py
@@ -61,19 +61,28 @@ def test_codegen_export_has_no_ty_or_ruff_diagnostics(tmp_path: Path) -> None:
 
     try:
         ruff_fix = _run(
-            ["uv", "run", "ruff", "check", "--fix", str(export_file)],
+            ["uv", "run", "--no-sync", "ruff", "check", "--fix", str(export_file)],
             cwd=repo_root,
         )
         assert ruff_fix.returncode == 0, f"ruff --fix failed:\n{ruff_fix.stdout}\n{ruff_fix.stderr}"
 
         ty = _run(
-            ["uv", "run", "ty", "check", "--project", str(repo_root), str(export_file)],
+            [
+                "uv",
+                "run",
+                "--no-sync",
+                "ty",
+                "check",
+                "--project",
+                str(repo_root),
+                str(export_file),
+            ],
             cwd=repo_root,
         )
         assert ty.returncode == 0, f"ty failed:\n{ty.stdout}\n{ty.stderr}"
         assert ty.stderr.strip() == ""
 
-        ruff = _run(["uv", "run", "ruff", "check", str(export_file)], cwd=repo_root)
+        ruff = _run(["uv", "run", "--no-sync", "ruff", "check", str(export_file)], cwd=repo_root)
         assert ruff.returncode == 0, f"ruff failed after --fix:\n{ruff.stdout}\n{ruff.stderr}"
         assert ruff.stderr.strip() == ""
     finally:
@@ -95,7 +104,7 @@ def test_codegen_export_is_ruff_clean_without_fix(tmp_path: Path) -> None:
     export_file.write_text(code, encoding="utf-8")
 
     try:
-        ruff = _run(["uv", "run", "ruff", "check", str(export_file)], cwd=repo_root)
+        ruff = _run(["uv", "run", "--no-sync", "ruff", "check", str(export_file)], cwd=repo_root)
         assert ruff.returncode == 0, f"ruff failed:\n{ruff.stdout}\n{ruff.stderr}"
         assert ruff.stderr.strip() == ""
     finally:
@@ -118,7 +127,7 @@ def test_codegen_export_is_ruff_format_clean_without_fix(tmp_path: Path) -> None
 
     try:
         ruff_format = _run(
-            ["uv", "run", "ruff", "format", "--check", str(export_file)],
+            ["uv", "run", "--no-sync", "ruff", "format", "--check", str(export_file)],
             cwd=repo_root,
         )
         assert ruff_format.returncode == 0, (

--- a/tests/integration/exporter/test_series_bindings_api_helpers_module.py
+++ b/tests/integration/exporter/test_series_bindings_api_helpers_module.py
@@ -173,6 +173,9 @@ def test_helpers_module_is_ruff_clean_and_package_type_checks(
     split introduces); whole-package raw-Ruff hygiene (e.g. `api.py` import ordering) is
     tracked separately by issues #252/#253 and is intentionally not asserted here.
     """
+    # Generated helpers TYPE_CHECKING-import pandas/polars; ty needs them installed.
+    pytest.importorskip("pandas")
+    pytest.importorskip("polars")
     repo_root = Path(__file__).resolve().parents[3]
     files = _generate(workbook)
     pkg_root = tmp_path / "exported"
@@ -183,13 +186,14 @@ def test_helpers_module_is_ruff_clean_and_package_type_checks(
     def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
         return subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, check=False)
 
-    ruff = _run(["uv", "run", "ruff", "check", str(pkg_root / "_api_helpers.py")])
+    ruff = _run(["uv", "run", "--no-sync", "ruff", "check", str(pkg_root / "_api_helpers.py")])
     assert ruff.returncode == 0, f"_api_helpers.py is not Ruff-clean:\n{ruff.stdout}\n{ruff.stderr}"
 
     ty = _run(
         [
             "uv",
             "run",
+            "--no-sync",
             "ty",
             "check",
             "--project",

--- a/tests/integration/exporter/test_ty_regression_large_export_choose.py
+++ b/tests/integration/exporter/test_ty_regression_large_export_choose.py
@@ -61,7 +61,16 @@ def test_ty_check_generated_choose_has_no_diagnostics(tmp_path: Path) -> None:
 
     try:
         ty = _run(
-            ["uv", "run", "ty", "check", "--project", str(repo_root), str(export_file)],
+            [
+                "uv",
+                "run",
+                "--no-sync",
+                "ty",
+                "check",
+                "--project",
+                str(repo_root),
+                str(export_file),
+            ],
             cwd=repo_root,
         )
         assert ty.returncode == 0, f"ty failed:\n{ty.stdout}\n{ty.stderr}"

--- a/tests/integration/exporter/test_ty_regression_large_export_sum_range.py
+++ b/tests/integration/exporter/test_ty_regression_large_export_sum_range.py
@@ -61,7 +61,16 @@ def test_ty_check_generated_sum_range_has_no_diagnostics(tmp_path: Path) -> None
 
     try:
         ty = _run(
-            ["uv", "run", "ty", "check", "--project", str(repo_root), str(export_file)],
+            [
+                "uv",
+                "run",
+                "--no-sync",
+                "ty",
+                "check",
+                "--project",
+                str(repo_root),
+                str(export_file),
+            ],
             cwd=repo_root,
         )
         assert ty.returncode == 0, f"ty failed:\n{ty.stdout}\n{ty.stderr}"

--- a/tests/integration/exporter/test_web_viz_api.py
+++ b/tests/integration/exporter/test_web_viz_api.py
@@ -173,7 +173,7 @@ def test_write_web_viz_html_writes_html_file(tmp_path: Path) -> None:
 
 def test_write_web_viz_html_accepts_custom_template(tmp_path: Path) -> None:
     g = _build_two_component_digraph()
-    p = to_web_viz_payload(g, seed=1, layout="spring")
+    p = to_web_viz_payload(g, seed=1, layout="stratified_multipartite")
     pkg = "excel_grapher.grapher"
     ref = importlib.resources.files(pkg).joinpath("lightweight_viz_template.html")
     tpl = tmp_path / "tpl.html"
@@ -195,6 +195,8 @@ def test_write_web_viz_html_accepts_custom_template(tmp_path: Path) -> None:
     ("spring", "forceatlas2", "multipartite"),
 )
 def test_to_web_viz_payload_supports_networkx_layouts(layout: str) -> None:
+    # NetworkX spring/multipartite layouts import NumPy internally.
+    pytest.importorskip("numpy")
     g = _build_two_component_digraph()
     payload = to_web_viz_payload(g, layout=layout, seed=11)
     flat = lightweight_viz_flat(payload)
@@ -213,6 +215,8 @@ def test_to_web_viz_stratified_has_distinct_scc_ranks() -> None:
 
 
 def test_to_web_viz_payload_can_omit_module_overlay() -> None:
+    # Without module overlay, stratified fallback uses NetworkX multipartite (needs NumPy).
+    pytest.importorskip("numpy")
     g = _build_two_component_digraph()
     payload = to_web_viz_payload(g, include_module_overlay=False, seed=1)
     assert payload.overlays == ()

--- a/tests/integration/exporter/test_web_viz_payload_perf.py
+++ b/tests/integration/exporter/test_web_viz_payload_perf.py
@@ -26,6 +26,10 @@ def _chain_graph(n: int) -> nx.DiGraph:
 
 
 def test_to_web_viz_payload_100_node_chain_completes_under_time_budget() -> None:
+    # NetworkX multipartite layout imports NumPy internally.
+    import pytest
+
+    pytest.importorskip("numpy")
     g = _chain_graph(100)
     t0 = time.perf_counter()
     p = to_web_viz_payload(

--- a/tests/unit/core/operators_test_helpers.py
+++ b/tests/unit/core/operators_test_helpers.py
@@ -1,5 +1,6 @@
 """Shared helpers for operator semantics and fast-path parity tests."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/unit/core/operators_test_helpers.py
+++ b/tests/unit/core/operators_test_helpers.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, cast
 
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core.operators import (
     xl_add,

--- a/tests/unit/core/test_logic_funcs.py
+++ b/tests/unit/core/test_logic_funcs.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core import CellValue, XlError
 from excel_grapher.core.excel_function_meta import grid_range_arg_indices

--- a/tests/unit/core/test_logic_funcs.py
+++ b/tests/unit/core/test_logic_funcs.py
@@ -1,5 +1,6 @@
 """Unit tests for cell-wise AND/OR over lazy Range (#397)."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from typing import cast

--- a/tests/unit/core/test_operator_maps.py
+++ b/tests/unit/core/test_operator_maps.py
@@ -30,6 +30,7 @@ def test_map_arithmetic_over_lazy_range_visits_each_cell_once() -> None:
 
 
 def test_map_arithmetic_agrees_with_ndarray_xl_mul_when_fully_consumed() -> None:
+    np = pytest.importorskip("numpy")
     values = {"S!A1": 1.5, "S!A2": 2.5, "S!B1": 3.0, "S!B2": 4.0}
 
     def resolve(address: str) -> CellValue:
@@ -38,7 +39,6 @@ def test_map_arithmetic_agrees_with_ndarray_xl_mul_when_fully_consumed() -> None
     left = Range("S", 1, 1, 2, 1, resolve)
     right = Range("S", 1, 2, 2, 2, resolve)
     mapped = map_arithmetic("*", left, right)
-    import numpy as np
 
     arr = xl_mul(
         np.array([[1.5], [2.5]], dtype=object),
@@ -77,8 +77,9 @@ def test_large_range_fastpath_miss_materializes_cells_only_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When the vectorized fast path declines, reuse the materialized arrays."""
+    pytest.importorskip("numpy")
     from excel_grapher.core import operators as operators_mod
-    from excel_grapher.core.operators_fastpath import MIN_OPERATOR_FASTPATH_CELLS
+    from excel_grapher.core.operator_thresholds import MIN_OPERATOR_FASTPATH_CELLS
 
     nrows = MIN_OPERATOR_FASTPATH_CELLS
     calls: list[str] = []

--- a/tests/unit/core/test_operators_arithmetic_fastpath.py
+++ b/tests/unit/core/test_operators_arithmetic_fastpath.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher import DependencyGraph, FormulaEvaluator, Node, create_dependency_graph
 from excel_grapher.core.address_keys import parse_address

--- a/tests/unit/core/test_operators_arithmetic_fastpath.py
+++ b/tests/unit/core/test_operators_arithmetic_fastpath.py
@@ -1,5 +1,6 @@
 """Vectorized numeric arithmetic fast path for binary operators."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/core/test_operators_array.py
+++ b/tests/unit/core/test_operators_array.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core.operators import xl_concat, xl_eq, xl_mul, xl_pow
 from excel_grapher.core.types import XlError

--- a/tests/unit/core/test_operators_array.py
+++ b/tests/unit/core/test_operators_array.py
@@ -1,5 +1,6 @@
 """Element-wise array semantics for shared Excel operators."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/core/test_operators_baseline.py
+++ b/tests/unit/core/test_operators_baseline.py
@@ -23,8 +23,9 @@ baseline.
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core.operators import xl_concat, xl_div, xl_eq, xl_mul
 from excel_grapher.core.types import XlError

--- a/tests/unit/core/test_operators_baseline.py
+++ b/tests/unit/core/test_operators_baseline.py
@@ -21,6 +21,7 @@ multiply workloads while keeping gap-sized (~15 cell) paths within ~5% of this
 baseline.
 """
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/core/test_operators_compare_fastpath.py
+++ b/tests/unit/core/test_operators_compare_fastpath.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher import create_dependency_graph
 from excel_grapher.core.operators import xl_eq

--- a/tests/unit/core/test_operators_compare_fastpath.py
+++ b/tests/unit/core/test_operators_compare_fastpath.py
@@ -1,5 +1,6 @@
 """Vectorized comparison fast paths for binary operators."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/core/test_operators_concat_fastpath.py
+++ b/tests/unit/core/test_operators_concat_fastpath.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core.operators import xl_concat
 from excel_grapher.core.types import XlError

--- a/tests/unit/core/test_operators_concat_fastpath.py
+++ b/tests/unit/core/test_operators_concat_fastpath.py
@@ -1,5 +1,6 @@
 """Vectorized concat fast path for binary operators."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/core/test_operators_integration_perf.py
+++ b/tests/unit/core/test_operators_integration_perf.py
@@ -7,6 +7,9 @@ tracked in the opt-in ``@pytest.mark.slow`` modules:
 - ``test_operators_arithmetic_fastpath`` — ``xl_mul`` ~11x
 - ``test_operators_compare_fastpath`` — ``xl_gt`` ~5x, ``xl_eq`` ~1.5x
 - ``test_operators_concat_fastpath`` — ``xl_concat`` ~2.7x
+
+Perf budget assertions require the optional ``fast`` extra (NumPy). Correctness /
+parity cases still run without it.
 """
 
 from __future__ import annotations
@@ -17,13 +20,8 @@ from pathlib import Path
 import pytest
 
 from excel_grapher import FormulaEvaluator, create_dependency_graph
-from tests.bench.operators_bench import (
-    bench_workload,
-    build_workloads,
-    load_baseline_document,
-)
+from excel_grapher.core.numpy_support import HAS_NUMPY
 from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
-from tests.unit.core.test_operators_baseline import BASELINE_PATH
 from tests.unit.gaps.workbook_helpers import write_large_string_criteria_sumproduct
 
 LARGE_CRITERIA_ROWS = 10_000
@@ -32,6 +30,7 @@ SUMPRODUCT_10K_EVAL_TIME_BUDGET_SEC = 5.0
 SUMPRODUCT_CHAIN_1K_BASELINE_SPEEDUP_FACTOR = 1.25
 
 
+@pytest.mark.skipif(not HAS_NUMPY, reason="requires excel-grapher[fast] (NumPy)")
 def test_large_string_criteria_sumproduct_evaluator_under_time_budget(
     tmp_path: Path,
 ) -> None:
@@ -79,8 +78,12 @@ def test_large_string_criteria_sumproduct_10k_eval_codegen_parity(tmp_path: Path
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(not HAS_NUMPY, reason="requires excel-grapher[fast] (NumPy)")
 def test_sumproduct_criteria_chain_1k_beats_baseline() -> None:
     """Direct criteria-chain workload should exceed the Sprint 0 loop baseline."""
+    from tests.bench.operators_bench import bench_workload, build_workloads, load_baseline_document
+    from tests.unit.core.test_operators_baseline import BASELINE_PATH
+
     workload = next(w for w in build_workloads() if w.name == "sumproduct_criteria_chain_1k")
     baseline_doc = load_baseline_document(BASELINE_PATH)["workloads"]
     baseline_cps = next(

--- a/tests/unit/core/test_optional_numpy.py
+++ b/tests/unit/core/test_optional_numpy.py
@@ -29,9 +29,12 @@ def _top_level_numpy_imports(path: Path) -> list[str]:
             for alias in node.names:
                 if alias.name == "numpy" or alias.name.startswith("numpy."):
                     found.append(alias.name)
-        elif isinstance(node, ast.ImportFrom) and node.module is not None:
-            if node.module == "numpy" or node.module.startswith("numpy."):
-                found.append(node.module)
+        elif (
+            isinstance(node, ast.ImportFrom)
+            and node.module is not None
+            and (node.module == "numpy" or node.module.startswith("numpy."))
+        ):
+            found.append(node.module)
     return found
 
 
@@ -77,12 +80,11 @@ def test_coercions_flatten_and_as_scalar_accept_ndarray_like_without_numpy() -> 
     assert list(flatten(FakeArray())) == [1, 2, 3, 4]
 
 
-def test_has_numpy_flag_matches_import() -> None:
-    from excel_grapher.core.numpy_support import HAS_NUMPY
+def test_has_numpy_flag_matches_find_spec() -> None:
+    import importlib.util
 
-    try:
-        import numpy  # noqa: F401
-    except ImportError:
-        assert HAS_NUMPY is False
-    else:
-        assert HAS_NUMPY is True
+    from excel_grapher.core import numpy_support
+
+    present = importlib.util.find_spec("numpy") is not None
+    assert numpy_support.HAS_NUMPY is present
+    assert (numpy_support.np is not None) is present

--- a/tests/unit/core/test_optional_numpy.py
+++ b/tests/unit/core/test_optional_numpy.py
@@ -1,0 +1,88 @@
+"""NumPy is an optional accelerator (`fast` extra), not a required install."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parents[3] / "excel_grapher" / "core"
+_RUNTIME = Path(__file__).resolve().parents[3] / "excel_grapher" / "runtime"
+
+# Modules that must load (and stay correct) without a top-level NumPy import.
+_NUMPY_FREE_TOP_LEVEL = (
+    _CORE / "coercions.py",
+    _CORE / "math_funcs.py",
+    _CORE / "operators_fastpath_stub.py",
+    _CORE / "operators_reference.py",
+    _CORE / "operator_thresholds.py",
+    _RUNTIME / "info.py",
+)
+
+
+def _top_level_numpy_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "numpy" or alias.name.startswith("numpy."):
+                    found.append(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            if node.module == "numpy" or node.module.startswith("numpy."):
+                found.append(node.module)
+    return found
+
+
+@pytest.mark.parametrize("path", _NUMPY_FREE_TOP_LEVEL, ids=lambda p: p.name)
+def test_library_modules_have_no_top_level_numpy_import(path: Path) -> None:
+    assert path.is_file(), f"missing {path}"
+    assert _top_level_numpy_imports(path) == []
+
+
+def test_operators_fastpath_stub_is_noop_and_numpy_free() -> None:
+    """Stub always falls back; AST guard above ensures it has no NumPy import."""
+    from excel_grapher.core.operators_fastpath_stub import (
+        MIN_OPERATOR_FASTPATH_CELLS,
+        try_fastpath_arithmetic_array,
+        try_fastpath_compare_array,
+        try_fastpath_concat_array,
+        try_fastpath_sumproduct,
+    )
+
+    assert MIN_OPERATOR_FASTPATH_CELLS == 64
+    assert try_fastpath_arithmetic_array("+", object(), object()) is None
+    assert try_fastpath_compare_array("=", object(), object()) is None
+    assert try_fastpath_concat_array(object(), object()) is None
+    assert try_fastpath_sumproduct([]) is None
+
+
+def test_coercions_flatten_and_as_scalar_accept_ndarray_like_without_numpy() -> None:
+    """Duck-type ndarray buffers so coercions stay NumPy-free at import time."""
+    from excel_grapher.core.coercions import as_scalar, flatten
+    from excel_grapher.core.types import XlError
+
+    class FakeArray:
+        ndim = 2
+
+        @property
+        def flat(self) -> list[int]:
+            return [1, 2, 3, 4]
+
+        def tolist(self) -> list[list[int]]:
+            return [[1, 2], [3, 4]]
+
+    assert as_scalar(FakeArray()) is XlError.VALUE
+    assert list(flatten(FakeArray())) == [1, 2, 3, 4]
+
+
+def test_has_numpy_flag_matches_import() -> None:
+    from excel_grapher.core.numpy_support import HAS_NUMPY
+
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        assert HAS_NUMPY is False
+    else:
+        assert HAS_NUMPY is True

--- a/tests/unit/core/test_scalar_boundary.py
+++ b/tests/unit/core/test_scalar_boundary.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher import DependencyGraph, Node
 from excel_grapher.core import CellValue, XlError, as_scalar, get_error, to_number, to_string

--- a/tests/unit/core/test_scalar_boundary.py
+++ b/tests/unit/core/test_scalar_boundary.py
@@ -1,5 +1,6 @@
 """Scalar boundary and shallow get_error for lazy Range (#336 Phase 1)."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from typing import cast

--- a/tests/unit/evaluator/test_helpers.py
+++ b/tests/unit/evaluator/test_helpers.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import pytest
 
 np = pytest.importorskip("numpy")

--- a/tests/unit/evaluator/test_helpers.py
+++ b/tests/unit/evaluator/test_helpers.py
@@ -1,5 +1,6 @@
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.evaluator.helpers import (
     to_bool,

--- a/tests/unit/gaps/test_sumproduct_criteria_gaps.py
+++ b/tests/unit/gaps/test_sumproduct_criteria_gaps.py
@@ -4,6 +4,7 @@ Regression coverage for element-wise range comparisons and products inside
 ``SUMPRODUCT``, e.g. ``(range="label")*values`` and ``(range>threshold)*1``.
 """
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/gaps/test_sumproduct_criteria_gaps.py
+++ b/tests/unit/gaps/test_sumproduct_criteria_gaps.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher import DependencyGraph, FormulaEvaluator, Node, create_dependency_graph
 from excel_grapher.core.address_keys import parse_address

--- a/tests/unit/runtime/test_smoke_blocker_functions.py
+++ b/tests/unit/runtime/test_smoke_blocker_functions.py
@@ -1,5 +1,6 @@
 """Unit tests for smoke-blocker runtime functions."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/unit/runtime/test_smoke_blocker_functions.py
+++ b/tests/unit/runtime/test_smoke_blocker_functions.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core.coercions import datetime_to_excel_serial, to_number
 from excel_grapher.core.types import XlError

--- a/tests/unit/runtime/test_sumproduct_fastpath.py
+++ b/tests/unit/runtime/test_sumproduct_fastpath.py
@@ -1,5 +1,6 @@
 """Vectorized ``xl_sumproduct`` fast path."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/runtime/test_sumproduct_fastpath.py
+++ b/tests/unit/runtime/test_sumproduct_fastpath.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core.operators import xl_eq, xl_mul
 from excel_grapher.core.operators_fastpath import (

--- a/tests/unit/runtime/test_sumproduct_runtime_wrapper.py
+++ b/tests/unit/runtime/test_sumproduct_runtime_wrapper.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import cast
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy")
 
 from excel_grapher.core import CellValue, XlError
 from excel_grapher.core.grid import Range

--- a/tests/unit/runtime/test_sumproduct_runtime_wrapper.py
+++ b/tests/unit/runtime/test_sumproduct_runtime_wrapper.py
@@ -1,5 +1,6 @@
 """Evaluator ``xl_sumproduct`` wrapper materializes large grids for NumPy fastpath."""
 
+# ruff: noqa: E402
 from __future__ import annotations
 
 from typing import cast

--- a/user_guide/03-evaluator.qmd
+++ b/user_guide/03-evaluator.qmd
@@ -26,21 +26,24 @@ Multi-cell range arguments are classified at resolve time:
   `excel_grapher.core.grid` and evaluate only the cells they touch.
 - Binary / unary operators bind the same lazy `Range` and map via shared
   `core.operator_maps` (aligned with export `xl_map_*`). Large ops may opt into
-  the ndarray fast path after an explicit materialization buffer (results are
-  nested lists at the `CellValue` boundary).
+  the ndarray fast path after an explicit materialization buffer when the
+  optional `fast` extra (NumPy) is installed (results are nested lists at the
+  `CellValue` boundary).
 - Full-scan reductions (`SUM` / `SUMPRODUCT` / `COUNTIF` / …) also bind lazy
   `Range` and walk cells in row-major order via `flatten` / Grid. `SUM` and
   friends fail-fast on the first cell error; `COUNTIF` / `AVERAGEIF` skip
   error cells in the criteria range (Excel). Large `SUMPRODUCT` may
-  materialize once for the NumPy fast path (internal buffer only).
+  materialize once for the NumPy fast path when `excel-grapher[fast]` is
+  installed (internal buffer only).
 - `AND` / `OR` still reject multi-cell ranges with `#VALUE!` until cell-wise
   range support lands.
 - Other functions reject multi-cell ranges with `#VALUE!` (no object-repr leaks;
   sibling cells stay unevaluated).
 
 `CellValue` in the evaluator path is scalar, reference geometry, or nested-list
-grid results — not persisted `np.ndarray` operands. NumPy remains available for
-optional operator / `SUMPRODUCT` fast paths.
+grid results — not persisted `np.ndarray` operands. NumPy is optional: install
+`excel-grapher[fast]` for operator / `SUMPRODUCT` acceleration on large
+workbooks; without it the same semantics use shared Grid / nested-list loops.
 
 Scalar coercions (`as_scalar`) reinforce the same boundary. Lookups and
 full-scan reductions skip the AST error precheck so each consumer owns its

--- a/uv.lock
+++ b/uv.lock
@@ -724,6 +724,12 @@ dev = [
     { name = "xlsxwriter" },
     { name = "xlwings" },
 ]
+test-core = [
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+    { name = "xlsxwriter" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -758,6 +764,12 @@ dev = [
     { name = "ty", specifier = ">=0.0.9" },
     { name = "xlsxwriter", specifier = ">=3.2.0" },
     { name = "xlwings", specifier = ">=0.34.0" },
+]
+test-core = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.14.0" },
+    { name = "ty", specifier = ">=0.0.9" },
+    { name = "xlsxwriter", specifier = ">=3.2.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -685,7 +685,6 @@ source = { editable = "." }
 dependencies = [
     { name = "fastpyxl" },
     { name = "jsonschema" },
-    { name = "numpy" },
     { name = "pyyaml" },
 ]
 
@@ -693,6 +692,10 @@ dependencies = [
 all = [
     { name = "graphviz" },
     { name = "networkx" },
+    { name = "numpy" },
+]
+fast = [
+    { name = "numpy" },
 ]
 networkx = [
     { name = "networkx" },
@@ -730,10 +733,11 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "networkx", marker = "extra == 'all'", specifier = ">=3.0" },
     { name = "networkx", marker = "extra == 'networkx'", specifier = ">=3.0" },
-    { name = "numpy", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'all'", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'fast'", specifier = ">=1.24" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
-provides-extras = ["networkx", "viz", "all"]
+provides-extras = ["fast", "networkx", "viz", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #403. Makes NumPy an optional accelerator via the `fast` extra so the default install stays NumPy-free (aligned with the already NumPy-free export runtime).

## Changes

### Packaging
- Remove `numpy` from required `[project.dependencies]`
- Add `fast = ["numpy>=1.24"]` optional extra
- Include NumPy in the `all` extra

### Runtime
- Detect NumPy at import; fall back to `operators_fastpath_stub` when absent
- Skip large-grid materialization without NumPy (use shared `operator_maps` / `sumproduct_cells`)
- Lazy-import NumPy inside `operators_reference` array helpers
- Duck-type ndarray buffers in `coercions`; use `numbers.Real` instead of `np.integer` / `np.floating`
- Extract `MIN_OPERATOR_FASTPATH_CELLS` to NumPy-free `operator_thresholds`

### Testing / CI
- New `test_optional_numpy.py` guards (AST + stub + duck-typing)
- Fastpath / ndarray tests `importorskip("numpy")`; perf budgets require `fast`
- CI job `test-no-numpy`: `uv sync --dev --extra networkx --extra viz` (no NumPy)

### Docs
- README install modes, `user_guide/03-evaluator.qmd`, `parity.mdc`

## Acceptance
- [x] Default install path does not require NumPy
- [x] `excel-grapher[fast]` restores vectorized fastpaths
- [x] Export codegen remains NumPy-free
- [x] `CellValue` stays free of `np.ndarray`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eea153c9-457e-4650-80ac-1c3b48ed0d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eea153c9-457e-4650-80ac-1c3b48ed0d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

