### PR TITLE
fix(grapher): OFFSET named ranges with COUNTA(...)+n no longer collapse to 1×1

### DIFF
--- a/excel_grapher/grapher/resolver.py
+++ b/excel_grapher/grapher/resolver.py
@@ -151,6 +151,8 @@ def _eval_number_for_defined_name(
             return float(inner) / 100.0
         return None
     if isinstance(node, BinaryOpNode):
+        if node.op not in {"+", "-", "*", "/", "^"}:
+            return None
         left = _eval_number_for_defined_name(node.left, get_cell_value, bounds)
         right = _eval_number_for_defined_name(node.right, get_cell_value, bounds)
         if left is None or right is None:

--- a/excel_grapher/grapher/resolver.py
+++ b/excel_grapher/grapher/resolver.py
@@ -15,16 +15,19 @@ from excel_grapher.core.addressing import offset_range, split_sheet_qualified_ad
 from excel_grapher.core.coercions import to_number
 from excel_grapher.core.formula_ast import (
     AstNode,
+    BinaryOpNode,
     CellRefNode,
     FormulaParseError,
     FunctionCallNode,
     NumberNode,
     RangeNode,
+    UnaryOpNode,
 )
 from excel_grapher.core.formula_ast import (
     parse as parse_formula_ast,
 )
 from excel_grapher.core.formula_normalization import expand_whole_column_row_for_parse
+from excel_grapher.core.operators_reference import apply_arithmetic
 from excel_grapher.core.types import CellValue, ExcelRange, XlError
 
 from .parser import CellRef
@@ -112,20 +115,50 @@ def _base_node_to_excel_range(
     return None
 
 
+def _as_int_or_float(n: float) -> int | float:
+    """Return an int when *n* is integral, otherwise leave as float."""
+    return int(n) if n == int(n) else n
+
+
 def _eval_number_for_defined_name(
     node: AstNode,
     get_cell_value: Callable[[str], CellValue],
     bounds: dict[str, tuple[int, int]],
 ) -> int | float | None:
-    """Evaluate an AST node to a number for OFFSET args (rows, cols, height, width)."""
+    """Evaluate an AST node to a number for OFFSET args (rows, cols, height, width).
+
+    Supports literals, cell refs, bare `COUNTA(range)`, and arithmetic /
+    unary expressions over those (e.g. `COUNTA(A:A)+5`). Unsupported nodes
+    return `None` so callers can fail closed.
+    """
     if isinstance(node, NumberNode):
-        return int(node.value) if node.value == int(node.value) else node.value
+        return _as_int_or_float(node.value)
     if isinstance(node, CellRefNode):
         val = get_cell_value(node.address)
         n = to_number(val)
         if isinstance(n, XlError):
             return None
-        return int(n) if n == int(n) else float(n)
+        return _as_int_or_float(n)
+    if isinstance(node, UnaryOpNode):
+        inner = _eval_number_for_defined_name(node.operand, get_cell_value, bounds)
+        if inner is None:
+            return None
+        if node.op == "-":
+            return _as_int_or_float(-float(inner))
+        if node.op == "+":
+            return _as_int_or_float(float(inner))
+        if node.op == "%":
+            return float(inner) / 100.0
+        return None
+    if isinstance(node, BinaryOpNode):
+        left = _eval_number_for_defined_name(node.left, get_cell_value, bounds)
+        right = _eval_number_for_defined_name(node.right, get_cell_value, bounds)
+        if left is None or right is None:
+            return None
+        result = apply_arithmetic(node.op, float(left), float(right))
+        if isinstance(result, XlError):
+            return None
+        return _as_int_or_float(result)
     if isinstance(node, FunctionCallNode) and node.name.upper() == "COUNTA" and len(node.args) == 1:
         rng: ExcelRange | None = None
         if isinstance(node.args[0], RangeNode):
@@ -162,16 +195,22 @@ def _eval_offset_formula_to_range(
     cols = _eval_number_for_defined_name(node.args[2], get_cell_value, bounds)
     if rows is None or cols is None:
         return None
-    height = (
-        _eval_number_for_defined_name(node.args[3], get_cell_value, bounds)
-        if len(node.args) >= 4
-        else None
-    )
-    width = (
-        _eval_number_for_defined_name(node.args[4], get_cell_value, bounds)
-        if len(node.args) >= 5
-        else None
-    )
+    # Explicit height/width that fail to evaluate must not fall back to the base
+    # shape (which collapses cell-anchored OFFSETs to a poison 1x1 range).
+    height: int | float | None
+    if len(node.args) >= 4:
+        height = _eval_number_for_defined_name(node.args[3], get_cell_value, bounds)
+        if height is None:
+            return None
+    else:
+        height = None
+    width: int | float | None
+    if len(node.args) >= 5:
+        width = _eval_number_for_defined_name(node.args[4], get_cell_value, bounds)
+        if width is None:
+            return None
+    else:
+        width = None
     if height is not None and height <= 0:
         return None
     if width is not None and width <= 0:

--- a/tests/integration/evaluator/test_lic_dsf_ci_score_parity.py
+++ b/tests/integration/evaluator/test_lic_dsf_ci_score_parity.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import fastpyxl
 import pytest
+from fastpyxl.utils.cell import coordinate_from_string
 
 from excel_grapher import FormulaEvaluator, XlError, create_dependency_graph
 from excel_grapher.grapher.resolver import build_named_range_map
@@ -55,10 +56,9 @@ def test_lic_dsf_arith_offset_names_resolve_to_multicell_tables() -> None:
         sheet, start, end = maps.range_map[name]
         assert start == "A1", f"{name}: unexpected start {start}"
         assert end != "A1", f"{name} collapsed to 1x1 anchor on {sheet} ({start}:{end})"
-        # Padded COUNTA+n tables span multiple columns (headers + year field).
-        assert end[0].isalpha() and not (end.startswith("A") and end[1:].isdigit()), (
-            f"{name}: expected multi-column end, got {end}"
-        )
+        # These padded COUNTA+n tables always span multiple columns (headers + years).
+        end_col, _end_row = coordinate_from_string(end)
+        assert end_col != "A", f"{name}: expected multi-column end, got {end}"
 
 
 @pytest.mark.slow

--- a/tests/integration/evaluator/test_lic_dsf_ci_score_parity.py
+++ b/tests/integration/evaluator/test_lic_dsf_ci_score_parity.py
@@ -1,0 +1,114 @@
+"""LIC-DSF CI-score chain: arithmetic OFFSET named ranges must not collapse to 1x1.
+
+Regression for issue #410: `DSF__DATA_{CPIA,REMGDP,GDPUSD}` use
+`COUNTA(...)+n` extents. When those collapsed to the anchor cell, INDEX/MATCH
+returned `#REF!` into CI Summary remittances / GDP-USD / score inputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fastpyxl
+import pytest
+
+from excel_grapher import FormulaEvaluator, XlError, create_dependency_graph
+from excel_grapher.grapher.resolver import build_named_range_map
+from tests.utils.excel_workbook_parity import assert_workbook_parity
+
+WORKBOOK_PATH = Path("examples/lic_dsf/data/lic-dsf-template-2025-08-12.xlsm")
+
+# Direct consumers of the arithmetic-OFFSET data tables + CI Summary mirrors.
+_CI_CHAIN_TARGETS: list[str] = [
+    "Imported data!L75",  # INDEX(DSF__DATA_REMGDP, ...)
+    "Imported data!L76",  # INDEX(DSF__DATA_GDPUSD, ...)
+    "Imported data!K82",  # IFERROR(INDEX(DSF__DATA_CPIA, ...), ...)
+    "CI Summary!C56",  # remittances mirror of L75
+    "CI Summary!C57",  # GDP-USD mirror of L76
+    "CI Summary!H50",  # remittance ratio using remittances/GDP
+]
+
+RTOL = 1e-5
+ATOL = 1e-9
+
+_ARITH_OFFSET_NAMES: tuple[str, ...] = (
+    "DSF__DATA_CPIA",
+    "DSF__DATA_GDPUSD",
+    "DSF__DATA_REMGDP",
+)
+
+
+@pytest.mark.slow
+def test_lic_dsf_arith_offset_names_resolve_to_multicell_tables() -> None:
+    """COUNTA(...)+n defined names must expand past the A1:A1 collapse."""
+    if not WORKBOOK_PATH.exists():
+        pytest.skip(f"Test workbook not found at {WORKBOOK_PATH}")
+
+    wb = fastpyxl.load_workbook(WORKBOOK_PATH, data_only=False, read_only=True, keep_vba=True)
+    try:
+        maps = build_named_range_map(wb)
+    finally:
+        wb.close()
+
+    for name in _ARITH_OFFSET_NAMES:
+        assert name in maps.range_map, f"{name} missing from range_map"
+        sheet, start, end = maps.range_map[name]
+        assert start == "A1", f"{name}: unexpected start {start}"
+        assert end != "A1", f"{name} collapsed to 1x1 anchor on {sheet} ({start}:{end})"
+        # Padded COUNTA+n tables span multiple columns (headers + year field).
+        assert end[0].isalpha() and not (end.startswith("A") and end[1:].isdigit()), (
+            f"{name}: expected multi-column end, got {end}"
+        )
+
+
+@pytest.mark.slow
+def test_lic_dsf_ci_chain_evaluator_matches_excel_cache() -> None:
+    """Imported-data INDEX rows and CI Summary mirrors match Excel cached values."""
+    if not WORKBOOK_PATH.exists():
+        pytest.skip(f"Test workbook not found at {WORKBOOK_PATH}")
+
+    graph = create_dependency_graph(
+        WORKBOOK_PATH,
+        _CI_CHAIN_TARGETS,
+        load_values=True,
+        max_depth=50,
+        use_cached_dynamic_refs=True,
+    )
+    assert_workbook_parity(
+        graph,
+        _CI_CHAIN_TARGETS,
+        rtol=RTOL,
+        atol=ATOL,
+        fail_fast=True,
+    )
+
+
+@pytest.mark.slow
+def test_lic_dsf_ci_index_formulas_not_substituted_as_a1_a1() -> None:
+    """Normalized INDEX formulas should reference the full padded data tables."""
+    if not WORKBOOK_PATH.exists():
+        pytest.skip(f"Test workbook not found at {WORKBOOK_PATH}")
+
+    graph = create_dependency_graph(
+        WORKBOOK_PATH,
+        ["Imported data!L75", "Imported data!L76", "Imported data!K82"],
+        load_values=True,
+        max_depth=30,
+        use_cached_dynamic_refs=True,
+    )
+    for addr, needle in (
+        ("Imported data!L75", "data_REM_FINAL!A1:A1"),
+        ("Imported data!L76", "data_GDPUSD!A1:A1"),
+        ("Imported data!K82", "CPIA!A1:A1"),
+    ):
+        node = graph.get_node(addr)
+        assert node is not None
+        assert node.normalized_formula is not None
+        assert needle not in node.normalized_formula, (
+            f"{addr} still references collapsed {needle}: {node.normalized_formula}"
+        )
+
+    with FormulaEvaluator(graph) as ev:
+        for addr in ("Imported data!L75", "Imported data!L76"):
+            result = ev._evaluate_cell(addr)
+            assert not isinstance(result, XlError), f"{addr} returned {result}"

--- a/tests/integration/grapher/test_named_ranges.py
+++ b/tests/integration/grapher/test_named_ranges.py
@@ -157,3 +157,127 @@ def test_normalized_formula_resolves_range_named_range(tmp_path: Path) -> None:
     # Range-based name should be fully expanded in normalized_formula so that
     # downstream parsers never see a bare identifier like NumRange.
     assert node.normalized_formula == "=VLOOKUP(Sheet1!A1, Sheet1!A1:B1, 2, FALSE())"
+
+
+def test_named_range_map_resolves_offset_counta_plus_literal(tmp_path: Path) -> None:
+    """OFFSET height/width with COUNTA(...)+n (LIC-DSF DSF__DATA_* pattern) resolve to padded ranges."""
+    excel_path = tmp_path / "offset_counta_plus.xlsx"
+    wb = _new_workbook()
+    wb.create_sheet("CPIA")
+    cpia = wb["CPIA"]
+    # Two non-blank rows in col A, three non-blank header cells → COUNTA+5 => h=7, w=8
+    cpia["A1"].value = "Database"
+    cpia["B1"].value = "Code"
+    cpia["C1"].value = "Year"
+    cpia["A2"].value = "book.xlsx"
+    cpia["B2"].value = 652
+    cpia["C2"].value = 3.5
+    attr = "OFFSET(CPIA!$A$1,0,0,COUNTA(CPIA!$A:$A)+5,COUNTA(CPIA!$1:$1)+5)"
+    wb.defined_names.add(DefinedName("DSF__DATA_CPIA", attr_text=attr))
+    wb.save(excel_path)
+
+    maps = build_named_range_map(
+        fastpyxl.load_workbook(excel_path, data_only=False, read_only=True)
+    )
+    assert "DSF__DATA_CPIA" in maps.range_map
+    sheet, start, end = maps.range_map["DSF__DATA_CPIA"]
+    assert sheet == "CPIA"
+    assert start == "A1"
+    # Must not collapse to the 1x1 anchor A1:A1 (issue #410).
+    assert end != "A1"
+    assert end == "H7"
+
+
+def test_named_range_map_resolves_offset_counta_minus_literal(tmp_path: Path) -> None:
+    """OFFSET height with COUNTA(...)-n resolves without collapsing to the anchor."""
+    excel_path = tmp_path / "offset_counta_minus.xlsx"
+    wb = _new_workbook()
+    wb.create_sheet("lookup")
+    lookup = wb["lookup"]
+    lookup["AX4"].value = "a"
+    lookup["AX5"].value = "b"
+    lookup["AX6"].value = "c"
+    attr = "OFFSET(lookup!$AX$4,0,0,COUNTA(lookup!$AX:$AX)-1,1)"
+    wb.defined_names.add(DefinedName("SHEETS_TO_HIDE", attr_text=attr))
+    wb.save(excel_path)
+
+    maps = build_named_range_map(
+        fastpyxl.load_workbook(excel_path, data_only=False, read_only=True)
+    )
+    assert "SHEETS_TO_HIDE" in maps.range_map
+    sheet, start, end = maps.range_map["SHEETS_TO_HIDE"]
+    assert sheet == "lookup"
+    assert start == "AX4"
+    # COUNTA(AX4:AX6)=3 → height 2 → AX4:AX5
+    assert end == "AX5"
+
+
+def test_named_range_map_omits_offset_when_counta_minus_nonpositive(
+    tmp_path: Path,
+) -> None:
+    """COUNTA(...)-n that yields a non-positive height must not register a poison 1x1."""
+    excel_path = tmp_path / "offset_counta_nonpositive.xlsx"
+    wb = _new_workbook()
+    wb.create_sheet("lookup")
+    lookup = wb["lookup"]
+    lookup["AX4"].value = "only"
+    attr = "OFFSET(lookup!$AX$4,0,0,COUNTA(lookup!$AX:$AX)-1,1)"
+    wb.defined_names.add(DefinedName("SHEETS_TO_HIDE", attr_text=attr))
+    wb.save(excel_path)
+
+    maps = build_named_range_map(
+        fastpyxl.load_workbook(excel_path, data_only=False, read_only=True)
+    )
+    assert "SHEETS_TO_HIDE" not in maps.range_map
+    assert "SHEETS_TO_HIDE" not in maps.cell_map
+
+
+def test_named_range_map_omits_offset_with_unevaluable_extent(tmp_path: Path) -> None:
+    """Explicit height using unsupported COUNTIF must not collapse to the 1x1 anchor."""
+    excel_path = tmp_path / "offset_countif_extent.xlsx"
+    wb = _new_workbook()
+    wb.create_sheet("lookup")
+    lookup = wb["lookup"]
+    lookup["AY4"].value = "x"
+    lookup["AY5"].value = "y"
+    attr = 'OFFSET(lookup!$AY$4,0,0,COUNTIF(lookup!$AY:$AY,"?*")-1,1)'
+    wb.defined_names.add(DefinedName("COUNTRY_DROP_DOWN", attr_text=attr))
+    wb.save(excel_path)
+
+    maps = build_named_range_map(
+        fastpyxl.load_workbook(excel_path, data_only=False, read_only=True)
+    )
+    assert "COUNTRY_DROP_DOWN" not in maps.range_map
+    assert "COUNTRY_DROP_DOWN" not in maps.cell_map
+
+
+def test_dependency_graph_expands_offset_counta_plus_named_range(tmp_path: Path) -> None:
+    """INDEX over a COUNTA+n named range expands to the padded table, not A1:A1."""
+    excel_path = tmp_path / "graph_offset_counta_plus.xlsx"
+    wb = _new_workbook()
+    wb.create_sheet("CPIA")
+    cpia = wb["CPIA"]
+    cpia["A1"].value = "hdr"
+    cpia["B1"].value = "code"
+    cpia["C1"].value = "year"
+    cpia["A2"].value = "row"
+    cpia["B2"].value = 652
+    cpia["C2"].value = 3.5
+    wb.defined_names.add(
+        DefinedName(
+            "DSF__DATA_CPIA",
+            attr_text="OFFSET(CPIA!$A$1,0,0,COUNTA(CPIA!$A:$A)+5,COUNTA(CPIA!$1:$1)+5)",
+        )
+    )
+    ws = wb["Sheet1"]
+    ws["D1"].value = "=INDEX(DSF__DATA_CPIA,2,3)"
+    wb.save(excel_path)
+
+    graph = create_dependency_graph(excel_path, ["Sheet1!D1"], load_values=False)
+    node = graph.get_node("Sheet1!D1")
+    assert node is not None
+    assert node.normalized_formula is not None
+    assert "CPIA!A1:A1" not in node.normalized_formula
+    assert "CPIA!A1:H7" in node.normalized_formula
+    deps = graph.get_dependencies("Sheet1!D1")
+    assert "CPIA!C2" in deps

--- a/tests/integration/grapher/test_named_ranges.py
+++ b/tests/integration/grapher/test_named_ranges.py
@@ -251,6 +251,24 @@ def test_named_range_map_omits_offset_with_unevaluable_extent(tmp_path: Path) ->
     assert "COUNTRY_DROP_DOWN" not in maps.cell_map
 
 
+def test_named_range_map_omits_offset_with_non_arithmetic_binary_extent(
+    tmp_path: Path,
+) -> None:
+    """Concat/comparison binary ops in extents must omit the name, not raise."""
+    excel_path = tmp_path / "offset_concat_extent.xlsx"
+    wb = _new_workbook()
+    wb.create_sheet("S")
+    wb["S"]["A1"].value = 1
+    wb.defined_names.add(DefinedName("BadConcat", attr_text="OFFSET(S!$A$1,0,0,1&2,1)"))
+    wb.save(excel_path)
+
+    maps = build_named_range_map(
+        fastpyxl.load_workbook(excel_path, data_only=False, read_only=True)
+    )
+    assert "BadConcat" not in maps.range_map
+    assert "BadConcat" not in maps.cell_map
+
+
 def test_dependency_graph_expands_offset_counta_plus_named_range(tmp_path: Path) -> None:
     """INDEX over a COUNTA+n named range expands to the padded table, not A1:A1."""
     excel_path = tmp_path / "graph_offset_counta_plus.xlsx"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Formula-based defined names like `OFFSET(..., COUNTA(A:A)+5, COUNTA(1:1)+5)` were resolved to the **1×1 anchor** because `_eval_number_for_defined_name` could not evaluate arithmetic ASTs, and a failed height/width was treated as “omitted” (defaulting to the base cell shape). On LIC-DSF that `#REF!`’d the Imported data → CI Summary remittances / GDP-USD / CI-score chain.

Fixes #410.

## Changes

- Recursively evaluate `BinaryOpNode` / `UnaryOpNode` in defined-name OFFSET extent args (via `apply_arithmetic`).
- Fail closed when an **explicit** height/width cannot be evaluated (no poison `A1:A1` in `range_map`).
- Integration tests for `COUNTA+n` / `COUNTA-n`, unevaluable `COUNTIF` extents, and a slow LIC-DSF CI-slice regression.

## Test plan

- [x] `uv run pytest tests/integration/grapher/test_named_ranges.py`
- [x] `uv run pytest tests/integration/evaluator/test_lic_dsf_ci_score_parity.py -m slow`
- [x] `uv run ruff check` / `ruff format --check` / `ty check` on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a26342b-8319-44bf-bc95-17d198a24bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a26342b-8319-44bf-bc95-17d198a24bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

