### PR TITLE
fix(series-bindings): share workbook reader across validate/resolve (#416)

### DIFF
--- a/excel_grapher/series_bindings/ranges.py
+++ b/excel_grapher/series_bindings/ranges.py
@@ -78,8 +78,9 @@ def expand_data_range(
     both-end sheet-qualified ranges like `Sheet1!A1:Sheet1!B2`, which collapse
     to single-prefix form, and defined names).
     """
+    # Sheet-qualified targets do not need named-range maps; skip the workbook open.
     nr, nrr, wb_sheets = _resolve_named_range_maps(
-        workbook=workbook,
+        workbook=None if "!" in data_range else workbook,
         named_ranges=named_ranges,
         named_range_ranges=named_range_ranges,
     )

--- a/excel_grapher/series_bindings/resolve.py
+++ b/excel_grapher/series_bindings/resolve.py
@@ -53,7 +53,11 @@ _TRAILING_UNIT_RE = re.compile(r"\s*\([^)]*\)\s*$")
 
 
 class _WorkbookValues:
-    """Lazy cached value reader for bind cells outside the dependency graph."""
+    """Lazy cached value reader for bind cells outside the dependency graph.
+
+    Opens the workbook with `read_only=False` because label and header binds
+    perform random cell access, which is inefficient in read-only mode.
+    """
 
     def __init__(self, path: Path | str) -> None:
         self._path = Path(path)
@@ -66,7 +70,7 @@ class _WorkbookValues:
         self._workbook_cache = fastpyxl.load_workbook(
             self._path,
             data_only=True,
-            read_only=True,
+            read_only=False,
             keep_vba=keep_vba,
         )
         return self._workbook_cache
@@ -77,6 +81,18 @@ class _WorkbookValues:
         if sheet not in wb.sheetnames:
             raise KeyError(f"Sheet {sheet!r} not found in workbook")
         return wb[sheet][coord].value
+
+    def close(self) -> None:
+        """Close the cached workbook, if open."""
+        if self._workbook_cache is not None:
+            self._workbook_cache.close()
+            self._workbook_cache = None
+
+    def __enter__(self) -> _WorkbookValues:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
 
 
 def _read_cell_value(graph: DependencyGraph, reader: _WorkbookValues, address: str) -> Any:
@@ -642,8 +658,13 @@ def resolve_series_binding(
     direction: BindingDirection = "input",
     export_addresses: Iterable[str] | None = None,
     concept_scheme: dict[str, Any] | None = None,
+    reader: _WorkbookValues | None = None,
 ) -> SeriesResolution:
-    """Resolve each participating cell in a series binding to coordinates and record fields."""
+    """Resolve each participating cell in a series binding to coordinates and record fields.
+
+    Pass `reader` to reuse a shared `_WorkbookValues` across multiple series;
+    when omitted, a reader is created for this call and closed before returning.
+    """
     series_id = str(series.get("id", ""))
     issues: list[ResolutionIssue] = []
     leaves: list[LeafResolution] = []
@@ -709,142 +730,150 @@ def resolve_series_binding(
     key_fields = [str(c) for c in (series.get("key") or [])]
     require_unique_key = bool(validation.get("require_unique_key", True))
 
-    reader = _WorkbookValues(workbook)
-    series_coordinates: dict[str, Scalar] = {}
-    seen_keys: dict[tuple[tuple[str, Scalar], ...], str] = {}
+    owns_reader = reader is None
+    if owns_reader:
+        reader = _WorkbookValues(workbook)
+    active_reader = reader
 
     try:
-        coerced_series_context = _coerce_series_context(series, concept_scheme=concept_scheme)
-    except ValueError as exc:
-        return {
-            "series_id": series_id,
-            "ok": False,
-            "requires_address": True,
-            "leaves": [],
-            "issues": [
-                make_issue(
-                    "error",
-                    "series_context_coercion_failed",
-                    str(exc),
-                    series_id=series_id,
-                )
-            ],
-        }
+        series_coordinates: dict[str, Scalar] = {}
+        seen_keys: dict[tuple[tuple[str, Scalar], ...], str] = {}
 
-    build_record = _build_input_record if direction == "input" else _build_output_record
-
-    bind_failures: dict[str, list[str]] = {}
-    for address in addresses:
-        coordinates: dict[str, Scalar] = {}
         try:
-            if direction == "input":
-                coordinates[measure_concept] = _execute_bind(
-                    measure_bind if isinstance(measure_bind, dict) else {"kind": "data_cell"},
-                    graph=graph,
-                    reader=reader,
-                    data_address=address,
-                    inferred_read_as=measure_inferred_read,
-                )
-
-            for dim in structure.get("dimensions") or []:
-                if not isinstance(dim, dict):
-                    continue
-                field_name = effective_dimension_id(dim)
-                bind = dim.get("bind")
-                if not isinstance(bind, dict):
-                    continue
-                scope = dim.get("scope")
-                if scope == "series" and field_name in series_coordinates:
-                    coordinates[field_name] = series_coordinates[field_name]
-                    continue
-                inferred = _component_dtype(concept_scheme, series, dim)
-                value = _execute_bind(
-                    bind,
-                    graph=graph,
-                    reader=reader,
-                    data_address=address,
-                    inferred_read_as=inferred,
-                )
-                coordinates[field_name] = value
-                if scope == "series":
-                    series_coordinates[field_name] = value
-
-            for attr in structure.get("attributes") or []:
-                if not isinstance(attr, dict):
-                    continue
-                field_name = effective_dimension_id(attr)
-                bind = _attribute_bind(attr)
-                if bind is None:
-                    continue
-                inferred = _component_dtype(concept_scheme, series, attr)
-                coordinates[field_name] = _execute_bind(
-                    bind,
-                    graph=graph,
-                    reader=reader,
-                    data_address=address,
-                    inferred_read_as=inferred,
-                )
-        except (KeyError, ValueError, TypeError) as exc:
-            bind_failures.setdefault(str(exc), []).append(address)
-            continue
-
-        key = _extract_key(coordinates, key_fields)
-        record = build_record(
-            coordinates=coordinates,
-            series=series,
-            measure_concept=measure_concept,
-            series_context=coerced_series_context,
-        )
-        leaves.append(
-            {
-                "address": address,
-                "coordinates": coordinates,
-                "key": key,
-                "record": record,
-            }
-        )
-
-        if require_unique_key and key_fields:
-            key_tuple = tuple(sorted(key.items()))
-            if key_tuple in seen_keys:
-                requires_address = True
-                issues.append(
+            coerced_series_context = _coerce_series_context(series, concept_scheme=concept_scheme)
+        except ValueError as exc:
+            return {
+                "series_id": series_id,
+                "ok": False,
+                "requires_address": True,
+                "leaves": [],
+                "issues": [
                     make_issue(
                         "error",
-                        "duplicate_key",
-                        f"Duplicate key {dict(key_tuple)!r} at {address} "
-                        f"(first seen at {seen_keys[key_tuple]})",
+                        "series_context_coercion_failed",
+                        str(exc),
                         series_id=series_id,
-                        address=address,
                     )
-                )
-            else:
-                seen_keys[key_tuple] = address
+                ],
+            }
 
-    issues.extend(
-        _bind_resolution_issues(bind_failures, series_id=series_id),
-    )
+        build_record = _build_input_record if direction == "input" else _build_output_record
 
-    layout = series.get("layout")
-    if layout == "scalar" and not key_fields and len(leaves) > 1:
-        issues.append(
-            make_issue(
-                "error",
-                "keyless_scalar_ambiguous",
-                "Keyless scalar binding must resolve to exactly one leaf; "
-                f"got {len(leaves)} leaves in data_range",
-                series_id=series_id,
+        bind_failures: dict[str, list[str]] = {}
+        for address in addresses:
+            coordinates: dict[str, Scalar] = {}
+            try:
+                if direction == "input":
+                    coordinates[measure_concept] = _execute_bind(
+                        measure_bind if isinstance(measure_bind, dict) else {"kind": "data_cell"},
+                        graph=graph,
+                        reader=active_reader,
+                        data_address=address,
+                        inferred_read_as=measure_inferred_read,
+                    )
+
+                for dim in structure.get("dimensions") or []:
+                    if not isinstance(dim, dict):
+                        continue
+                    field_name = effective_dimension_id(dim)
+                    bind = dim.get("bind")
+                    if not isinstance(bind, dict):
+                        continue
+                    scope = dim.get("scope")
+                    if scope == "series" and field_name in series_coordinates:
+                        coordinates[field_name] = series_coordinates[field_name]
+                        continue
+                    inferred = _component_dtype(concept_scheme, series, dim)
+                    value = _execute_bind(
+                        bind,
+                        graph=graph,
+                        reader=active_reader,
+                        data_address=address,
+                        inferred_read_as=inferred,
+                    )
+                    coordinates[field_name] = value
+                    if scope == "series":
+                        series_coordinates[field_name] = value
+
+                for attr in structure.get("attributes") or []:
+                    if not isinstance(attr, dict):
+                        continue
+                    field_name = effective_dimension_id(attr)
+                    bind = _attribute_bind(attr)
+                    if bind is None:
+                        continue
+                    inferred = _component_dtype(concept_scheme, series, attr)
+                    coordinates[field_name] = _execute_bind(
+                        bind,
+                        graph=graph,
+                        reader=active_reader,
+                        data_address=address,
+                        inferred_read_as=inferred,
+                    )
+            except (KeyError, ValueError, TypeError) as exc:
+                bind_failures.setdefault(str(exc), []).append(address)
+                continue
+
+            key = _extract_key(coordinates, key_fields)
+            record = build_record(
+                coordinates=coordinates,
+                series=series,
+                measure_concept=measure_concept,
+                series_context=coerced_series_context,
             )
+            leaves.append(
+                {
+                    "address": address,
+                    "coordinates": coordinates,
+                    "key": key,
+                    "record": record,
+                }
+            )
+
+            if require_unique_key and key_fields:
+                key_tuple = tuple(sorted(key.items()))
+                if key_tuple in seen_keys:
+                    requires_address = True
+                    issues.append(
+                        make_issue(
+                            "error",
+                            "duplicate_key",
+                            f"Duplicate key {dict(key_tuple)!r} at {address} "
+                            f"(first seen at {seen_keys[key_tuple]})",
+                            series_id=series_id,
+                            address=address,
+                        )
+                    )
+                else:
+                    seen_keys[key_tuple] = address
+
+        issues.extend(
+            _bind_resolution_issues(bind_failures, series_id=series_id),
         )
 
-    ok = not any(i["level"] == "error" for i in issues)
-    return {
-        "series_id": series_id,
-        "ok": ok,
-        "requires_address": requires_address,
-        "leaves": leaves,
-        "issues": issues,
-    }
+        layout = series.get("layout")
+        if layout == "scalar" and not key_fields and len(leaves) > 1:
+            issues.append(
+                make_issue(
+                    "error",
+                    "keyless_scalar_ambiguous",
+                    "Keyless scalar binding must resolve to exactly one leaf; "
+                    f"got {len(leaves)} leaves in data_range",
+                    series_id=series_id,
+                )
+            )
+
+        ok = not any(i["level"] == "error" for i in issues)
+        return {
+            "series_id": series_id,
+            "ok": ok,
+            "requires_address": requires_address,
+            "leaves": leaves,
+            "issues": issues,
+        }
+    finally:
+        if owns_reader:
+            active_reader.close()
 
 
 def _series_supports_direction(series: dict[str, Any], direction: BindingDirection) -> bool:
@@ -882,21 +911,23 @@ def resolve_series_bindings(
     concept_scheme = bindings.get("concept_scheme")
     if not isinstance(concept_scheme, dict):
         concept_scheme = None
-    for series in bindings.get("series", []):
-        if not isinstance(series, dict):
-            continue
-        if not _series_supports_direction(series, direction):
-            continue
-        result = resolve_series_binding(
-            graph,
-            workbook,
-            series,
-            direction=direction,
-            export_addresses=export_addresses,
-            concept_scheme=concept_scheme,
-        )
-        series_results.append(result)
-        all_issues.extend(result["issues"])
+    with _WorkbookValues(workbook) as reader:
+        for series in bindings.get("series", []):
+            if not isinstance(series, dict):
+                continue
+            if not _series_supports_direction(series, direction):
+                continue
+            result = resolve_series_binding(
+                graph,
+                workbook,
+                series,
+                direction=direction,
+                export_addresses=export_addresses,
+                concept_scheme=concept_scheme,
+                reader=reader,
+            )
+            series_results.append(result)
+            all_issues.extend(result["issues"])
 
     ok = all(r["ok"] for r in series_results) and not any(i["level"] == "error" for i in all_issues)
     return {"ok": ok, "series": series_results, "issues": all_issues}

--- a/excel_grapher/series_bindings/validate.py
+++ b/excel_grapher/series_bindings/validate.py
@@ -571,101 +571,114 @@ def validate_series_bindings(
     workbook: Path | str | None = None,
 ) -> ValidationReport:
     """Validate binding manifests against an extracted dependency graph."""
+    from excel_grapher.series_bindings.resolve import _WorkbookValues, resolve_series_binding
+
     issues: list[ValidationIssue] = []
     concept_dtypes = _concept_dtype_map(bindings)
+    shared_reader: _WorkbookValues | None = None
 
-    for series in bindings.get("series", []):
-        if not isinstance(series, dict):
-            continue
-        series_id = str(series.get("id", ""))
-        issues.extend(_validate_series_structure(series))
-        issues.extend(_validate_layout_intent(series))
-        issues.extend(_validate_implementation_support(series))
-        issues.extend(_validate_dtype_read_consistency(series, concept_dtypes=concept_dtypes))
-
-        data_range = series.get("data_range")
-        if not isinstance(data_range, str):
-            continue
-
-        _, require_unique_key = _series_validation_flags(series)
-        try:
-            addresses = expand_data_range_for_graph(
-                graph,
-                data_range,
-                workbook=workbook,
-            )
-        except (ValueError, TypeError) as exc:
-            issues.append(
-                _issue(
-                    "error",
-                    "invalid_data_range",
-                    str(exc),
-                    series_id=series_id,
-                )
-            )
-            continue
-
-        if not addresses:
-            issues.append(
-                _issue(
-                    "error",
-                    "empty_data_range",
-                    "data_range expands to zero cells",
-                    series_id=series_id,
-                )
-            )
-            continue
-
-        issues.extend(_validate_input_mode(series))
-        issues.extend(_validate_input_binding_overlap(graph, series, addresses))
-        issues.extend(_validate_internal_binding_overlap(graph, series, addresses))
-
-        graph_input_addresses = _input_binding_addresses(graph, series, addresses)
-        graph_internal_addresses = _internal_binding_addresses(graph, series, addresses)
-
-        if require_unique_key:
-            cell_scoped_keys = [
-                str(c)
-                for c in (series.get("key") or [])
-                if any(
-                    isinstance(d, dict)
-                    and effective_dimension_id(d) == str(c)
-                    and d.get("scope") == "cell"
-                    for d in (series.get("structure") or {}).get("dimensions") or []
-                )
-            ]
-            binding_addresses = (
-                graph_internal_addresses
-                if has_internal_direction(series)
-                else graph_input_addresses
-            )
-            if not binding_addresses:
+    try:
+        for series in bindings.get("series", []):
+            if not isinstance(series, dict):
                 continue
-            if cell_scoped_keys and workbook is None:
+            series_id = str(series.get("id", ""))
+            issues.extend(_validate_series_structure(series))
+            issues.extend(_validate_layout_intent(series))
+            issues.extend(_validate_implementation_support(series))
+            issues.extend(_validate_dtype_read_consistency(series, concept_dtypes=concept_dtypes))
+
+            data_range = series.get("data_range")
+            if not isinstance(data_range, str):
+                continue
+
+            _, require_unique_key = _series_validation_flags(series)
+            try:
+                addresses = expand_data_range_for_graph(
+                    graph,
+                    data_range,
+                    workbook=workbook,
+                )
+            except (ValueError, TypeError) as exc:
                 issues.append(
                     _issue(
-                        "warning",
-                        "unique_key_deferred",
-                        "require_unique_key is set but coordinate resolution is not implemented yet "
-                        f"(cell-scoped key dimensions: {cell_scoped_keys})",
+                        "error",
+                        "invalid_data_range",
+                        str(exc),
                         series_id=series_id,
                     )
                 )
-            elif workbook is not None:
-                from excel_grapher.series_bindings.resolve import resolve_series_binding
+                continue
 
-                direction = "internal" if has_internal_direction(series) else "input"
-                resolved = resolve_series_binding(graph, workbook, series, direction=direction)
-                issues.extend(resolved["issues"])
-                if resolved["requires_address"]:
+            if not addresses:
+                issues.append(
+                    _issue(
+                        "error",
+                        "empty_data_range",
+                        "data_range expands to zero cells",
+                        series_id=series_id,
+                    )
+                )
+                continue
+
+            issues.extend(_validate_input_mode(series))
+            issues.extend(_validate_input_binding_overlap(graph, series, addresses))
+            issues.extend(_validate_internal_binding_overlap(graph, series, addresses))
+
+            graph_input_addresses = _input_binding_addresses(graph, series, addresses)
+            graph_internal_addresses = _internal_binding_addresses(graph, series, addresses)
+
+            if require_unique_key:
+                cell_scoped_keys = [
+                    str(c)
+                    for c in (series.get("key") or [])
+                    if any(
+                        isinstance(d, dict)
+                        and effective_dimension_id(d) == str(c)
+                        and d.get("scope") == "cell"
+                        for d in (series.get("structure") or {}).get("dimensions") or []
+                    )
+                ]
+                binding_addresses = (
+                    graph_internal_addresses
+                    if has_internal_direction(series)
+                    else graph_input_addresses
+                )
+                if not binding_addresses:
+                    continue
+                if cell_scoped_keys and workbook is None:
                     issues.append(
                         _issue(
                             "warning",
-                            "requires_address",
-                            "Duplicate or ambiguous record keys require address disambiguation",
+                            "unique_key_deferred",
+                            "require_unique_key is set but coordinate resolution is not implemented yet "
+                            f"(cell-scoped key dimensions: {cell_scoped_keys})",
                             series_id=series_id,
                         )
                     )
+                elif workbook is not None:
+                    if shared_reader is None:
+                        shared_reader = _WorkbookValues(workbook)
+                    direction = "internal" if has_internal_direction(series) else "input"
+                    resolved = resolve_series_binding(
+                        graph,
+                        workbook,
+                        series,
+                        direction=direction,
+                        reader=shared_reader,
+                    )
+                    issues.extend(resolved["issues"])
+                    if resolved["requires_address"]:
+                        issues.append(
+                            _issue(
+                                "warning",
+                                "requires_address",
+                                "Duplicate or ambiguous record keys require address disambiguation",
+                                series_id=series_id,
+                            )
+                        )
+    finally:
+        if shared_reader is not None:
+            shared_reader.close()
 
     ok = not any(i["level"] == "error" for i in issues)
     return {"ok": ok, "issues": issues}

--- a/tests/unit/series_bindings/test_ranges.py
+++ b/tests/unit/series_bindings/test_ranges.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import fastpyxl
 import pytest
@@ -68,3 +69,16 @@ def test_expand_data_range_for_graph_uses_graph_named_ranges(tmp_path: Path) -> 
 
     graph = create_dependency_graph(path, ["Inputs!F5"], load_values=True)
     assert expand_data_range_for_graph(graph, "CellOne") == ["Inputs!F5"]
+
+
+def test_expand_sheet_qualified_range_skips_workbook_load(tmp_path: Path) -> None:
+    path = tmp_path / "demo.xlsx"
+    wb = xlsxwriter.Workbook(path)
+    wb.add_worksheet("S")
+    wb.close()
+
+    with patch("excel_grapher.series_bindings.ranges.fastpyxl.load_workbook") as load_wb:
+        addresses = expand_data_range("S!B2:C2", workbook=path)
+
+    assert addresses == ["S!B2", "S!C2"]
+    load_wb.assert_not_called()

--- a/tests/unit/series_bindings/test_resolve.py
+++ b/tests/unit/series_bindings/test_resolve.py
@@ -254,6 +254,7 @@ def test_resolve_series_bindings_loads_workbook_once(tmp_path: Path) -> None:
         }
 
     bindings: WorkbookSeriesBindings = {
+        "schema_version": "1.4.0",
         "workbook": wb_path.name,
         "series": [series("s2", 2), series("s3", 3)],
     }

--- a/tests/unit/series_bindings/test_resolve.py
+++ b/tests/unit/series_bindings/test_resolve.py
@@ -5,18 +5,21 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
+import fastpyxl
 import pytest
 import xlsxwriter
 
 from excel_grapher.grapher import create_dependency_graph
-from excel_grapher.grapher.graph import DependencyGraph
+from excel_grapher.grapher.graph import DependencyGraph, Node
 from excel_grapher.series_bindings import (
     expand_data_range,
     load_series_bindings,
     resolve_series_binding,
     resolve_series_bindings,
 )
+from excel_grapher.series_bindings.types import WorkbookSeriesBindings
 from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
 
 
@@ -181,6 +184,94 @@ def test_resolve_series_bindings_workbook(tmp_path: Path) -> None:
     assert report["ok"] is True
     assert len(report["series"]) == 1
     assert report["series"][0]["requires_address"] is False
+
+
+def test_resolve_series_bindings_loads_workbook_once(tmp_path: Path) -> None:
+    """Multi-series resolve should share one workbook reader (issue #416)."""
+    wb_path = tmp_path / "demo.xlsx"
+    wb = fastpyxl.Workbook()
+    ws = wb.active
+    ws.title = "S"
+    ws["A1"] = "label"
+    ws["B1"] = 2020
+    ws["C1"] = 2021
+    for row, label, b, c in [(2, "x", 1.0, 2.0), (3, "y", 3.0, 4.0)]:
+        ws[f"A{row}"] = label
+        ws[f"B{row}"] = b
+        ws[f"C{row}"] = c
+    wb.save(wb_path)
+
+    graph = DependencyGraph()
+    for col, row, val in [("B", 2, 1.0), ("C", 2, 2.0), ("B", 3, 3.0), ("C", 3, 4.0)]:
+        graph.add_node(
+            Node(
+                sheet="S",
+                column=col,
+                row=row,
+                formula=None,
+                normalized_formula=None,
+                value=val,
+                is_leaf=True,
+            )
+        )
+
+    def series(series_id: str, row: int) -> dict[str, Any]:
+        return {
+            "id": series_id,
+            "sheet": "S",
+            "layout": "matrix",
+            "data_range": f"S!B{row}:C{row}",
+            "key": ["INDICATOR", "TIME_PERIOD"],
+            "input": {"mode": "leaf", "setter": {"name": f"set_{series_id}"}},
+            "structure": {
+                "dimensions": [
+                    {
+                        "id": "INDICATOR",
+                        "concept": "INDICATOR",
+                        "role": "key",
+                        "scope": "cell",
+                        "bind": {
+                            "kind": "row_label",
+                            "label_column": "A",
+                            "fill": True,
+                            "read": "string",
+                        },
+                    },
+                    {
+                        "id": "TIME_PERIOD",
+                        "concept": "TIME_PERIOD",
+                        "role": "key",
+                        "scope": "cell",
+                        "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                    },
+                ],
+                "measure": {
+                    "concept": "OBS_VALUE",
+                    "dtype": "float",
+                    "bind": {"kind": "data_cell", "read": "float"},
+                },
+            },
+        }
+
+    bindings: WorkbookSeriesBindings = {
+        "workbook": wb_path.name,
+        "series": [series("s2", 2), series("s3", 3)],
+    }
+    calls: list[dict[str, Any]] = []
+    real_load = fastpyxl.load_workbook
+
+    def wrapped(*args: Any, **kwargs: Any):
+        calls.append(dict(kwargs))
+        return real_load(*args, **kwargs)
+
+    with patch("fastpyxl.load_workbook", side_effect=wrapped):
+        report = resolve_series_bindings(graph, bindings, workbook=wb_path)
+
+    assert report["ok"] is True
+    assert len(report["series"]) == 2
+    assert len(calls) == 1
+    assert calls[0].get("data_only") is True
+    assert calls[0].get("read_only") is False
 
 
 def _write_bool_workbook(path: Path) -> None:

--- a/tests/unit/series_bindings/test_validate.py
+++ b/tests/unit/series_bindings/test_validate.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
+import fastpyxl
 import xlsxwriter
 
-from excel_grapher.grapher import create_dependency_graph
+from excel_grapher.grapher import DependencyGraph, Node, create_dependency_graph
 from excel_grapher.series_bindings import (
     expand_data_range,
     load_series_bindings,
@@ -357,3 +359,102 @@ def test_validate_series_layout_requires_cell_scoped_dimension(tmp_path: Path) -
         issue["code"] == "layout_constraint_violation" and "cell-scoped" in issue["message"]
         for issue in report["issues"]
     )
+
+
+def _matrix_row_series(series_id: str, row: int) -> dict:
+    return {
+        "id": series_id,
+        "sheet": "S",
+        "layout": "matrix",
+        "data_range": f"S!B{row}:C{row}",
+        "key": ["INDICATOR", "TIME_PERIOD"],
+        "input": {"mode": "leaf"},
+        "structure": {
+            "dimensions": [
+                {
+                    "id": "INDICATOR",
+                    "concept": "INDICATOR",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {
+                        "kind": "row_label",
+                        "label_column": "A",
+                        "fill": True,
+                        "read": "string",
+                    },
+                },
+                {
+                    "id": "TIME_PERIOD",
+                    "concept": "TIME_PERIOD",
+                    "role": "key",
+                    "scope": "cell",
+                    "bind": {"kind": "column_header", "header_row": 1, "read": "int"},
+                },
+            ],
+            "measure": {
+                "concept": "OBS_VALUE",
+                "dtype": "float",
+                "bind": {"kind": "data_cell", "read": "float"},
+            },
+        },
+        "validation": {"require_unique_key": True},
+    }
+
+
+def _write_matrix_demo_workbook(path: Path) -> DependencyGraph:
+    wb = fastpyxl.Workbook()
+    ws = wb.active
+    ws.title = "S"
+    ws["A1"] = "label"
+    ws["B1"] = 2020
+    ws["C1"] = 2021
+    for row, label, b, c in [(2, "x", 1.0, 2.0), (3, "y", 3.0, 4.0), (4, "z", 5.0, 6.0)]:
+        ws[f"A{row}"] = label
+        ws[f"B{row}"] = b
+        ws[f"C{row}"] = c
+    wb.save(path)
+
+    graph = DependencyGraph()
+    for col, row, val in [
+        ("B", 2, 1.0),
+        ("C", 2, 2.0),
+        ("B", 3, 3.0),
+        ("C", 3, 4.0),
+        ("B", 4, 5.0),
+        ("C", 4, 6.0),
+    ]:
+        graph.add_node(
+            Node(
+                sheet="S",
+                column=col,
+                row=row,
+                formula=None,
+                normalized_formula=None,
+                value=val,
+                is_leaf=True,
+            )
+        )
+    return graph
+
+
+def test_validate_series_bindings_loads_workbook_once(tmp_path: Path) -> None:
+    """Validate should share one workbook reader across series (issue #416)."""
+    wb_path = tmp_path / "demo.xlsx"
+    graph = _write_matrix_demo_workbook(wb_path)
+    series_list = [_matrix_row_series(f"s{row}", row) for row in (2, 3, 4)]
+    bindings: WorkbookSeriesBindings = {"workbook": wb_path.name, "series": series_list}
+
+    calls: list[dict] = []
+    real_load = fastpyxl.load_workbook
+
+    def wrapped(*args, **kwargs):
+        calls.append(dict(kwargs))
+        return real_load(*args, **kwargs)
+
+    with patch("fastpyxl.load_workbook", side_effect=wrapped):
+        report = validate_series_bindings(graph, bindings, workbook=wb_path)
+
+    assert report["ok"] is True
+    assert len(calls) == 1
+    assert calls[0].get("data_only") is True
+    assert calls[0].get("read_only") is False

--- a/tests/unit/series_bindings/test_validate.py
+++ b/tests/unit/series_bindings/test_validate.py
@@ -442,7 +442,11 @@ def test_validate_series_bindings_loads_workbook_once(tmp_path: Path) -> None:
     wb_path = tmp_path / "demo.xlsx"
     graph = _write_matrix_demo_workbook(wb_path)
     series_list = [_matrix_row_series(f"s{row}", row) for row in (2, 3, 4)]
-    bindings: WorkbookSeriesBindings = {"workbook": wb_path.name, "series": series_list}
+    bindings: WorkbookSeriesBindings = {
+        "schema_version": "1.4.0",
+        "workbook": wb_path.name,
+        "series": series_list,
+    }
 
     calls: list[dict] = []
     real_load = fastpyxl.load_workbook


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`validate_series_bindings` (and `resolve_series_bindings`) reloaded the workbook once per series via `_WorkbookValues`, using `read_only=True` for random label/header access. On large manifests this dominated validate time.

### Changes

- Share one `_WorkbookValues` across series in `validate_series_bindings` and `resolve_series_bindings`
- Open with `read_only=False` (random bind access); close when owned
- Prefer graph node values via existing `_read_cell_value` path
- Skip named-range workbook opens for sheet-qualified `data_range` targets

### Tests

- MCVE-style assert: validate of 3 matrix series loads the workbook once (`data_only=True`, `read_only=False`)
- Same for multi-series `resolve_series_bindings`
- Sheet-qualified `expand_data_range` does not call `load_workbook`

Closes #416

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7683d72b-b38f-49b0-b8de-e0a0fca43d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7683d72b-b38f-49b0-b8de-e0a0fca43d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

