### PR TITLE
feat(series-bindings): migrate formula bodies onto read_* via _readers

### DIFF
--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ast as py_ast
-import json
 import re
 from collections.abc import Iterable, Mapping, Sequence, Set
 from contextlib import contextmanager
@@ -60,6 +59,7 @@ if TYPE_CHECKING:
     from excel_grapher.grapher import DependencyGraph
     from excel_grapher.series_bindings.docstring_renderers import SeriesDocstringRendererSpec
     from excel_grapher.series_bindings.docstrings import SeriesBindingDocstringCallbackSpec
+    from excel_grapher.series_bindings.reader_index import ReaderIndex
     from excel_grapher.series_bindings.types import InputSeries, WorkbookSeriesBindings
 
 
@@ -172,6 +172,8 @@ class CodeGenerator:
         self._formula_cell_address: str | None = None
         self._return_unpack_state: _ReturnUnpackState | None = None
         self._return_unpack_stack: list[_ReturnUnpackFrame] = []
+        self._reader_index: ReaderIndex | None = None
+        self._used_readers: set[str] = set()
 
     def __enter__(self) -> CodeGenerator:
         return self
@@ -192,6 +194,8 @@ class CodeGenerator:
         self._formula_cell_address = None
         self._return_unpack_state = None
         self._return_unpack_stack = []
+        self._reader_index = None
+        self._used_readers.clear()
 
     def _include_dep_tracking(
         self,
@@ -452,11 +456,20 @@ class CodeGenerator:
         return self._emit_range_address(node.start, node.end)
 
     def _emit_range_address(self, start: str, end: str) -> str:
-        """Emit an xl_range call for a normalized start/end address pair."""
+        """Emit an xl_range or binding-aligned read_*_range call for a start/end pair."""
         sheet, r1, c1, r2, c2 = self._range_coords(start, end)
         start_cell = f"{fastpyxl.utils.cell.get_column_letter(c1)}{r1}"
         end_cell = f"{fastpyxl.utils.cell.get_column_letter(c2)}{r2}"
-        expr = f"xl_range(ctx, {repr(format_range_key(sheet, start_cell, end_cell))})"
+        range_key = format_range_key(sheet, start_cell, end_cell)
+        if self._reader_index is not None:
+            from excel_grapher.series_bindings.reader_index import resolve_reader_ref
+
+            resolved = resolve_reader_ref(range_key, index=self._reader_index)
+            if resolved["reader"] is not None:
+                self._used_readers.add(resolved["reader"])
+            expr = resolved["call_form"]
+        else:
+            expr = f"xl_range(ctx, {repr(range_key)})"
         return self._hoist_return_expr(expr)
 
     def _emit_cell_eval(self, address: str) -> str:
@@ -468,6 +481,13 @@ class CodeGenerator:
             if node is not None and node.formula is not None:
                 func_name = address_to_python_name(normalized)
                 expr = f"xl_eval(ctx, {repr(normalized)}, {func_name})"
+            elif self._reader_index is not None:
+                from excel_grapher.series_bindings.reader_index import resolve_reader_ref
+
+                resolved = resolve_reader_ref(normalized, index=self._reader_index)
+                if resolved["reader"] is not None:
+                    self._used_readers.add(resolved["reader"])
+                expr = resolved["call_form"]
             else:
                 expr = f"xl_cell(ctx, {repr(normalized)})"
         return self._hoist_return_expr(expr)
@@ -503,6 +523,8 @@ class CodeGenerator:
         export_addresses: Iterable[str],
         public_addresses: Iterable[str],
         include_helpers: bool = True,
+        include_readers: bool = True,
+        include_leaf_indexes: bool = True,
         series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
         docstring_renderer: SeriesDocstringRendererSpec = "google",
     ) -> list[str]:
@@ -517,6 +539,8 @@ class CodeGenerator:
                 public_addresses,
             ),
             include_helpers=include_helpers,
+            include_readers=include_readers,
+            include_leaf_indexes=include_leaf_indexes,
             series_docstring_callback=series_docstring_callback,
             docstring_renderer=docstring_renderer,
         )
@@ -576,6 +600,51 @@ class CodeGenerator:
             *emit_series_helpers_definitions(),
         ]
         return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def _emit_readers_module(reader_lines: Sequence[str]) -> str:
+        """Emit the `_readers.py` module holding leaf maps and read_* duals."""
+        text = "\n".join(reader_lines)
+        runtime_names = ["CellValue", "EvalContext", "xl_cell"]
+        if "xl_range(" in text:
+            runtime_names.append("xl_range")
+        runtime_import = CodeGenerator._format_from_runtime_import(runtime_names)
+        lines: list[str] = [
+            "from __future__ import annotations",
+            "",
+            runtime_import,
+            "",
+            *reader_lines,
+        ]
+        return "\n".join(lines).rstrip() + "\n"
+
+    @staticmethod
+    def _series_reader_module_imports(lines: Sequence[str]) -> list[str]:
+        """Return leaf-index / address / `read_*` symbols defined in `_readers` source."""
+        names: list[str] = []
+        for line in lines:
+            match = re.match(
+                r"^(?:(_LEAF_INDEX_[A-Z0-9_]+|_READER_ADDRESSES_[A-Z0-9_]+) =|"
+                r"def (read_[a-z0-9_]+)\()",
+                line,
+            )
+            if match:
+                name = match.group(1) or match.group(2)
+                if name not in names:
+                    names.append(name)
+        return names
+
+    @staticmethod
+    def _format_from_module_import(module: str, names: list[str]) -> str:
+        """Format a relative `from .<module> import ...` statement."""
+        if not names:
+            return ""
+        joined = ", ".join(names)
+        prefix = f"from .{module} import "
+        if len(prefix) + len(joined) <= 88:
+            return prefix + joined
+        inner = ",\n    ".join(names)
+        return f"{prefix}(\n    {inner},\n)"
 
     _SERIES_HELPER_IMPORT_NAMES: tuple[str, ...] = (
         "DataFrameInput",
@@ -2318,6 +2387,7 @@ class CodeGenerator:
             input_ranges=input_ranges,
             blank_ranges=blank_ranges,
             series_bindings=series_bindings,
+            bindings_workbook=bindings_workbook,
         )
         runtime_code = parts["runtime_code"]
         cell_code_lines = parts["cell_code_lines"]
@@ -2462,6 +2532,10 @@ class CodeGenerator:
         - data.py: DEFAULT_INPUTS and CONSTANTS
         - runtime.py: embedded Excel runtime (emit_runtime)
         - internals.py: formula cell functions + resolver dispatch
+
+        When series bindings declare input series, the package also includes:
+        - `_readers.py`: leaf maps and `read_*` duals (imported by `api` and `internals`)
+        - `_api_helpers.py`: coercion helpers for setters
         """
         normalized_targets = self._resolve_targets(targets)
 
@@ -2474,6 +2548,7 @@ class CodeGenerator:
             input_ranges=input_ranges,
             blank_ranges=blank_ranges,
             series_bindings=series_bindings,
+            bindings_workbook=bindings_workbook,
         )
         runtime_code = parts["runtime_code"]
         cell_code_lines = parts["cell_code_lines"]
@@ -2511,6 +2586,10 @@ class CodeGenerator:
         )
         runtime_import_block = self._format_from_runtime_import(internals_import_names)
         internals_lines: list[str] = ["from __future__ import annotations", ""]
+        used_readers = sorted(self._used_readers)
+        if used_readers:
+            internals_lines.append(self._format_from_module_import("_readers", used_readers))
+            internals_lines.append("")
         if runtime_import_block:
             internals_lines.append(runtime_import_block)
             internals_lines.append("")
@@ -2561,18 +2640,38 @@ class CodeGenerator:
         reader_leaves: dict[str, dict[str, object]] | None = None
         reader_ranges: dict[str, dict[str, object]] | None = None
         api_helpers_py: str | None = None
+        readers_py: str | None = None
         if series_bindings is not None:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
-            # Route the verbose input-coercion helpers to a private `_api_helpers`
-            # module so `api.py` stays focused on the public surface.
+            # Route coercion helpers to `_api_helpers` and leaf maps / readers to
+            # `_readers` so `api.py` stays focused on the public surface and
+            # `internals.py` can call `read_*` without an import cycle.
             emit_input = self._series_bindings_have_input(series_bindings)
+            reader_lines: list[str] = []
+            if emit_input:
+                from excel_grapher.series_bindings.setter_codegen import emit_readers_block
+
+                reader_lines = emit_readers_block(
+                    cast("DependencyGraph", self._public_graph()),
+                    bindings_workbook,
+                    series_bindings,
+                    export_addresses=self._export_addresses_with_aliases(
+                        _all_cells,
+                        series_public_addresses,
+                    ),
+                    series_docstring_callback=series_docstring_callback,
+                    docstring_renderer=docstring_renderer,
+                )
+                readers_py = self._emit_readers_module(reader_lines)
             setter_lines = self._emit_series_binding_setters(
                 series_bindings,
                 bindings_workbook,
                 export_addresses=_all_cells,
                 public_addresses=series_public_addresses,
                 include_helpers=not emit_input,
+                include_readers=not emit_input,
+                include_leaf_indexes=not emit_input,
                 series_docstring_callback=series_docstring_callback,
                 docstring_renderer=docstring_renderer,
             )
@@ -2580,12 +2679,33 @@ class CodeGenerator:
                 runtime_entry_names.append("xl_range")
                 runtime_entry_names.sort()
                 runtime_imports = self._format_from_runtime_import(runtime_entry_names)
-                api_lines[4] = runtime_imports
+                for idx, line in enumerate(api_lines):
+                    if line.startswith("from .runtime import"):
+                        end = idx + 1
+                        if line.startswith("from .runtime import ("):
+                            while end < len(api_lines) and not api_lines[end].startswith(")"):
+                                end += 1
+                            end += 1
+                        api_lines[idx:end] = [runtime_imports]
+                        break
+            insert_at = next(
+                i for i, line in enumerate(api_lines) if line.startswith("import warnings")
+            )
             if emit_input:
                 api_helpers_py = self._emit_api_helpers_module()
                 helper_imports = self._series_helper_imports(setter_lines)
                 if helper_imports:
-                    api_lines.insert(4, f"from ._api_helpers import {', '.join(helper_imports)}")
+                    api_lines.insert(
+                        insert_at,
+                        self._format_from_module_import("_api_helpers", helper_imports),
+                    )
+                    insert_at += 1
+                reader_imports = self._series_reader_module_imports(reader_lines)
+                if reader_imports:
+                    api_lines.insert(
+                        insert_at,
+                        self._format_from_module_import("_readers", reader_imports),
+                    )
             api_lines.extend(setter_lines)
             (
                 series_setter_names,
@@ -2593,14 +2713,21 @@ class CodeGenerator:
                 series_compute_names,
             ) = self._series_binding_public_names(series_bindings)
             series_range_reader_names = self._series_binding_emitted_range_reader_names(
-                setter_lines
+                reader_lines if reader_lines else setter_lines
             )
-            reader_leaves, reader_ranges = self._series_binding_reader_discovery(
-                cast("DependencyGraph", self._public_graph()),
-                series_bindings,
-                workbook=bindings_workbook,
-                export_addresses=_all_cells,
-            )
+            if self._reader_index is not None:
+                from excel_grapher.series_bindings.reader_index import (
+                    reader_index_as_discovery_dicts,
+                )
+
+                reader_leaves, reader_ranges = reader_index_as_discovery_dicts(self._reader_index)
+            else:
+                reader_leaves, reader_ranges = self._series_binding_reader_discovery(
+                    cast("DependencyGraph", self._public_graph()),
+                    series_bindings,
+                    workbook=bindings_workbook,
+                    export_addresses=_all_cells,
+                )
             api_lines.append("")
         else:
             series_range_reader_names = []
@@ -2686,8 +2813,8 @@ class CodeGenerator:
         }
         if api_helpers_py is not None:
             modules["_api_helpers.py"] = api_helpers_py
-        if groups_manifest is not None:
-            modules["groups.json"] = json.dumps(groups_manifest, indent=2) + "\n"
+        if readers_py is not None:
+            modules["_readers.py"] = readers_py
         return modules
 
     def _workbook_sort_addresses(self, addresses: Iterable[str]) -> list[str]:
@@ -2711,6 +2838,7 @@ class CodeGenerator:
         input_ranges: Sequence[str] | None = None,
         blank_ranges: Sequence[str] | None = None,
         series_bindings: WorkbookSeriesBindings | None = None,
+        bindings_workbook: Path | str | None = None,
     ) -> GenerationParts:
         """Generate shared intermediate artifacts for single-file and modular exports."""
         self._reset_transient_state()
@@ -2731,6 +2859,29 @@ class CodeGenerator:
         # package can evaluate the full excel_grapher dependency closure (for the workbook's
         # cached state) without missing-cell KeyErrors.
         all_cells = self._collect_all_cells(normalized_dependency_targets)
+
+        if (
+            series_bindings is not None
+            and bindings_workbook is not None
+            and self._series_bindings_have_input(series_bindings)
+        ):
+            from excel_grapher.series_bindings.reader_index import build_reader_index
+
+            series_public = self._series_binding_public_addresses(
+                series_bindings,
+                bindings_workbook,
+            )
+            self._reader_index = build_reader_index(
+                cast("DependencyGraph", self._public_graph()),
+                series_bindings,
+                workbook=bindings_workbook,
+                export_addresses=self._export_addresses_with_aliases(
+                    all_cells,
+                    series_public,
+                ),
+            )
+        else:
+            self._reader_index = None
 
         # Generate formula cell functions and collect used xl_* functions
         self._emitted.clear()
@@ -2819,6 +2970,9 @@ class CodeGenerator:
             series_bindings
         ):
             runtime_symbols.add("xl_range")
+        if series_bindings is not None and self._series_bindings_have_input(series_bindings):
+            # Generated `read_*` annotations return `CellValue`.
+            runtime_symbols.add("CellValue")
         if self._iterate_enabled:
             runtime_symbols.add("xl_iterative_compute")
         include_dep_tracking = self._include_dep_tracking(series_bindings)

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -619,31 +619,47 @@ class CodeGenerator:
         return "\n".join(lines).rstrip() + "\n"
 
     @staticmethod
-    def _series_reader_module_imports(lines: Sequence[str]) -> list[str]:
-        """Return leaf-index / address / `read_*` symbols defined in `_readers` source."""
+    def _series_reader_leaf_index_imports(lines: Sequence[str]) -> list[str]:
+        """Return `_LEAF_INDEX_*` symbols that setters in `api.py` need to import."""
         names: list[str] = []
         for line in lines:
-            match = re.match(
-                r"^(?:(_LEAF_INDEX_[A-Z0-9_]+|_READER_ADDRESSES_[A-Z0-9_]+) =|"
-                r"def (read_[a-z0-9_]+)\()",
-                line,
-            )
+            match = re.match(r"^(_LEAF_INDEX_[A-Z0-9_]+) =", line)
             if match:
-                name = match.group(1) or match.group(2)
+                name = match.group(1)
                 if name not in names:
                     names.append(name)
         return names
 
     @staticmethod
-    def _format_from_module_import(module: str, names: list[str]) -> str:
+    def _series_reader_public_imports(lines: Sequence[str]) -> list[str]:
+        """Return public `read_*` symbols defined in `_readers` for package re-export."""
+        names: list[str] = []
+        for line in lines:
+            match = re.match(r"^def (read_[a-z0-9_]+)\(", line)
+            if match:
+                name = match.group(1)
+                if name not in names:
+                    names.append(name)
+        return names
+
+    @staticmethod
+    def _format_from_module_import(
+        module: str,
+        names: list[str],
+        *,
+        noqa: str | None = None,
+    ) -> str:
         """Format a relative `from .<module> import ...` statement."""
         if not names:
             return ""
         joined = ", ".join(names)
         prefix = f"from .{module} import "
-        if len(prefix) + len(joined) <= 88:
-            return prefix + joined
+        suffix = f"  # noqa: {noqa}" if noqa else ""
+        if len(prefix) + len(joined) + len(suffix) <= 88:
+            return prefix + joined + suffix
         inner = ",\n    ".join(names)
+        if noqa:
+            return f"{prefix}(  # noqa: {noqa}\n    {inner},\n)"
         return f"{prefix}(\n    {inner},\n)"
 
     _SERIES_HELPER_IMPORT_NAMES: tuple[str, ...] = (
@@ -1036,15 +1052,14 @@ class CodeGenerator:
         if "def " not in blob:
             return []
         names = set(used_xl_functions)
-        names.update({"xl_cell", "xl_eval"})
-        if "xl_range(" in blob:
-            names.add("xl_range")
-        if "xl_raise(" in blob:
-            names.add("xl_raise")
-        if "XlError" in blob:
-            names.add("XlError")
-        if "ExcelRange(" in blob:
-            names.add("ExcelRange")
+        # Only pull symbols that appear in emitted bodies. After Phase 2, bound
+        # leaves may use `read_*` exclusively, so `xl_cell` is not always needed.
+        for symbol in ("xl_cell", "xl_eval", "xl_range", "xl_raise", "XlError", "ExcelRange"):
+            if symbol == "XlError":
+                if "XlError" in blob:
+                    names.add(symbol)
+            elif f"{symbol}(" in blob:
+                names.add(symbol)
         return sorted(names)
 
     @staticmethod
@@ -2460,12 +2475,19 @@ class CodeGenerator:
                 )
             )
             lines.append("")
-            reader_leaves, reader_ranges = self._series_binding_reader_discovery(
-                cast("DependencyGraph", self._public_graph()),
-                series_bindings,
-                workbook=bindings_workbook,
-                export_addresses=_all_cells,
-            )
+            if self._reader_index is not None:
+                from excel_grapher.series_bindings.reader_index import (
+                    reader_index_as_discovery_dicts,
+                )
+
+                reader_leaves, reader_ranges = reader_index_as_discovery_dicts(self._reader_index)
+            else:
+                reader_leaves, reader_ranges = self._series_binding_reader_discovery(
+                    cast("DependencyGraph", self._public_graph()),
+                    series_bindings,
+                    workbook=bindings_workbook,
+                    export_addresses=_all_cells,
+                )
         lines.extend(
             self._emit_series_binding_discovery_lines(
                 series_setter_names,
@@ -2589,9 +2611,9 @@ class CodeGenerator:
         used_readers = sorted(self._used_readers)
         if used_readers:
             internals_lines.append(self._format_from_module_import("_readers", used_readers))
-            internals_lines.append("")
         if runtime_import_block:
             internals_lines.append(runtime_import_block)
+        if used_readers or runtime_import_block:
             internals_lines.append("")
         internals_lines.append("# --- Formula cell functions ---\n")
         internals_lines.extend(cell_code_lines)
@@ -2601,46 +2623,19 @@ class CodeGenerator:
         )
         internals_py = "\n".join(internals_lines).rstrip() + "\n"
 
-        runtime_entry_names = ["EvalContext", "coerce_inputs_dict", "xl_cell"]
-        if needs_range_helper:
-            runtime_entry_names.append("xl_range_rows")
-        if self._iterate_enabled:
-            runtime_entry_names.append("xl_iterative_compute")
-        runtime_entry_names.sort()
-        runtime_imports = self._format_from_runtime_import(runtime_entry_names)
-
-        api_lines: list[str] = [
-            "from __future__ import annotations",
-            "",
-            "from .data import CONSTANTS, DEFAULT_INPUTS",
-            "from .internals import _resolve_formula",
-            runtime_imports,
-            "import warnings",
-            "",
-            "",
-            "def make_context(inputs: dict[str, object] | None = None) -> EvalContext:",
-            '    """Create an EvalContext with merged inputs."""',
-            "    merged: dict[str, object] = dict(DEFAULT_INPUTS)",
-            "    merged.update(CONSTANTS)",
-            "    if inputs is not None:",
-            "        merged.update(inputs)",
-            (
-                "    return EvalContext("
-                "inputs=coerce_inputs_dict(merged), resolver=_resolve_formula, "
-                f"iterative_enabled={bool(self._iterate_enabled)}, "
-                f"iterate_count={int(self._iterate_count)}, "
-                f"iterate_delta={float(self._iterate_delta)!r})"
-            ),
-            "",
-            "",
-        ]
         series_setter_names: list[str] = []
         series_reader_names: list[str] = []
         series_compute_names: list[str] = []
+        series_range_reader_names: list[str] = []
         reader_leaves: dict[str, dict[str, object]] | None = None
         reader_ranges: dict[str, dict[str, object]] | None = None
         api_helpers_py: str | None = None
         readers_py: str | None = None
+        reader_lines: list[str] = []
+        setter_lines: list[str] = []
+        leaf_index_imports: list[str] = []
+        helper_imports: list[str] = []
+        public_reader_imports: list[str] = []
         if series_bindings is not None:
             if bindings_workbook is None:
                 raise ValueError("bindings_workbook is required when series_bindings is set")
@@ -2648,7 +2643,6 @@ class CodeGenerator:
             # `_readers` so `api.py` stays focused on the public surface and
             # `internals.py` can call `read_*` without an import cycle.
             emit_input = self._series_bindings_have_input(series_bindings)
-            reader_lines: list[str] = []
             if emit_input:
                 from excel_grapher.series_bindings.setter_codegen import emit_readers_block
 
@@ -2664,6 +2658,8 @@ class CodeGenerator:
                     docstring_renderer=docstring_renderer,
                 )
                 readers_py = self._emit_readers_module(reader_lines)
+                leaf_index_imports = self._series_reader_leaf_index_imports(reader_lines)
+                public_reader_imports = self._series_reader_public_imports(reader_lines)
             setter_lines = self._emit_series_binding_setters(
                 series_bindings,
                 bindings_workbook,
@@ -2675,38 +2671,9 @@ class CodeGenerator:
                 series_docstring_callback=series_docstring_callback,
                 docstring_renderer=docstring_renderer,
             )
-            if "xl_range(" in "\n".join(setter_lines):
-                runtime_entry_names.append("xl_range")
-                runtime_entry_names.sort()
-                runtime_imports = self._format_from_runtime_import(runtime_entry_names)
-                for idx, line in enumerate(api_lines):
-                    if line.startswith("from .runtime import"):
-                        end = idx + 1
-                        if line.startswith("from .runtime import ("):
-                            while end < len(api_lines) and not api_lines[end].startswith(")"):
-                                end += 1
-                            end += 1
-                        api_lines[idx:end] = [runtime_imports]
-                        break
-            insert_at = next(
-                i for i, line in enumerate(api_lines) if line.startswith("import warnings")
-            )
             if emit_input:
                 api_helpers_py = self._emit_api_helpers_module()
                 helper_imports = self._series_helper_imports(setter_lines)
-                if helper_imports:
-                    api_lines.insert(
-                        insert_at,
-                        self._format_from_module_import("_api_helpers", helper_imports),
-                    )
-                    insert_at += 1
-                reader_imports = self._series_reader_module_imports(reader_lines)
-                if reader_imports:
-                    api_lines.insert(
-                        insert_at,
-                        self._format_from_module_import("_readers", reader_imports),
-                    )
-            api_lines.extend(setter_lines)
             (
                 series_setter_names,
                 series_reader_names,
@@ -2728,51 +2695,97 @@ class CodeGenerator:
                     workbook=bindings_workbook,
                     export_addresses=_all_cells,
                 )
-            api_lines.append("")
-        else:
-            series_range_reader_names = []
+
         groups_manifest = self._series_binding_groups_manifest(series_bindings)
-        api_lines.extend(
-            self._emit_series_binding_discovery_lines(
-                series_setter_names,
-                series_compute_names,
-                groups_manifest,
-                reader_names=series_reader_names,
-                reader_leaves=reader_leaves,
-                reader_ranges=reader_ranges,
-            )
+        discovery_lines = self._emit_series_binding_discovery_lines(
+            series_setter_names,
+            series_compute_names,
+            groups_manifest,
+            reader_names=series_reader_names,
+            reader_leaves=reader_leaves,
+            reader_ranges=reader_ranges,
         )
-        api_lines.append("")
-        api_lines.append("")
-        api_lines.append("TARGETS = {")
-        for target, handler in targets_entries:
-            api_lines.append(f"    {repr(target)}: {handler},")
-        api_lines.extend(
+        api_body_lines: list[str] = [
+            "def make_context(inputs: dict[str, object] | None = None) -> EvalContext:",
+            '    """Create an EvalContext with merged inputs."""',
+            "    merged: dict[str, object] = dict(DEFAULT_INPUTS)",
+            "    merged.update(CONSTANTS)",
+            "    if inputs is not None:",
+            "        merged.update(inputs)",
+            (
+                "    return EvalContext("
+                "inputs=coerce_inputs_dict(merged), resolver=_resolve_formula, "
+                f"iterative_enabled={bool(self._iterate_enabled)}, "
+                f"iterate_count={int(self._iterate_count)}, "
+                f"iterate_delta={float(self._iterate_delta)!r})"
+            ),
+            "",
+            "",
+            *setter_lines,
+            *([] if not setter_lines else [""]),
+            *discovery_lines,
+            "",
+            "",
+            "TARGETS = {",
+            *[f"    {repr(target)}: {handler}," for target, handler in targets_entries],
+            "}",
+            "",
+            "",
+            "def compute_all(ctx: EvalContext | None = None, *, "
+            "inputs: dict[str, object] | None = None) -> dict[str, object]:",
+            '    """Compute all target cells and return results."""',
+            "    if ctx is None:",
+            "        ctx = make_context(inputs)",
+            "    elif inputs is not None:",
+            "        warnings.warn(",
+            '            "inputs will be ignored because ctx was provided",',
+            "            UserWarning,",
+            "            stacklevel=2,",
+            "        )",
+            (
+                "    return xl_iterative_compute(ctx, TARGETS)"
+                if self._iterate_enabled
+                else "    return {target: handler(ctx, target) for target, handler in TARGETS.items()}"
+            ),
+            "",
+        ]
+        api_body_text = "\n".join(api_body_lines)
+        runtime_entry_names = ["EvalContext", "coerce_inputs_dict"]
+        # TARGETS may reference handlers by name (`xl_cell`, `xl_range_rows`) without a call.
+        if re.search(r"\bxl_cell\b", api_body_text):
+            runtime_entry_names.append("xl_cell")
+        if re.search(r"\bxl_range\b", api_body_text):
+            runtime_entry_names.append("xl_range")
+        if needs_range_helper or re.search(r"\bxl_range_rows\b", api_body_text):
+            runtime_entry_names.append("xl_range_rows")
+        if self._iterate_enabled:
+            runtime_entry_names.append("xl_iterative_compute")
+        runtime_entry_names = sorted(set(runtime_entry_names))
+        runtime_imports = self._format_from_runtime_import(runtime_entry_names)
+
+        api_import_lines: list[str] = [
+            "from __future__ import annotations",
+            "",
+            "import warnings",
+            "",
+        ]
+        if helper_imports:
+            api_import_lines.append(self._format_from_module_import("_api_helpers", helper_imports))
+        if leaf_index_imports:
+            api_import_lines.append(self._format_from_module_import("_readers", leaf_index_imports))
+        api_import_lines.extend(
             [
-                "}",
+                "from .data import CONSTANTS, DEFAULT_INPUTS",
+                "from .internals import _resolve_formula",
+                runtime_imports,
                 "",
-                "",
-                "def compute_all(ctx: EvalContext | None = None, *, "
-                "inputs: dict[str, object] | None = None) -> dict[str, object]:",
-                '    """Compute all target cells and return results."""',
-                "    if ctx is None:",
-                "        ctx = make_context(inputs)",
-                "    elif inputs is not None:",
-                "        warnings.warn(",
-                '            "inputs will be ignored because ctx was provided",',
-                "            UserWarning,",
-                "            stacklevel=2,",
-                "        )",
-                (
-                    "    return xl_iterative_compute(ctx, TARGETS)"
-                    if self._iterate_enabled
-                    else "    return {target: handler(ctx, target) for target, handler in TARGETS.items()}"
-                ),
                 "",
             ]
         )
-        api_py = "\n".join(api_lines)
+        api_py = "\n".join([*api_import_lines, *api_body_lines])
 
+        # Symbols defined in `api.py` (readers live in `_readers` and are imported
+        # separately into `__init__.py` for the public package surface).
         api_exports = [
             "compute_all",
             "make_context",
@@ -2787,22 +2800,50 @@ class CodeGenerator:
         if groups_manifest is not None:
             api_exports.append("list_groups")
         api_exports.extend(series_setter_names)
-        api_exports.extend(series_reader_names)
-        api_exports.extend(series_range_reader_names)
         api_exports.extend(series_compute_names)
-        api_imports = ", ".join(api_exports)
-        all_exports = api_exports + ["DEFAULT_INPUTS"]
-        init_py = "\n".join(
+
+        # Package `__all__` keeps prior discovery → setters → readers → computes order.
+        all_exports = [
+            "compute_all",
+            "make_context",
+            "list_setters",
+            "list_readers",
+            "list_computes",
+        ]
+        if reader_leaves is not None:
+            all_exports.append("list_reader_leaves")
+        if reader_ranges is not None:
+            all_exports.append("list_reader_ranges")
+        if groups_manifest is not None:
+            all_exports.append("list_groups")
+        all_exports.extend(series_setter_names)
+        all_exports.extend(series_reader_names)
+        all_exports.extend(series_range_reader_names)
+        all_exports.extend(series_compute_names)
+        all_exports.append("DEFAULT_INPUTS")
+        init_lines = [
+            "from __future__ import annotations",
+            "",
+        ]
+        if public_reader_imports:
+            init_lines.append(
+                self._format_from_module_import(
+                    "_readers",
+                    public_reader_imports,
+                    noqa="F401",
+                )
+            )
+        # Import names are sorted for isort; `__all__` keeps the deliberate public order.
+        init_lines.append(self._format_from_module_import("api", sorted(api_exports), noqa="F401"))
+        init_lines.extend(
             [
-                "from __future__ import annotations",
-                "",
-                f"from .api import {api_imports}  # noqa: F401",
                 "from .data import DEFAULT_INPUTS  # noqa: F401",
                 "",
                 f"__all__ = {all_exports!r}",
                 "",
             ]
         )
+        init_py = "\n".join(init_lines)
 
         modules = {
             "__init__.py": init_py,
@@ -2860,29 +2901,6 @@ class CodeGenerator:
         # cached state) without missing-cell KeyErrors.
         all_cells = self._collect_all_cells(normalized_dependency_targets)
 
-        if (
-            series_bindings is not None
-            and bindings_workbook is not None
-            and self._series_bindings_have_input(series_bindings)
-        ):
-            from excel_grapher.series_bindings.reader_index import build_reader_index
-
-            series_public = self._series_binding_public_addresses(
-                series_bindings,
-                bindings_workbook,
-            )
-            self._reader_index = build_reader_index(
-                cast("DependencyGraph", self._public_graph()),
-                series_bindings,
-                workbook=bindings_workbook,
-                export_addresses=self._export_addresses_with_aliases(
-                    all_cells,
-                    series_public,
-                ),
-            )
-        else:
-            self._reader_index = None
-
         # Generate formula cell functions and collect used xl_* functions
         self._emitted.clear()
         cell_code_lines: list[str] = []
@@ -2932,6 +2950,34 @@ class CodeGenerator:
                 for address in all_graph_cells:
                     _track_cell(address)
                     all_cells.append(address)
+
+        # Build the reader index after the export surface is final (including any
+        # OFFSET widening) so discovery and body rewrite share one map. Clear
+        # `_used_readers` first: the probe `_emit_ast` pass above may have
+        # touched the (previously unset) index without contributing to emit.
+        self._used_readers.clear()
+        if (
+            series_bindings is not None
+            and bindings_workbook is not None
+            and self._series_bindings_have_input(series_bindings)
+        ):
+            from excel_grapher.series_bindings.reader_index import build_reader_index
+
+            series_public = self._series_binding_public_addresses(
+                series_bindings,
+                bindings_workbook,
+            )
+            self._reader_index = build_reader_index(
+                cast("DependencyGraph", self._public_graph()),
+                series_bindings,
+                workbook=bindings_workbook,
+                export_addresses=self._export_addresses_with_aliases(
+                    all_cells,
+                    series_public,
+                ),
+            )
+        else:
+            self._reader_index = None
 
         for address in self._workbook_sort_addresses(formula_emit_order):
             formula_cells.add(address)

--- a/excel_grapher/series_bindings/bindings_codegen.py
+++ b/excel_grapher/series_bindings/bindings_codegen.py
@@ -25,6 +25,8 @@ def emit_series_bindings_block(
     *,
     export_addresses: Iterable[str] | None = None,
     include_helpers: bool = True,
+    include_readers: bool = True,
+    include_leaf_indexes: bool = True,
     series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
 ) -> list[str]:
@@ -34,6 +36,9 @@ def emit_series_bindings_block(
     (single-file export). When false only the public setter/reader/compute functions are
     emitted; the helpers and aliases are expected to be importable from a separate
     module (the multi-module export's `_api_helpers`).
+
+    When `include_readers` / `include_leaf_indexes` are false, those symbols are omitted
+    so a dedicated `_readers` module can own them (modular export).
     """
     series_list = bindings_export_order(bindings)
     emit_input = any(has_input_direction(s) for s in series_list)
@@ -53,6 +58,8 @@ def emit_series_bindings_block(
                 export_addresses=export_addresses,
                 include_type_aliases=include_aliases,
                 include_helpers=include_helpers,
+                include_readers=include_readers,
+                include_leaf_indexes=include_leaf_indexes,
                 series_docstring_callback=series_docstring_callback,
                 docstring_renderer=docstring_renderer,
             )

--- a/excel_grapher/series_bindings/groups.py
+++ b/excel_grapher/series_bindings/groups.py
@@ -1,7 +1,7 @@
 """View-level series binding groups: export sequencing and group manifest.
 
-Groups are a presentation concern of the generated `set_*`/`compute_*` API.
-They sequence code export and feed documentation tooling; they never affect
+Groups are a presentation concern of the generated `set_*`/`compute_*`/`read_*` API.
+They sequence code export and power `list_groups()` discovery; they never affect
 graph extraction, binding resolution, or record semantics.
 """
 
@@ -35,7 +35,7 @@ class GroupNode(TypedDict):
 
 
 class GroupsManifest(TypedDict):
-    """Machine-readable group structure for documentation tooling."""
+    """Machine-readable group structure returned by generated `list_groups()`."""
 
     groups: list[GroupNode]
     ungrouped: list[GroupMember]
@@ -225,7 +225,7 @@ def _manifest_node(node: _TreeNode) -> GroupNode:
 def group_manifest(
     bindings: WorkbookSeriesBindings | dict[str, Any],
 ) -> GroupsManifest:
-    """Build the nested group manifest consumed by documentation tooling.
+    """Build the nested group manifest returned by generated `list_groups()`.
 
     Unlike `bindings_export_order`, a multi-membership binding appears under
     every group it references.

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -247,11 +247,6 @@ def emit_leaf_index_lines(series: dict[str, Any], resolved: SeriesResolution) ->
     return lines
 
 
-def leaf_index_symbol_name(series_id: str) -> str:
-    """Return the generated `_LEAF_INDEX_<ID>` symbol for a series id."""
-    return _leaf_index_name(series_id)
-
-
 def dimension_id_to_param_name(field: str) -> str:
     """Convert an SDMX / effective dimension id to a Python keyword parameter name.
 
@@ -528,7 +523,8 @@ def emit_reader_function(
     """Emit a `read_*` dual that resolves domain keys via `_LEAF_INDEX_*`.
 
     For uniquely keyed series, expects the matching `_LEAF_INDEX_<ID>` constant to
-    already be present (normally emitted by `emit_setter_function`). For duplicate-key
+    already be present (emitted by `emit_leaf_index_lines` / `emit_readers_block`, or
+    co-emitted by `emit_setter_function` in single-file mode). For duplicate-key
     bindings (`requires_address`), emits an address-keyed reader validated against the
     resolved leaf addresses — the inverse of the address-required setter path.
     """

--- a/excel_grapher/series_bindings/setter_codegen.py
+++ b/excel_grapher/series_bindings/setter_codegen.py
@@ -28,6 +28,7 @@ from excel_grapher.series_bindings.resolve import (
     warn_series_resolution_issues,
 )
 from excel_grapher.series_bindings.types import (
+    ResolutionReport,
     SeriesResolution,
     WorkbookSeriesBindings,
 )
@@ -231,6 +232,26 @@ def _leaf_index_name(series_id: str) -> str:
     return f"_LEAF_INDEX_{series_id.upper()}"
 
 
+def emit_leaf_index_lines(series: dict[str, Any], resolved: SeriesResolution) -> list[str]:
+    """Emit the `_LEAF_INDEX_<ID>` constant shared by a setter/reader dual."""
+    if resolved["requires_address"]:
+        return []
+    key_fields = [str(c) for c in (series.get("key") or [])]
+    index_name = _leaf_index_name(resolved["series_id"])
+    lines = [f"{index_name} = {{"]
+    for leaf in resolved["leaves"]:
+        key_tuple_src = _key_tuple_literal(key_fields, leaf["key"])
+        lines.append(f"    {key_tuple_src}: {repr(leaf['address'])},")
+    lines.append("}")
+    lines.append("")
+    return lines
+
+
+def leaf_index_symbol_name(series_id: str) -> str:
+    """Return the generated `_LEAF_INDEX_<ID>` symbol for a series id."""
+    return _leaf_index_name(series_id)
+
+
 def dimension_id_to_param_name(field: str) -> str:
     """Convert an SDMX / effective dimension id to a Python keyword parameter name.
 
@@ -395,6 +416,7 @@ def emit_setter_function(
     bindings: WorkbookSeriesBindings | None = None,
     series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
     docstring_renderer: SeriesDocstringRendererSpec = "google",
+    include_leaf_index: bool = True,
 ) -> list[str]:
     """Emit Python source lines for one series binding setter."""
     if not resolved["leaves"]:
@@ -420,13 +442,8 @@ def emit_setter_function(
     index_name = _leaf_index_name(resolved["series_id"])
 
     lines: list[str] = []
-    if not requires_address:
-        lines.append(f"{index_name} = {{")
-        for leaf in resolved["leaves"]:
-            key_tuple_src = _key_tuple_literal(key_fields, leaf["key"])
-            lines.append(f"    {key_tuple_src}: {repr(leaf['address'])},")
-        lines.append("}")
-        lines.append("")
+    if include_leaf_index and not requires_address:
+        lines.extend(emit_leaf_index_lines(series, resolved))
     lines.extend(_emit_key_order_constant(resolved, key_fields))
     scalar_shorthand = _accepts_scalar_shorthand(series, resolved)
     concept_scheme = bindings.get("concept_scheme") if bindings is not None else None
@@ -521,9 +538,9 @@ def emit_reader_function(
     key_fields = [str(c) for c in (series.get("key") or [])]
     fn_name = _reader_function_name(series, resolved)
     index_name = _leaf_index_name(resolved["series_id"])
-    # `xl_cell` returns the full CellValue union; keep the annotation wide so
-    # exported packages type-check without embedding CellValue in api.py.
-    return_annotation = "object"
+    # Readers live in `_readers.py` (modular) or alongside the runtime embed
+    # (single-file), both of which expose `CellValue`.
+    return_annotation = "CellValue"
     key_dtypes = _key_dtypes_for_codegen(series, key_fields)
     requires_address = bool(resolved["requires_address"])
 
@@ -623,7 +640,7 @@ def emit_reader_range_function(
 
     reader_name = _reader_function_name(series, resolved)
     fn_name = f"{reader_name}_range"
-    lines: list[str] = [f"def {fn_name}(ctx: EvalContext) -> object:"]
+    lines: list[str] = [f"def {fn_name}(ctx: EvalContext) -> CellValue:"]
     if series_docstring_callback is not None and (
         graph is None or workbook is None or bindings is None
     ):
@@ -649,24 +666,14 @@ def emit_reader_range_function(
     return lines
 
 
-def emit_setters_block(
+def _iter_input_resolutions(
     graph: DependencyGraph,
     workbook: Path | str,
     bindings: WorkbookSeriesBindings,
     *,
     export_addresses: Iterable[str] | None = None,
-    include_type_aliases: bool = True,
-    include_helpers: bool = True,
-    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
-    docstring_renderer: SeriesDocstringRendererSpec = "google",
-) -> list[str]:
-    """Emit all series setter and reader functions for a validated binding manifest.
-
-    When `include_helpers` is true the coercion/record-apply helpers and type aliases
-    are inlined alongside the setters (single-file export). When false only the setter
-    and reader functions are emitted and callers must supply the helpers separately, e.g. via a
-    dedicated `_api_helpers` module in the multi-module export.
-    """
+) -> tuple[list[tuple[dict[str, Any], SeriesResolution]], list[str], ResolutionReport]:
+    """Resolve input series and return (pairs, failed ids, report)."""
     report = resolve_series_bindings(
         graph,
         bindings,
@@ -674,27 +681,12 @@ def emit_setters_block(
         direction="input",
         export_addresses=export_addresses,
     )
-    lines: list[str] = ["# --- Series binding setters (Records API) ---", ""]
-    concept_scheme = bindings.get("concept_scheme")
-    if not isinstance(concept_scheme, dict):
-        concept_scheme = None
-    include_datetime = resolutions_include_datetime(report["series"]) or any(
-        _measure_dtype_for_codegen(series, concept_scheme=concept_scheme) == "datetime"
-        for series in bindings.get("series", [])
-        if isinstance(series, dict) and has_input_direction(series)
-    )
-    if include_helpers:
-        lines.extend(emit_input_coerce_helpers())
-        if include_type_aliases:
-            lines.extend(emit_setter_type_alias_lines(include_datetime=include_datetime))
-        lines.extend(emit_setter_helpers())
-    elif include_datetime:
-        lines.extend(["from datetime import datetime", ""])
     by_id = {
         s["id"]: s
         for s in bindings.get("series", [])
         if isinstance(s, dict) and has_input_direction(s)
     }
+    pairs: list[tuple[dict[str, Any], SeriesResolution]] = []
     failed: list[str] = []
     for resolved in report["series"]:
         if not resolved["ok"] and not resolved["requires_address"]:
@@ -711,17 +703,45 @@ def emit_setters_block(
         series = by_id.get(resolved["series_id"])
         if series is None:
             continue
-        lines.extend(
-            emit_setter_function(
-                series,
-                resolved,
-                graph=graph,
-                workbook=workbook,
-                bindings=bindings,
-                series_docstring_callback=series_docstring_callback,
-                docstring_renderer=docstring_renderer,
-            )
-        )
+        pairs.append((series, resolved))
+    return pairs, failed, report
+
+
+def emit_readers_block(
+    graph: DependencyGraph,
+    workbook: Path | str,
+    bindings: WorkbookSeriesBindings,
+    *,
+    export_addresses: Iterable[str] | None = None,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
+    docstring_renderer: SeriesDocstringRendererSpec = "google",
+    include_leaf_indexes: bool = True,
+) -> list[str]:
+    """Emit `_LEAF_INDEX_*` maps and `read_*` / `read_*_range` functions.
+
+    Used by the modular export's private `_readers.py` module so formula bodies
+    can call readers without importing the public `api` module.
+    """
+    pairs, failed, report = _iter_input_resolutions(
+        graph,
+        workbook,
+        bindings,
+        export_addresses=export_addresses,
+    )
+    lines: list[str] = ["# --- Series binding readers ---", ""]
+    concept_scheme = bindings.get("concept_scheme")
+    if not isinstance(concept_scheme, dict):
+        concept_scheme = None
+    include_datetime = resolutions_include_datetime(report["series"]) or any(
+        _measure_dtype_for_codegen(series, concept_scheme=concept_scheme) == "datetime"
+        for series in bindings.get("series", [])
+        if isinstance(series, dict) and has_input_direction(series)
+    )
+    if include_datetime:
+        lines.extend(["from datetime import datetime", ""])
+    for series, resolved in pairs:
+        if include_leaf_indexes:
+            lines.extend(emit_leaf_index_lines(series, resolved))
         lines.extend(
             emit_reader_function(
                 series,
@@ -744,6 +764,92 @@ def emit_setters_block(
                 docstring_renderer=docstring_renderer,
             )
         )
+    if failed:
+        raise ValueError(f"Cannot codegen readers: resolution failed for {failed!r}")
+    return lines
+
+
+def emit_setters_block(
+    graph: DependencyGraph,
+    workbook: Path | str,
+    bindings: WorkbookSeriesBindings,
+    *,
+    export_addresses: Iterable[str] | None = None,
+    include_type_aliases: bool = True,
+    include_helpers: bool = True,
+    include_readers: bool = True,
+    include_leaf_indexes: bool = True,
+    series_docstring_callback: SeriesBindingDocstringCallbackSpec | None = None,
+    docstring_renderer: SeriesDocstringRendererSpec = "google",
+) -> list[str]:
+    """Emit all series setter and reader functions for a validated binding manifest.
+
+    When `include_helpers` is true the coercion/record-apply helpers and type aliases
+    are inlined alongside the setters (single-file export). When false only the setter
+    and reader functions are emitted and callers must supply the helpers separately, e.g. via a
+    dedicated `_api_helpers` module in the multi-module export.
+
+    When `include_readers` / `include_leaf_indexes` are false, readers and leaf maps
+    are omitted so a separate `_readers` module can own them.
+    """
+    pairs, failed, report = _iter_input_resolutions(
+        graph,
+        workbook,
+        bindings,
+        export_addresses=export_addresses,
+    )
+    lines: list[str] = ["# --- Series binding setters (Records API) ---", ""]
+    concept_scheme = bindings.get("concept_scheme")
+    if not isinstance(concept_scheme, dict):
+        concept_scheme = None
+    include_datetime = resolutions_include_datetime(report["series"]) or any(
+        _measure_dtype_for_codegen(series, concept_scheme=concept_scheme) == "datetime"
+        for series in bindings.get("series", [])
+        if isinstance(series, dict) and has_input_direction(series)
+    )
+    if include_helpers:
+        lines.extend(emit_input_coerce_helpers())
+        if include_type_aliases:
+            lines.extend(emit_setter_type_alias_lines(include_datetime=include_datetime))
+        lines.extend(emit_setter_helpers())
+    elif include_datetime:
+        lines.extend(["from datetime import datetime", ""])
+    for series, resolved in pairs:
+        lines.extend(
+            emit_setter_function(
+                series,
+                resolved,
+                graph=graph,
+                workbook=workbook,
+                bindings=bindings,
+                series_docstring_callback=series_docstring_callback,
+                docstring_renderer=docstring_renderer,
+                include_leaf_index=include_leaf_indexes,
+            )
+        )
+        if include_readers:
+            lines.extend(
+                emit_reader_function(
+                    series,
+                    resolved,
+                    graph=graph,
+                    workbook=workbook,
+                    bindings=bindings,
+                    series_docstring_callback=series_docstring_callback,
+                    docstring_renderer=docstring_renderer,
+                )
+            )
+            lines.extend(
+                emit_reader_range_function(
+                    series,
+                    resolved,
+                    graph=graph,
+                    workbook=workbook,
+                    bindings=bindings,
+                    series_docstring_callback=series_docstring_callback,
+                    docstring_renderer=docstring_renderer,
+                )
+            )
     if failed:
         raise ValueError(f"Cannot codegen setters: resolution failed for {failed!r}")
     return lines

--- a/tests/integration/exporter/test_optimal_projection_codegen_modules.py
+++ b/tests/integration/exporter/test_optimal_projection_codegen_modules.py
@@ -88,7 +88,7 @@ def test_optimal_projected_generate_modules_package_runs_and_matches_evaluator(
         bindings_workbook=workbook_path,
     )
 
-    assert "xl_eval" in files["internals.py"]
+    assert "xl_cell" in files["internals.py"]
     assert "def compute_baseline(" in files["api.py"]
 
     pkg_dir = tmp_path / _PACKAGE

--- a/tests/integration/exporter/test_projection_codegen_modules.py
+++ b/tests/integration/exporter/test_projection_codegen_modules.py
@@ -89,7 +89,7 @@ def test_projected_generate_modules_package_runs_and_matches_evaluator(tmp_path:
         bindings_workbook=workbook_path,
     )
 
-    assert "xl_eval" in files["internals.py"]
+    assert "xl_cell" in files["internals.py"]
     assert "def compute_baseline(" in files["api.py"]
     assert "compute_baseline" in files["__init__.py"]
 

--- a/tests/integration/exporter/test_series_bindings_internals_readers.py
+++ b/tests/integration/exporter/test_series_bindings_internals_readers.py
@@ -135,3 +135,29 @@ def test_groups_json_is_not_emitted(workbook: Path) -> None:
     """Sanity: unrelated bindings without groups still omit groups.json."""
     files = _generate(workbook)
     assert "groups.json" not in files
+
+
+def test_single_file_generate_rewrites_bound_leaves(workbook: Path) -> None:
+    """Single-file export shares the Phase 2 rewrite (not only modular internals)."""
+    bindings = validate_bindings_document(deepcopy(BINDINGS_DOCUMENT))
+    targets = ["Calc!A1", "Calc!B1", "Calc!C1", "Calc!D1"] + expand_data_range(
+        "Inputs!F5:J5", workbook=workbook
+    )
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+    with CodeGenerator(graph) as gen:
+        code = gen.generate(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+    formula_section = code.split("# --- Formula cell functions ---", 1)[1].split(
+        "def make_context", 1
+    )[0]
+    assert "read_borvelia_primary_balance(ctx, time_period=3)" in formula_section
+    assert "xl_cell(ctx, 'Inputs!H5')" not in formula_section
+    assert "read_borvelia_primary_balance_range(ctx)" in formula_section
+    assert "xl_cell(ctx, 'Inputs!A1')" in formula_section
+    assert "xl_range(ctx, 'Inputs!F5:H5')" in formula_section
+    # Discovery metadata uses the same reader index as body rewrite.
+    assert "read_borvelia_primary_balance(ctx, time_period=3)" in code

--- a/tests/integration/exporter/test_series_bindings_internals_readers.py
+++ b/tests/integration/exporter/test_series_bindings_internals_readers.py
@@ -1,0 +1,137 @@
+"""Phase 2: formula bodies in internals.py call read_* for bound input leaves."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import xlsxwriter
+
+from excel_grapher.exporter.codegen import CodeGenerator
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
+
+
+def _write_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    inputs = wb.add_worksheet("Inputs")
+    calc = wb.add_worksheet("Calc")
+    for col, year in enumerate([1, 2, 3, 4, 5], start=5):
+        inputs.write(0, col, year)
+        inputs.write_number(4, col, float(year))
+    inputs.write("A5", "Primary balance")
+    # Formula over a bound leaf (H5 = time_period 3).
+    calc.write_formula("A1", "=Inputs!H5")
+    # Unbound leaf reference.
+    calc.write_formula("B1", "=Inputs!A1")
+    # Binding-aligned full data_range.
+    calc.write_formula("C1", "=SUM(Inputs!F5:J5)")
+    # Partial / non-aligned slice of the same row.
+    calc.write_formula("D1", "=SUM(Inputs!F5:H5)")
+    wb.close()
+
+
+BINDINGS_DOCUMENT: dict[str, Any] = {
+    "schema_version": "1.9.0",
+    "workbook": "internals_readers.xlsx",
+    "series": [
+        {
+            "id": "borvelia_primary_balance",
+            "sheet": "Inputs",
+            "data_range": "Inputs!F5:J5",
+            "layout": "series",
+            "input": {"setter": {"name": "set_borvelia_primary_balance"}},
+            "structure": {
+                "measure": {
+                    "concept": "OBS_VALUE",
+                    "dtype": "float",
+                    "bind": {"kind": "data_cell", "read": "float"},
+                },
+                "dimensions": [
+                    {
+                        "concept": "TIME_PERIOD",
+                        "role": "key",
+                        "scope": "cell",
+                        "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                    }
+                ],
+            },
+            "key": ["TIME_PERIOD"],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def workbook(tmp_path: Path) -> Path:
+    path = tmp_path / "internals_readers.xlsx"
+    _write_workbook(path)
+    return path
+
+
+def _generate(workbook: Path) -> dict[str, str]:
+    bindings = validate_bindings_document(deepcopy(BINDINGS_DOCUMENT))
+    targets = ["Calc!A1", "Calc!B1", "Calc!C1", "Calc!D1"] + expand_data_range(
+        "Inputs!F5:J5", workbook=workbook
+    )
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+    with CodeGenerator(graph) as gen:
+        return gen.generate_modules(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+
+def test_internals_use_readers_for_bound_leaves_and_aligned_ranges(workbook: Path) -> None:
+    files = _generate(workbook)
+    internals = files["internals.py"]
+
+    assert "read_borvelia_primary_balance(ctx, time_period=3)" in internals
+    assert "xl_cell(ctx, 'Inputs!H5')" not in internals
+
+    assert "read_borvelia_primary_balance_range(ctx)" in internals
+    assert "xl_range(ctx, 'Inputs!F5:J5')" not in internals
+
+    # Unbound leaf stays address-keyed.
+    assert "xl_cell(ctx, 'Inputs!A1')" in internals
+    # Partial slice is not binding-aligned.
+    assert "xl_range(ctx, 'Inputs!F5:H5')" in internals
+
+    assert "from ._readers import" in internals
+    assert "read_borvelia_primary_balance" in internals
+
+
+def test_internals_reader_calls_evaluate(
+    workbook: Path,
+    tmp_path: Path,
+) -> None:
+    files = _generate(workbook)
+    pkg_dir = tmp_path / "internals_readers_pkg"
+    pkg_dir.mkdir()
+    for filename, content in files.items():
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        pkg = importlib.import_module("internals_readers_pkg")
+        internals = importlib.import_module("internals_readers_pkg.internals")
+        ctx = pkg.make_context()
+        assert internals.cell_calc_a1(ctx) == 3.0
+        assert internals.cell_calc_c1(ctx) == 15.0
+        assert internals.cell_calc_d1(ctx) == 6.0
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in list(sys.modules):
+            if name == "internals_readers_pkg" or name.startswith("internals_readers_pkg."):
+                del sys.modules[name]
+
+
+def test_groups_json_is_not_emitted(workbook: Path) -> None:
+    """Sanity: unrelated bindings without groups still omit groups.json."""
+    files = _generate(workbook)
+    assert "groups.json" not in files

--- a/tests/integration/exporter/test_series_bindings_readers_module.py
+++ b/tests/integration/exporter/test_series_bindings_readers_module.py
@@ -169,4 +169,6 @@ def test_readers_module_is_ruff_clean(workbook: Path, tmp_path: Path) -> None:
         capture_output=True,
         text=True,
     )
-    assert ruff.returncode == 0, f"generated package is not Ruff-clean:\n{ruff.stdout}\n{ruff.stderr}"
+    assert ruff.returncode == 0, (
+        f"generated package is not Ruff-clean:\n{ruff.stdout}\n{ruff.stderr}"
+    )

--- a/tests/integration/exporter/test_series_bindings_readers_module.py
+++ b/tests/integration/exporter/test_series_bindings_readers_module.py
@@ -1,0 +1,163 @@
+"""Modular export routes readers and leaf maps into `_readers.py`.
+
+Public `read_*` names stay re-exported through `api.py` / `__init__.py` so the
+package surface is unchanged, while formula bodies in `internals.py` can import
+readers without forming an `api` ↔ `internals` cycle.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import xlsxwriter
+
+from excel_grapher.exporter.codegen import CodeGenerator
+from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.series_bindings import expand_data_range, validate_bindings_document
+
+
+def _write_workbook(path: Path) -> None:
+    wb = xlsxwriter.Workbook(path)
+    ws = wb.add_worksheet("Sheet1")
+    ws.write("A2", "Borvelia")
+    ws.write("A5", "Primary balance (% of GDP)")
+    for col, year in enumerate([1, 2, 3, 4, 5], start=5):
+        ws.write(0, col, year)
+        ws.write_number(4, col, float(year))
+    ws.write_formula("G5", "=F5+1")
+    wb.close()
+
+
+BINDINGS_DOCUMENT: dict[str, Any] = {
+    "schema_version": "1.3.0",
+    "workbook": "series_bindings_readers.xlsx",
+    "series": [
+        {
+            "id": "borvelia_primary_balance",
+            "sheet": "Sheet1",
+            "data_range": "Sheet1!F5:J5",
+            "layout": "series",
+            "input": {"setter": {"name": "set_borvelia_primary_balance"}},
+            "structure": {
+                "measure": {
+                    "concept": "OBS_VALUE",
+                    "dtype": "float",
+                    "bind": {"kind": "data_cell", "read": "float"},
+                },
+                "dimensions": [
+                    {
+                        "concept": "REF_AREA",
+                        "role": "key",
+                        "scope": "series",
+                        "bind": {"kind": "cell", "address": "Sheet1!A2", "read": "string"},
+                        "include_in_record": False,
+                    },
+                    {
+                        "concept": "INDICATOR",
+                        "role": "key",
+                        "scope": "series",
+                        "bind": {
+                            "kind": "row_label",
+                            "label_column": "A",
+                            "read": "string",
+                            "normalize": "strip_trailing_unit",
+                        },
+                        "include_in_record": False,
+                    },
+                    {
+                        "concept": "TIME_PERIOD",
+                        "role": "key",
+                        "scope": "cell",
+                        "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                    },
+                ],
+            },
+            "key": ["TIME_PERIOD"],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def workbook(tmp_path: Path) -> Path:
+    path = tmp_path / "series_bindings_readers.xlsx"
+    _write_workbook(path)
+    return path
+
+
+def _generate(workbook: Path) -> dict[str, str]:
+    bindings = validate_bindings_document(deepcopy(BINDINGS_DOCUMENT))
+    targets = expand_data_range("Sheet1!F5:J5", workbook=workbook) + ["Sheet1!G5"]
+    graph = create_dependency_graph(workbook, targets, load_values=True)
+    with CodeGenerator(graph) as gen:
+        return gen.generate_modules(
+            targets,
+            series_bindings=bindings,
+            bindings_workbook=workbook,
+        )
+
+
+def test_modular_export_emits_private_readers_module(workbook: Path) -> None:
+    files = _generate(workbook)
+
+    assert "_readers.py" in files
+    readers = files["_readers.py"]
+    assert "def read_borvelia_primary_balance(" in readers
+    assert "def read_borvelia_primary_balance_range(" in readers
+    assert "_LEAF_INDEX_BORVELIA_PRIMARY_BALANCE" in readers
+
+    api = files["api.py"]
+    assert "from ._readers import" in api
+    assert "def read_borvelia_primary_balance(" not in api
+    assert "def set_borvelia_primary_balance(" in api
+    assert "_LEAF_INDEX_BORVELIA_PRIMARY_BALANCE" not in api or (
+        "from ._readers import" in api and "_LEAF_INDEX_BORVELIA_PRIMARY_BALANCE" in api
+    )
+
+    assert "read_borvelia_primary_balance" in files["__init__.py"]
+
+
+def test_modular_readers_module_is_importable_and_usable(
+    workbook: Path,
+    tmp_path: Path,
+) -> None:
+    files = _generate(workbook)
+    pkg_dir = tmp_path / "readers_pkg"
+    pkg_dir.mkdir()
+    for filename, content in files.items():
+        (pkg_dir / filename).write_text(content, encoding="utf-8")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        pkg = importlib.import_module("readers_pkg")
+        ctx = pkg.make_context()
+        pkg.set_borvelia_primary_balance(ctx, [{"TIME_PERIOD": 1, "OBS_VALUE": 9.5}])
+        assert pkg.read_borvelia_primary_balance(ctx, time_period=1) == 9.5
+        assert pkg.list_readers() == ["read_borvelia_primary_balance"]
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in list(sys.modules):
+            if name == "readers_pkg" or name.startswith("readers_pkg."):
+                del sys.modules[name]
+
+
+def test_readers_module_is_ruff_clean(workbook: Path, tmp_path: Path) -> None:
+    files = _generate(workbook)
+    pkg_root = tmp_path / "ruff_readers_pkg"
+    pkg_root.mkdir()
+    for filename, content in files.items():
+        (pkg_root / filename).write_text(content, encoding="utf-8")
+
+    ruff = subprocess.run(
+        ["uv", "run", "--no-sync", "ruff", "check", str(pkg_root / "_readers.py")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert ruff.returncode == 0, f"_readers.py is not Ruff-clean:\n{ruff.stdout}\n{ruff.stderr}"

--- a/tests/integration/exporter/test_series_bindings_readers_module.py
+++ b/tests/integration/exporter/test_series_bindings_readers_module.py
@@ -114,13 +114,15 @@ def test_modular_export_emits_private_readers_module(workbook: Path) -> None:
 
     api = files["api.py"]
     assert "from ._readers import" in api
+    assert "_LEAF_INDEX_BORVELIA_PRIMARY_BALANCE" in api
     assert "def read_borvelia_primary_balance(" not in api
     assert "def set_borvelia_primary_balance(" in api
-    assert "_LEAF_INDEX_BORVELIA_PRIMARY_BALANCE" not in api or (
-        "from ._readers import" in api and "_LEAF_INDEX_BORVELIA_PRIMARY_BALANCE" in api
-    )
+    # Public readers are re-exported from `_readers` (not via unused api imports).
+    assert "read_borvelia_primary_balance" not in api.split("def set_borvelia_primary_balance")[0]
 
-    assert "read_borvelia_primary_balance" in files["__init__.py"]
+    init = files["__init__.py"]
+    assert "from ._readers import" in init
+    assert "read_borvelia_primary_balance" in init
 
 
 def test_modular_readers_module_is_importable_and_usable(
@@ -154,10 +156,17 @@ def test_readers_module_is_ruff_clean(workbook: Path, tmp_path: Path) -> None:
     for filename, content in files.items():
         (pkg_root / filename).write_text(content, encoding="utf-8")
 
+    # Scope to modules this PR owns. `internals.py` still uses legacy `'''Formula'''`
+    # docstrings (D300) outside this change.
+    targets = [
+        pkg_root / "_readers.py",
+        pkg_root / "api.py",
+        pkg_root / "__init__.py",
+    ]
     ruff = subprocess.run(
-        ["uv", "run", "--no-sync", "ruff", "check", str(pkg_root / "_readers.py")],
+        ["uv", "run", "--no-sync", "ruff", "check", *[str(p) for p in targets]],
         check=False,
         capture_output=True,
         text=True,
     )
-    assert ruff.returncode == 0, f"_readers.py is not Ruff-clean:\n{ruff.stdout}\n{ruff.stderr}"
+    assert ruff.returncode == 0, f"generated package is not Ruff-clean:\n{ruff.stdout}\n{ruff.stderr}"

--- a/tests/integration/user_flows/test_series_bindings_groups_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_groups_codegen.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
@@ -96,17 +95,12 @@ def test_grouped_export_sequences_definitions_and_all(workbook: Path) -> None:
     assert all_line.index("set_gdp_growth") < all_line.index("set_interest_rate")
 
 
-def test_grouped_export_emits_manifest_file_and_discovery(workbook: Path) -> None:
+def test_grouped_export_emits_list_groups_discovery(workbook: Path) -> None:
     modules = _generate_modules(workbook)
 
-    manifest = json.loads(modules["groups.json"])
-    assert [g["label"] for g in manifest["groups"]] == ["Fiscal", "Macro"]
-    macro = manifest["groups"][1]
-    assert [child["label"] for child in macro["children"]] == ["Growth"]
-    assert macro["children"][0]["members"][0]["setter"] == "set_gdp_growth"
-    assert [m["id"] for m in manifest["ungrouped"]] == ["interest_rate"]
-
+    assert "groups.json" not in modules
     assert "def list_groups(" in modules["api.py"]
+    assert "list_groups" in modules["__init__.py"]
 
 
 def test_grouped_export_preserves_setter_semantics(workbook: Path, tmp_path: Path) -> None:

--- a/tests/integration/user_flows/test_series_bindings_output_codegen.py
+++ b/tests/integration/user_flows/test_series_bindings_output_codegen.py
@@ -192,8 +192,10 @@ def test_generate_modules_exports_output_compute(
         bindings_workbook=workbook,
     )
     assert "def compute_borvelia_primary_balance(" in files["api.py"]
-    assert "def read_borvelia_primary_balance(" in files["api.py"]
-    assert "def read_borvelia_primary_balance_range(" in files["api.py"]
+    assert "_readers.py" in files
+    assert "def read_borvelia_primary_balance(" in files["_readers.py"]
+    assert "def read_borvelia_primary_balance_range(" in files["_readers.py"]
+    assert "from ._readers import" in files["api.py"]
     assert "def list_setters() -> list[str]:" in files["api.py"]
     assert "def list_readers() -> list[str]:" in files["api.py"]
     assert "def list_computes() -> list[str]:" in files["api.py"]
@@ -203,7 +205,7 @@ def test_generate_modules_exports_output_compute(
     assert "list_setters" in files["__init__.py"]
     assert "list_readers" in files["__init__.py"]
     assert "list_computes" in files["__init__.py"]
-    assert "Record" in files["api.py"]
+    assert "Record" in files["api.py"] or "Record" in files.get("_api_helpers.py", "")
 
     pkg_dir = tmp_path / "exported_series_output"
     for filename, content in files.items():

--- a/tests/unit/exporter/test_projection_codegen.py
+++ b/tests/unit/exporter/test_projection_codegen.py
@@ -129,7 +129,9 @@ def test_projected_generate_modules_emits_alias_resolver(tmp_path: Path) -> None
     internals = modules["internals.py"]
     api = modules["api.py"]
     assert "def compute_baseline(" in api
-    assert "xl_eval" in internals
+    # Projected leaf aliases resolve through `xl_cell`; formula→formula `xl_eval`
+    # is only imported when a body actually references another formula cell.
+    assert "xl_cell" in internals
     assert "Outputs!B12" in internals or "outputs_b12" in internals.lower()
 
 

--- a/tests/unit/series_bindings/test_reader_codegen.py
+++ b/tests/unit/series_bindings/test_reader_codegen.py
@@ -46,6 +46,7 @@ def _exec_readers(
         "EvalContext": EvalContext,
         "coerce_inputs_dict": coerce_inputs_dict,
         "xl_cell": xl_cell,
+        "CellValue": object,
     }
     if extra:
         namespace.update(extra)
@@ -151,7 +152,7 @@ def test_emit_reader_keyless_scalar(tmp_path: Path) -> None:
     )
     assert reader(ctx) == "Litellia"
     source = "\n".join(lines)
-    assert "def read_country_name(ctx: EvalContext) -> object:" in source or (
+    assert "def read_country_name(ctx: EvalContext) -> CellValue:" in source or (
         "def read_country_name(" in source and "time_period" not in source
     )
 
@@ -194,7 +195,7 @@ def test_emit_reader_requires_address_uses_address_kwarg(tmp_path: Path) -> None
     assert resolved["requires_address"] is True
     lines = emit_setter_function(series, resolved) + emit_reader_function(series, resolved)
     source = "\n".join(lines)
-    assert "def read_dup_headers(ctx: EvalContext, *, address: str) -> object:" in source
+    assert "def read_dup_headers(ctx: EvalContext, *, address: str) -> CellValue:" in source
     assert "_READER_ADDRESSES_DUP_HEADERS" in source
 
     ns = _exec_readers(lines)
@@ -272,7 +273,9 @@ def test_generate_modules_exports_requires_address_reader(tmp_path: Path) -> Non
         series_bindings=bindings,
         bindings_workbook=wb_path,
     )
-    assert "def read_dup_headers(" in files["api.py"]
+    assert "_readers.py" in files
+    assert "def read_dup_headers(" in files["_readers.py"]
+    assert "from ._readers import" in files["api.py"]
     assert "read_dup_headers" in files["__init__.py"]
     assert "read_dup_headers_range" in files["__init__.py"]
 

--- a/tests/unit/series_bindings/test_reader_codegen.py
+++ b/tests/unit/series_bindings/test_reader_codegen.py
@@ -275,7 +275,7 @@ def test_generate_modules_exports_requires_address_reader(tmp_path: Path) -> Non
     )
     assert "_readers.py" in files
     assert "def read_dup_headers(" in files["_readers.py"]
-    assert "from ._readers import" in files["api.py"]
+    assert "from ._readers import" in files["__init__.py"]
     assert "read_dup_headers" in files["__init__.py"]
     assert "read_dup_headers_range" in files["__init__.py"]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements three related series-binding codegen cleanups from the post-#407/#412 review:

1. **Stop emitting `groups.json`** — it was never consumed in-repo (runtime uses inlined `list_groups()`). Docs/tooling should call `list_groups()`.
2. **Private `_readers.py` module** — leaf maps (`_LEAF_INDEX_*`) and `read_*` / `read_*_range` duals move out of `api.py`, with public re-exports through `api` / `__init__` (same pattern as `_api_helpers`).
3. **Phase 2 body rewrite** — formula cells in `internals.py` now emit `read_*(ctx, …)` / `read_*_range(ctx)` for uniquely owned bound leaves and binding-aligned ranges via `resolve_reader_ref`. Unbound / ambiguous / partial-range refs still fall back to `xl_cell` / `xl_range`.

## Layout after modular export (with input bindings)

```text
__init__.py
api.py            # set_*, compute_*, list_*, re-exports read_*
_readers.py       # _LEAF_INDEX_*, read_*, read_*_range
_api_helpers.py   # coercion (unchanged)
internals.py      # formulas call read_* where bound
data.py / runtime.py
```

## Test plan

- [x] New integration: `_readers.py` presence, re-export, importable package, ruff-clean
- [x] New integration: internals rewrite for bound leaf / aligned range; unbound + partial-range fallbacks; runnable cell bodies
- [x] Updated groups tests: no `groups.json`; `list_groups()` discovery retained
- [x] `tests/unit/series_bindings/` + series-bindings user-flow / exporter suites green (519 passed in scoped run)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eeb5d54c-8401-4333-b7a5-f50dec36aa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeb5d54c-8401-4333-b7a5-f50dec36aa80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

