### PR TITLE
feat(series-bindings): reverse address map for reader call forms (#409)

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -649,11 +649,43 @@ class CodeGenerator:
         return dict(group_manifest(bindings))
 
     @staticmethod
+    def _series_binding_reader_discovery(
+        graph: DependencyGraph,
+        bindings: WorkbookSeriesBindings | None,
+        *,
+        workbook: Path | str | None,
+        export_addresses: Iterable[str] | None = None,
+    ) -> tuple[dict[str, dict[str, object]] | None, dict[str, dict[str, object]] | None]:
+        """Return discovery payloads for `list_reader_leaves` / `list_reader_ranges`."""
+        if bindings is None or workbook is None:
+            return None, None
+        from excel_grapher.series_bindings.normalize import has_input_direction
+        from excel_grapher.series_bindings.reader_index import (
+            build_reader_index,
+            reader_index_as_discovery_dicts,
+        )
+
+        if not any(
+            isinstance(series, dict) and has_input_direction(series)
+            for series in bindings.get("series", [])
+        ):
+            return None, None
+        index = build_reader_index(
+            graph,
+            bindings,
+            workbook=workbook,
+            export_addresses=export_addresses,
+        )
+        return reader_index_as_discovery_dicts(index)
+
+    @staticmethod
     def _emit_series_binding_discovery_lines(
         setter_names: Sequence[str],
         compute_names: Sequence[str],
         groups_manifest: Mapping[str, Any] | None = None,
         reader_names: Sequence[str] | None = None,
+        reader_leaves: Mapping[str, Mapping[str, object]] | None = None,
+        reader_ranges: Mapping[str, Mapping[str, object]] | None = None,
     ) -> list[str]:
         """Emit generated-code helpers that list public series-binding functions."""
         lines = [
@@ -671,6 +703,26 @@ class CodeGenerator:
             '    """Return generated series-binding compute function names."""',
             f"    return {list(compute_names)!r}",
         ]
+        if reader_leaves is not None:
+            lines.extend(
+                [
+                    "",
+                    "",
+                    "def list_reader_leaves() -> dict[str, dict[str, object]]:",
+                    '    """Return address → semantic reader call metadata."""',
+                    f"    return {dict(reader_leaves)!r}",
+                ]
+            )
+        if reader_ranges is not None:
+            lines.extend(
+                [
+                    "",
+                    "",
+                    "def list_reader_ranges() -> dict[str, dict[str, object]]:",
+                    '    """Return binding-aligned data_range → range-reader metadata."""',
+                    f"    return {dict(reader_ranges)!r}",
+                ]
+            )
         if groups_manifest is not None:
             lines.extend(
                 [
@@ -2317,6 +2369,8 @@ class CodeGenerator:
         series_setter_names: list[str] = []
         series_reader_names: list[str] = []
         series_compute_names: list[str] = []
+        reader_leaves: dict[str, dict[str, object]] | None = None
+        reader_ranges: dict[str, dict[str, object]] | None = None
         if series_bindings is not None:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
@@ -2336,12 +2390,20 @@ class CodeGenerator:
                 )
             )
             lines.append("")
+            reader_leaves, reader_ranges = self._series_binding_reader_discovery(
+                cast("DependencyGraph", self._public_graph()),
+                series_bindings,
+                workbook=bindings_workbook,
+                export_addresses=_all_cells,
+            )
         lines.extend(
             self._emit_series_binding_discovery_lines(
                 series_setter_names,
                 series_compute_names,
                 self._series_binding_groups_manifest(series_bindings),
                 reader_names=series_reader_names,
+                reader_leaves=reader_leaves,
+                reader_ranges=reader_ranges,
             )
         )
         lines.append("")
@@ -2496,6 +2558,8 @@ class CodeGenerator:
         series_setter_names: list[str] = []
         series_reader_names: list[str] = []
         series_compute_names: list[str] = []
+        reader_leaves: dict[str, dict[str, object]] | None = None
+        reader_ranges: dict[str, dict[str, object]] | None = None
         api_helpers_py: str | None = None
         if series_bindings is not None:
             if bindings_workbook is None:
@@ -2531,6 +2595,12 @@ class CodeGenerator:
             series_range_reader_names = self._series_binding_emitted_range_reader_names(
                 setter_lines
             )
+            reader_leaves, reader_ranges = self._series_binding_reader_discovery(
+                cast("DependencyGraph", self._public_graph()),
+                series_bindings,
+                workbook=bindings_workbook,
+                export_addresses=_all_cells,
+            )
             api_lines.append("")
         else:
             series_range_reader_names = []
@@ -2541,6 +2611,8 @@ class CodeGenerator:
                 series_compute_names,
                 groups_manifest,
                 reader_names=series_reader_names,
+                reader_leaves=reader_leaves,
+                reader_ranges=reader_ranges,
             )
         )
         api_lines.append("")
@@ -2581,6 +2653,10 @@ class CodeGenerator:
             "list_readers",
             "list_computes",
         ]
+        if reader_leaves is not None:
+            api_exports.append("list_reader_leaves")
+        if reader_ranges is not None:
+            api_exports.append("list_reader_ranges")
         if groups_manifest is not None:
             api_exports.append("list_groups")
         api_exports.extend(series_setter_names)

--- a/excel_grapher/series_bindings/__init__.py
+++ b/excel_grapher/series_bindings/__init__.py
@@ -61,6 +61,15 @@ from excel_grapher.series_bindings.normalize import (
 )
 from excel_grapher.series_bindings.output_series import derive_output_series
 from excel_grapher.series_bindings.ranges import expand_data_range, expand_data_range_for_graph
+from excel_grapher.series_bindings.reader_index import (
+    ReaderCallResolution,
+    ReaderIndex,
+    ReaderLeafEntry,
+    ReaderRangeEntry,
+    build_reader_index,
+    format_reader_call_form,
+    resolve_reader_ref,
+)
 from excel_grapher.series_bindings.resolve import resolve_series_binding, resolve_series_bindings
 from excel_grapher.series_bindings.schema import (
     SeriesBindingsSchemaError,
@@ -126,6 +135,10 @@ __all__ = [
     "InternalSeriesCell",
     "OutputSeries",
     "OutputSeriesCell",
+    "ReaderCallResolution",
+    "ReaderIndex",
+    "ReaderLeafEntry",
+    "ReaderRangeEntry",
     "Record",
     "Records",
     "IMPLEMENTED_BIND_KINDS",
@@ -163,6 +176,7 @@ __all__ = [
     "bindings_canonical_sha256",
     "bindings_export_order",
     "bindings_have_groups",
+    "build_reader_index",
     "group_manifest",
     "group_slug",
     "grouped_public_names",
@@ -172,6 +186,7 @@ __all__ = [
     "derive_input_series",
     "derive_internal_series",
     "derive_output_series",
+    "format_reader_call_form",
     "emit_compute_function",
     "emit_computes_block",
     "emit_series_bindings_block",
@@ -198,6 +213,7 @@ __all__ = [
     "register_series_docstring_callback",
     "resolve_series_docstring_callback",
     "unregister_series_docstring_callback",
+    "resolve_reader_ref",
     "resolve_series_binding",
     "resolve_series_bindings",
     "resolve_series_docstring_renderer",

--- a/excel_grapher/series_bindings/reader_index.py
+++ b/excel_grapher/series_bindings/reader_index.py
@@ -53,7 +53,11 @@ class ReaderRangeEntry(TypedDict):
 
 
 class ReaderIndex(TypedDict):
-    """Machine-readable reverse map from Excel geometry to reader call forms."""
+    """Machine-readable reverse map from Excel geometry to reader call forms.
+
+    `ambiguous` holds normalized cell addresses and/or `data_range` strings that
+    are claimed by more than one input series (resolve falls back to `xl_*`).
+    """
 
     leaves: dict[str, ReaderLeafEntry]
     ranges: dict[str, ReaderRangeEntry]
@@ -126,7 +130,9 @@ def _leaf_entry(
         kwargs = {}
         call_form = format_reader_call_form(reader)
     else:
-        kwargs = {dimension_id_to_param_name(field): keys[field] for field in key_fields}
+        kwargs = {
+            dimension_id_to_param_name(field): keys[field] for field in key_fields if field in keys
+        }
         call_form = format_reader_call_form(reader, kwargs=kwargs)
     return {
         "series_id": series_id,
@@ -147,10 +153,10 @@ def build_reader_index(
 ) -> ReaderIndex:
     """Build reverse address/range indexes from Phase 1 leaf resolution.
 
-    Leaves owned by more than one input series are recorded in `ambiguous` and
-    omitted from `leaves` so consumers fall back to `xl_cell` with a clear
-    reason. Range entries are emitted only when codegen would emit
-    `read_<id>_range`.
+    Leaves or binding-aligned `data_range`s owned by more than one input series
+    are recorded in `ambiguous` and omitted from `leaves` / `ranges` so
+    consumers fall back to `xl_cell` / `xl_range` with reason `ambiguous_owner`.
+    Range entries are emitted only when codegen would emit `read_<id>_range`.
     """
     report = resolve_series_bindings(
         graph,
@@ -165,8 +171,8 @@ def build_reader_index(
         if isinstance(s, dict) and has_input_direction(s)
     }
 
-    owners: dict[str, list[ReaderLeafEntry]] = {}
-    ranges: dict[str, ReaderRangeEntry] = {}
+    leaf_owners: dict[str, list[ReaderLeafEntry]] = {}
+    range_owners: dict[str, list[ReaderRangeEntry]] = {}
 
     for resolved in report["series"]:
         series = by_id.get(resolved["series_id"])
@@ -185,29 +191,38 @@ def build_reader_index(
                 key_fields=key_fields,
                 kind=kind,
             )
-            owners.setdefault(address, []).append(entry)
+            leaf_owners.setdefault(address, []).append(entry)
 
         if _should_emit_reader_range(series, resolved):
             data_range = series.get("data_range")
             if isinstance(data_range, str) and data_range:
                 normalized_range = normalize_key(data_range)
                 range_reader = f"{reader}_range"
-                ranges[normalized_range] = {
-                    "series_id": resolved["series_id"],
-                    "reader": range_reader,
-                    "data_range": normalized_range,
-                    "call_form": format_reader_call_form(range_reader, range_reader=True),
-                }
+                range_owners.setdefault(normalized_range, []).append(
+                    {
+                        "series_id": resolved["series_id"],
+                        "reader": range_reader,
+                        "data_range": normalized_range,
+                        "call_form": format_reader_call_form(range_reader, range_reader=True),
+                    }
+                )
 
     leaves: dict[str, ReaderLeafEntry] = {}
+    ranges: dict[str, ReaderRangeEntry] = {}
     ambiguous: list[str] = []
-    for address, entries in sorted(owners.items()):
+    for address, entries in sorted(leaf_owners.items()):
         # Distinct series ids — duplicate identical entries from one series are fine.
         series_ids = {entry["series_id"] for entry in entries}
         if len(series_ids) != 1:
             ambiguous.append(address)
             continue
         leaves[address] = entries[0]
+    for data_range, entries in sorted(range_owners.items()):
+        series_ids = {entry["series_id"] for entry in entries}
+        if len(series_ids) != 1:
+            ambiguous.append(data_range)
+            continue
+        ranges[data_range] = entries[0]
 
     return {
         "leaves": leaves,
@@ -247,6 +262,14 @@ def resolve_reader_ref(
 
     normalized = normalize_key(ref)
     if _is_range_ref(normalized):
+        if normalized in index["ambiguous"]:
+            return {
+                "mode": "xl_range",
+                "call_form": f"xl_range(ctx, {normalized!r})",
+                "reason": "ambiguous_owner",
+                "series_id": None,
+                "reader": None,
+            }
         range_entry = index["ranges"].get(normalized)
         if range_entry is not None:
             return {

--- a/excel_grapher/series_bindings/reader_index.py
+++ b/excel_grapher/series_bindings/reader_index.py
@@ -1,0 +1,304 @@
+"""Reverse address/range → semantic reader call mapping (Phase 1b).
+
+Builds on Phase 1 leaf resolution (`_LEAF_INDEX_*` / `resolved["leaves"]`) so
+consumers (notably QCraft fingerprints) can describe data-layer reads as
+`read_<id>(ctx, …)` / `read_<id>_range(ctx)` instead of bare Excel geometry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Literal, NotRequired, TypedDict
+
+from excel_grapher.core.address_keys import normalize_key, split_address_on_colon
+from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.series_bindings.normalize import has_input_direction
+from excel_grapher.series_bindings.resolve import resolve_series_bindings
+from excel_grapher.series_bindings.setter_codegen import (
+    _reader_function_name,
+    _should_emit_reader,
+    _should_emit_reader_range,
+    dimension_id_to_param_name,
+)
+from excel_grapher.series_bindings.types import Scalar, SeriesResolution, WorkbookSeriesBindings
+
+ReaderLeafKind = Literal["keyed", "scalar", "address_keyed"]
+ReaderCallMode = Literal["reader", "reader_range", "xl_cell", "xl_range"]
+ReaderFallbackReason = Literal[
+    "unbound",
+    "ambiguous_owner",
+    "not_binding_aligned_range",
+]
+
+
+class ReaderLeafEntry(TypedDict):
+    """One uniquely-owned input leaf mapped to its semantic reader call."""
+
+    series_id: str
+    reader: str
+    keys: dict[str, Scalar]
+    kwargs: dict[str, Scalar]
+    kind: ReaderLeafKind
+    call_form: str
+
+
+class ReaderRangeEntry(TypedDict):
+    """One binding-aligned `data_range` mapped to its `read_*_range` helper."""
+
+    series_id: str
+    reader: str
+    data_range: str
+    call_form: str
+
+
+class ReaderIndex(TypedDict):
+    """Machine-readable reverse map from Excel geometry to reader call forms."""
+
+    leaves: dict[str, ReaderLeafEntry]
+    ranges: dict[str, ReaderRangeEntry]
+    ambiguous: tuple[str, ...]
+
+
+class ReaderCallResolution(TypedDict):
+    """Result of resolving a cell or range reference to a reader (or fallback)."""
+
+    mode: ReaderCallMode
+    call_form: str
+    reason: str | None
+    series_id: str | None
+    reader: str | None
+    keys: NotRequired[dict[str, Scalar]]
+    kwargs: NotRequired[dict[str, Scalar]]
+    kind: NotRequired[ReaderLeafKind]
+
+
+def format_reader_call_form(
+    reader: str,
+    *,
+    kwargs: Mapping[str, object] | None = None,
+    address: str | None = None,
+    range_reader: bool = False,
+) -> str:
+    """Build a bindings-aware call-form string for fingerprints / prompts.
+
+    Args:
+        reader: Generated reader function name (`read_<id>` or `read_<id>_range`).
+        kwargs: Snake_case dimension kwargs for keyed readers.
+        address: Address kwarg for duplicate-key (`requires_address`) readers.
+        range_reader: When True, emit the no-arg range form `reader(ctx)`.
+
+    Returns:
+        Call form such as `read_gdp(ctx, time_period=2020)` or
+        `read_gdp_range(ctx)`.
+    """
+    if range_reader or (not kwargs and address is None):
+        return f"{reader}(ctx)"
+    if address is not None:
+        return f"{reader}(ctx, address={address!r})"
+    assert kwargs is not None
+    parts = ", ".join(f"{name}={value!r}" for name, value in kwargs.items())
+    return f"{reader}(ctx, {parts})"
+
+
+def _leaf_kind(resolved: SeriesResolution, key_fields: list[str]) -> ReaderLeafKind:
+    if resolved["requires_address"]:
+        return "address_keyed"
+    if not key_fields:
+        return "scalar"
+    return "keyed"
+
+
+def _leaf_entry(
+    *,
+    series_id: str,
+    reader: str,
+    address: str,
+    key: Mapping[str, Scalar],
+    key_fields: list[str],
+    kind: ReaderLeafKind,
+) -> ReaderLeafEntry:
+    keys = {field: key[field] for field in key_fields if field in key}
+    if kind == "address_keyed":
+        kwargs: dict[str, Scalar] = {}
+        call_form = format_reader_call_form(reader, address=address)
+    elif kind == "scalar":
+        kwargs = {}
+        call_form = format_reader_call_form(reader)
+    else:
+        kwargs = {dimension_id_to_param_name(field): keys[field] for field in key_fields}
+        call_form = format_reader_call_form(reader, kwargs=kwargs)
+    return {
+        "series_id": series_id,
+        "reader": reader,
+        "keys": keys,
+        "kwargs": kwargs,
+        "kind": kind,
+        "call_form": call_form,
+    }
+
+
+def build_reader_index(
+    graph: DependencyGraph,
+    bindings: WorkbookSeriesBindings,
+    *,
+    workbook: Path | str,
+    export_addresses: Iterable[str] | None = None,
+) -> ReaderIndex:
+    """Build reverse address/range indexes from Phase 1 leaf resolution.
+
+    Leaves owned by more than one input series are recorded in `ambiguous` and
+    omitted from `leaves` so consumers fall back to `xl_cell` with a clear
+    reason. Range entries are emitted only when codegen would emit
+    `read_<id>_range`.
+    """
+    report = resolve_series_bindings(
+        graph,
+        bindings,
+        workbook=workbook,
+        direction="input",
+        export_addresses=export_addresses,
+    )
+    by_id = {
+        s["id"]: s
+        for s in bindings.get("series", [])
+        if isinstance(s, dict) and has_input_direction(s)
+    }
+
+    owners: dict[str, list[ReaderLeafEntry]] = {}
+    ranges: dict[str, ReaderRangeEntry] = {}
+
+    for resolved in report["series"]:
+        series = by_id.get(resolved["series_id"])
+        if series is None or not _should_emit_reader(resolved):
+            continue
+        reader = _reader_function_name(series, resolved)
+        key_fields = [str(field) for field in (series.get("key") or [])]
+        kind = _leaf_kind(resolved, key_fields)
+        for leaf in resolved["leaves"]:
+            address = normalize_key(leaf["address"])
+            entry = _leaf_entry(
+                series_id=resolved["series_id"],
+                reader=reader,
+                address=address,
+                key=leaf["key"],
+                key_fields=key_fields,
+                kind=kind,
+            )
+            owners.setdefault(address, []).append(entry)
+
+        if _should_emit_reader_range(series, resolved):
+            data_range = series.get("data_range")
+            if isinstance(data_range, str) and data_range:
+                normalized_range = normalize_key(data_range)
+                range_reader = f"{reader}_range"
+                ranges[normalized_range] = {
+                    "series_id": resolved["series_id"],
+                    "reader": range_reader,
+                    "data_range": normalized_range,
+                    "call_form": format_reader_call_form(range_reader, range_reader=True),
+                }
+
+    leaves: dict[str, ReaderLeafEntry] = {}
+    ambiguous: list[str] = []
+    for address, entries in sorted(owners.items()):
+        # Distinct series ids — duplicate identical entries from one series are fine.
+        series_ids = {entry["series_id"] for entry in entries}
+        if len(series_ids) != 1:
+            ambiguous.append(address)
+            continue
+        leaves[address] = entries[0]
+
+    return {
+        "leaves": leaves,
+        "ranges": ranges,
+        "ambiguous": tuple(ambiguous),
+    }
+
+
+def _is_range_ref(ref: str) -> bool:
+    return split_address_on_colon(ref) is not None
+
+
+def resolve_reader_ref(
+    ref: str,
+    *,
+    graph: DependencyGraph | None = None,
+    bindings: WorkbookSeriesBindings | None = None,
+    workbook: Path | str | None = None,
+    index: ReaderIndex | None = None,
+    export_addresses: Iterable[str] | None = None,
+) -> ReaderCallResolution:
+    """Resolve a cell or range reference to a reader call form or Excel fallback.
+
+    Prefer passing a prebuilt `index` when resolving many refs. Otherwise supply
+    `graph`, `bindings`, and `workbook` so the index can be built from Phase 1
+    leaf resolution.
+    """
+    if index is None:
+        if graph is None or bindings is None or workbook is None:
+            raise ValueError("resolve_reader_ref requires index= or graph/bindings/workbook")
+        index = build_reader_index(
+            graph,
+            bindings,
+            workbook=workbook,
+            export_addresses=export_addresses,
+        )
+
+    normalized = normalize_key(ref)
+    if _is_range_ref(normalized):
+        range_entry = index["ranges"].get(normalized)
+        if range_entry is not None:
+            return {
+                "mode": "reader_range",
+                "call_form": range_entry["call_form"],
+                "reason": None,
+                "series_id": range_entry["series_id"],
+                "reader": range_entry["reader"],
+            }
+        return {
+            "mode": "xl_range",
+            "call_form": f"xl_range(ctx, {normalized!r})",
+            "reason": "not_binding_aligned_range",
+            "series_id": None,
+            "reader": None,
+        }
+
+    if normalized in index["ambiguous"]:
+        return {
+            "mode": "xl_cell",
+            "call_form": f"xl_cell(ctx, {normalized!r})",
+            "reason": "ambiguous_owner",
+            "series_id": None,
+            "reader": None,
+        }
+
+    leaf = index["leaves"].get(normalized)
+    if leaf is None:
+        return {
+            "mode": "xl_cell",
+            "call_form": f"xl_cell(ctx, {normalized!r})",
+            "reason": "unbound",
+            "series_id": None,
+            "reader": None,
+        }
+
+    return {
+        "mode": "reader",
+        "call_form": leaf["call_form"],
+        "reason": None,
+        "series_id": leaf["series_id"],
+        "reader": leaf["reader"],
+        "keys": leaf["keys"],
+        "kwargs": leaf["kwargs"],
+        "kind": leaf["kind"],
+    }
+
+
+def reader_index_as_discovery_dicts(
+    index: ReaderIndex,
+) -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
+    """Convert a `ReaderIndex` into JSON-literal-friendly discovery payloads."""
+    leaves = {address: dict(entry) for address, entry in index["leaves"].items()}
+    ranges = {address: dict(entry) for address, entry in index["ranges"].items()}
+    return leaves, ranges

--- a/tests/unit/series_bindings/test_reader_index.py
+++ b/tests/unit/series_bindings/test_reader_index.py
@@ -1,0 +1,451 @@
+"""Tests for Phase 1b reverse address/range → reader call mapping."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import xlsxwriter
+
+from excel_grapher.exporter.codegen import CodeGenerator
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import (
+    build_reader_index,
+    expand_data_range,
+    format_reader_call_form,
+    load_series_bindings,
+    resolve_reader_ref,
+    resolve_series_binding,
+    validate_bindings_document,
+)
+from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
+
+
+def _write_borvelia_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("A2", "Borvelia")
+    ws.write("A5", "Primary balance (% of GDP)")
+    for col, year in enumerate([1, 2, 3, 4, 5], start=5):
+        ws.write(0, col, year)
+        ws.write_number(4, col, float(year - 3))
+    wb.close()
+
+
+def _write_scalar_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write("B5", "Borvelia")
+    wb.close()
+
+
+def _write_dup_headers_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write(0, 2, 1)
+    ws.write(0, 3, 1)
+    ws.write_number(1, 2, 10.0)
+    ws.write_number(1, 3, 20.0)
+    wb.close()
+
+
+KEYLESS_SCALAR_BINDING: dict[str, Any] = {
+    "schema_version": "1.3.0",
+    "series": [
+        {
+            "id": "country_name",
+            "sheet": "Inputs",
+            "data_range": "Inputs!B5",
+            "layout": "scalar",
+            "input": {
+                "setter": {
+                    "name": "set_country_name",
+                    "record_contract": "records",
+                    "strict": True,
+                }
+            },
+            "structure": {
+                "measure": {
+                    "concept": "OBS_VALUE",
+                    "dtype": "string",
+                    "bind": {"kind": "data_cell", "read": "string"},
+                },
+                "dimensions": [],
+            },
+            "key": [],
+        }
+    ],
+}
+
+
+def test_format_reader_call_form_keyed() -> None:
+    assert (
+        format_reader_call_form(
+            "read_borvelia_primary_balance",
+            kwargs={"time_period": 3},
+        )
+        == "read_borvelia_primary_balance(ctx, time_period=3)"
+    )
+
+
+def test_format_reader_call_form_scalar() -> None:
+    assert format_reader_call_form("read_country_name") == "read_country_name(ctx)"
+
+
+def test_format_reader_call_form_address_keyed() -> None:
+    assert (
+        format_reader_call_form("read_dup_headers", address="Sheet1!C2")
+        == "read_dup_headers(ctx, address='Sheet1!C2')"
+    )
+
+
+def test_format_reader_call_form_range() -> None:
+    assert (
+        format_reader_call_form("read_borvelia_primary_balance_range", range_reader=True)
+        == "read_borvelia_primary_balance_range(ctx)"
+    )
+
+
+def test_resolve_keyed_leaf_to_reader_call(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+
+    result = resolve_reader_ref(
+        "Inputs!H5",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader"
+    assert result["series_id"] == "borvelia_primary_balance"
+    assert result["reader"] == "read_borvelia_primary_balance"
+    assert result["keys"] == {"TIME_PERIOD": 3}
+    assert result["kwargs"] == {"time_period": 3}
+    assert result["call_form"] == "read_borvelia_primary_balance(ctx, time_period=3)"
+    assert result["reason"] is None
+
+
+def test_resolve_binding_aligned_range_to_range_reader(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+
+    result = resolve_reader_ref(
+        "Inputs!F5:J5",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader_range"
+    assert result["series_id"] == "borvelia_primary_balance"
+    assert result["reader"] == "read_borvelia_primary_balance_range"
+    assert result["call_form"] == "read_borvelia_primary_balance_range(ctx)"
+    assert result["reason"] is None
+
+
+def test_resolve_equivalent_range_form_to_range_reader(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+
+    result = resolve_reader_ref(
+        "Inputs!F5:Inputs!J5",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader_range"
+    assert result["reader"] == "read_borvelia_primary_balance_range"
+
+
+def test_resolve_partial_range_falls_back_to_xl_range(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+
+    result = resolve_reader_ref(
+        "Inputs!F5:H5",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "xl_range"
+    assert result["reason"] == "not_binding_aligned_range"
+    assert result["call_form"] == "xl_range(ctx, 'Inputs!F5:H5')"
+    assert result["reader"] is None
+
+
+def test_resolve_unbound_cell_falls_back_to_xl_cell(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+
+    result = resolve_reader_ref(
+        "Inputs!A2",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "xl_cell"
+    assert result["reason"] == "unbound"
+    assert result["call_form"] == "xl_cell(ctx, 'Inputs!A2')"
+
+
+def test_resolve_keyless_scalar_leaf(tmp_path: Path) -> None:
+    wb_path = tmp_path / "scalar.xlsx"
+    _write_scalar_workbook(wb_path)
+    bindings = validate_bindings_document(KEYLESS_SCALAR_BINDING)
+    graph = create_dependency_graph(wb_path, ["Inputs!B5"], load_values=True)
+
+    result = resolve_reader_ref(
+        "Inputs!B5",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader"
+    assert result["series_id"] == "country_name"
+    assert result["reader"] == "read_country_name"
+    assert result["keys"] == {}
+    assert result["kwargs"] == {}
+    assert result["call_form"] == "read_country_name(ctx)"
+    assert result["kind"] == "scalar"
+
+
+def test_resolve_address_keyed_leaf(tmp_path: Path) -> None:
+    wb_path = tmp_path / "dup_headers.xlsx"
+    _write_dup_headers_workbook(wb_path)
+    bindings = validate_bindings_document(
+        {
+            "schema_version": "1.3.0",
+            "series": [
+                {
+                    "id": "dup_headers",
+                    "sheet": "Sheet1",
+                    "data_range": "Sheet1!C2:D2",
+                    "layout": "series",
+                    "setter": {"name": "set_dup_headers", "allow_address": True, "strict": False},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [
+                            {
+                                "concept": "TIME_PERIOD",
+                                "role": "key",
+                                "scope": "cell",
+                                "bind": {
+                                    "kind": "column_header",
+                                    "header_row": 1,
+                                    "read": "int",
+                                },
+                            }
+                        ],
+                    },
+                    "key": ["TIME_PERIOD"],
+                    "validation": {"require_unique_key": True},
+                }
+            ],
+        }
+    )
+    graph = create_dependency_graph(wb_path, ["Sheet1!C2", "Sheet1!D2"], load_values=True)
+    resolved = resolve_series_binding(graph, wb_path, bindings["series"][0])
+    assert resolved["requires_address"] is True
+
+    result = resolve_reader_ref(
+        "Sheet1!C2",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader"
+    assert result["kind"] == "address_keyed"
+    assert result["reader"] == "read_dup_headers"
+    assert result["call_form"] == "read_dup_headers(ctx, address='Sheet1!C2')"
+
+
+def test_resolve_ambiguous_owner_falls_back(tmp_path: Path) -> None:
+    wb_path = tmp_path / "overlap.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write_number(0, 0, 1.0)
+    wb.close()
+
+    bindings = validate_bindings_document(
+        {
+            "schema_version": "1.3.0",
+            "series": [
+                {
+                    "id": "alpha",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!A1",
+                    "layout": "scalar",
+                    "setter": {"name": "set_alpha"},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [],
+                    },
+                    "key": [],
+                },
+                {
+                    "id": "beta",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!A1",
+                    "layout": "scalar",
+                    "setter": {"name": "set_beta"},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [],
+                    },
+                    "key": [],
+                },
+            ],
+        }
+    )
+    graph = create_dependency_graph(wb_path, ["Inputs!A1"], load_values=True)
+
+    result = resolve_reader_ref(
+        "Inputs!A1",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "xl_cell"
+    assert result["reason"] == "ambiguous_owner"
+    assert result["call_form"] == "xl_cell(ctx, 'Inputs!A1')"
+
+
+def test_build_reader_index_excludes_ambiguous_leaves(tmp_path: Path) -> None:
+    wb_path = tmp_path / "overlap.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    ws.write_number(0, 0, 1.0)
+    wb.close()
+
+    bindings = validate_bindings_document(
+        {
+            "schema_version": "1.3.0",
+            "series": [
+                {
+                    "id": "alpha",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!A1",
+                    "layout": "scalar",
+                    "setter": {"name": "set_alpha"},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [],
+                    },
+                    "key": [],
+                },
+                {
+                    "id": "beta",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!A1",
+                    "layout": "scalar",
+                    "setter": {"name": "set_beta"},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [],
+                    },
+                    "key": [],
+                },
+            ],
+        }
+    )
+    graph = create_dependency_graph(wb_path, ["Inputs!A1"], load_values=True)
+    index = build_reader_index(graph, bindings, workbook=wb_path)
+
+    assert "Inputs!A1" not in index["leaves"]
+    assert "Inputs!A1" in index["ambiguous"]
+
+
+def test_build_reader_index_keyed_and_range(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+
+    index = build_reader_index(graph, bindings, workbook=wb_path)
+
+    leaf = index["leaves"]["Inputs!H5"]
+    assert leaf["series_id"] == "borvelia_primary_balance"
+    assert leaf["reader"] == "read_borvelia_primary_balance"
+    assert leaf["keys"] == {"TIME_PERIOD": 3}
+    assert leaf["kwargs"] == {"time_period": 3}
+    assert leaf["kind"] == "keyed"
+    assert leaf["call_form"] == "read_borvelia_primary_balance(ctx, time_period=3)"
+
+    rng = index["ranges"]["Inputs!F5:J5"]
+    assert rng["reader"] == "read_borvelia_primary_balance_range"
+    assert rng["call_form"] == "read_borvelia_primary_balance_range(ctx)"
+
+
+def test_generated_modules_emit_list_reader_leaves(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    files = CodeGenerator(graph).generate_modules(
+        expand_data_range("Inputs!F5:J5"),
+        series_bindings=bindings,
+        bindings_workbook=wb_path,
+    )
+    assert "def list_reader_leaves(" in files["api.py"]
+    assert "def list_reader_ranges(" in files["api.py"]
+    assert "list_reader_leaves" in files["__init__.py"]
+    assert "list_reader_ranges" in files["__init__.py"]
+
+    pkg_dir = tmp_path / "exported_readers"
+    for filename, content in files.items():
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        pkg = importlib.import_module("exported_readers")
+        leaves = pkg.list_reader_leaves()
+        ranges = pkg.list_reader_ranges()
+        assert leaves["Inputs!H5"]["call_form"] == (
+            "read_borvelia_primary_balance(ctx, time_period=3)"
+        )
+        assert ranges["Inputs!F5:J5"]["call_form"] == ("read_borvelia_primary_balance_range(ctx)")
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in list(sys.modules):
+            if name == "exported_readers" or name.startswith("exported_readers."):
+                sys.modules.pop(name, None)

--- a/tests/unit/series_bindings/test_reader_index.py
+++ b/tests/unit/series_bindings/test_reader_index.py
@@ -449,3 +449,168 @@ def test_generated_modules_emit_list_reader_leaves(tmp_path: Path) -> None:
         for name in list(sys.modules):
             if name == "exported_readers" or name.startswith("exported_readers."):
                 sys.modules.pop(name, None)
+
+
+def test_resolve_reader_name_override(tmp_path: Path) -> None:
+    wb_path = tmp_path / "scalar.xlsx"
+    _write_scalar_workbook(wb_path)
+    bindings = validate_bindings_document(
+        {
+            "schema_version": "1.9.0",
+            "series": [
+                {
+                    "id": "country_name",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!B5",
+                    "layout": "scalar",
+                    "input": {
+                        "setter": {"name": "set_country_name"},
+                        "reader": {"name": "read_custom_country"},
+                    },
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "string",
+                            "bind": {"kind": "data_cell", "read": "string"},
+                        },
+                        "dimensions": [],
+                    },
+                    "key": [],
+                }
+            ],
+        }
+    )
+    graph = create_dependency_graph(wb_path, ["Inputs!B5"], load_values=True)
+
+    result = resolve_reader_ref(
+        "Inputs!B5",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader"
+    assert result["reader"] == "read_custom_country"
+    assert result["call_form"] == "read_custom_country(ctx)"
+
+
+def test_resolve_multi_key_leaf_call_form(tmp_path: Path) -> None:
+    from tests.fixtures.series_bindings.matrix_helpers import write_matrix_explicit_workbook
+
+    wb_path = tmp_path / "matrix_inputs.xlsx"
+    write_matrix_explicit_workbook(wb_path)
+    bindings = load_series_bindings(FIXTURES / "matrix_explicit_1_4_0.yaml")
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!B3:D5"), load_values=True)
+
+    result = resolve_reader_ref(
+        "Inputs!C3",
+        graph=graph,
+        bindings=bindings,
+        workbook=wb_path,
+    )
+
+    assert result["mode"] == "reader"
+    assert result["keys"] == {"INDICATOR": "GDP growth", "TIME_PERIOD": 2025}
+    assert result["kwargs"] == {"indicator": "GDP growth", "time_period": 2025}
+    assert result["call_form"] == (
+        "read_macro_matrix(ctx, indicator='GDP growth', time_period=2025)"
+    )
+
+
+def test_resolve_ambiguous_overlapping_range_falls_back(tmp_path: Path) -> None:
+    wb_path = tmp_path / "overlap_range.xlsx"
+    wb = xlsxwriter.Workbook(wb_path)
+    ws = wb.add_worksheet("Inputs")
+    for col, year in enumerate([1, 2], start=0):
+        ws.write(0, col, year)
+        ws.write_number(1, col, float(year))
+    wb.close()
+
+    bindings = validate_bindings_document(
+        {
+            "schema_version": "1.3.0",
+            "series": [
+                {
+                    "id": "a",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!A2:B2",
+                    "layout": "series",
+                    "setter": {"name": "set_a"},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [
+                            {
+                                "concept": "TIME_PERIOD",
+                                "role": "key",
+                                "scope": "cell",
+                                "bind": {
+                                    "kind": "column_header",
+                                    "header_row": 1,
+                                    "read": "int",
+                                },
+                            }
+                        ],
+                    },
+                    "key": ["TIME_PERIOD"],
+                    "validation": {"require_unique_key": True},
+                },
+                {
+                    "id": "b",
+                    "sheet": "Inputs",
+                    "data_range": "Inputs!A2:B2",
+                    "layout": "series",
+                    "setter": {"name": "set_b"},
+                    "structure": {
+                        "measure": {
+                            "concept": "OBS_VALUE",
+                            "dtype": "float",
+                            "bind": {"kind": "data_cell", "read": "float"},
+                        },
+                        "dimensions": [
+                            {
+                                "concept": "TIME_PERIOD",
+                                "role": "key",
+                                "scope": "cell",
+                                "bind": {
+                                    "kind": "column_header",
+                                    "header_row": 1,
+                                    "read": "int",
+                                },
+                            }
+                        ],
+                    },
+                    "key": ["TIME_PERIOD"],
+                    "validation": {"require_unique_key": True},
+                },
+            ],
+        }
+    )
+    graph = create_dependency_graph(wb_path, ["Inputs!A2", "Inputs!B2"], load_values=True)
+    index = build_reader_index(graph, bindings, workbook=wb_path)
+
+    assert "Inputs!A2:B2" not in index["ranges"]
+    assert "Inputs!A2:B2" in index["ambiguous"]
+
+    result = resolve_reader_ref("Inputs!A2:B2", index=index)
+    assert result["mode"] == "xl_range"
+    assert result["reason"] == "ambiguous_owner"
+    assert result["call_form"] == "xl_range(ctx, 'Inputs!A2:B2')"
+
+
+def test_single_file_generate_emits_reader_discovery(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(wb_path, expand_data_range("Inputs!F5:J5"), load_values=True)
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    source = CodeGenerator(graph).generate(
+        expand_data_range("Inputs!F5:J5"),
+        series_bindings=bindings,
+        bindings_workbook=wb_path,
+    )
+    assert "def list_reader_leaves(" in source
+    assert "def list_reader_ranges(" in source
+    assert "read_borvelia_primary_balance(ctx, time_period=3)" in source


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **excel-grapher's Phase 1b** slice of #409: machine-readable reverse mapping from Excel data-layer addresses/ranges to semantic `read_*` call forms, so QCraft fingerprints can stop describing bound leaves as bare `xl_cell` geometry.

Fingerprint/`reads:` prompt text generation remains **QCraft-owned**; this PR only supplies the mapping + discovery helpers that Phase 1 leaf indices already imply.

## What changed

- **`build_reader_index` / `resolve_reader_ref` / `format_reader_call_form`** — reuse Phase 1 leaf resolution to map:
  - uniquely owned cells → `read_<id>(ctx, time_period=…)` (or scalar / `address=` forms)
  - binding-aligned `data_range` → `read_<id>_range(ctx)`
  - unbound / ambiguous / partial ranges → `xl_cell` / `xl_range` with reason (`unbound`, `ambiguous_owner`, `not_binding_aligned_range`)
- **Generated discovery**: `list_reader_leaves()` and `list_reader_ranges()` emitted alongside existing `list_readers` (single-file + modular exports)
- No setter / runtime API changes

## Test plan

- [x] Unit tests for keyed/scalar/address-keyed resolve, range alignment + fallbacks, ambiguous owners, generated discovery
- [x] Related series-bindings / exporter suites green (417 passed)
- [x] ruff + ty clean on touched files

Closes #409 (excel-grapher scope; QCraft fingerprint wiring follows separately).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f23ed826-a62d-422e-ac7f-fde6dd950747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f23ed826-a62d-422e-ac7f-fde6dd950747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

