### PR TITLE
fix(evaluator): ISNUMBER/ISTEXT return FALSE for error arguments (#418)

### DIFF
--- a/.cursor/rules/parity.mdc
+++ b/.cursor/rules/parity.mdc
@@ -54,11 +54,12 @@ Export error-channel specifics:
 - The cell-evaluation boundary (`_evaluate_address` in `runtime/cache.py` and
   `runtime/cache_eval_slim.py`) raises for `XlError` values and caches the
   raising cell's code so re-reads raise without re-evaluating.
-- Error-consuming functions (`IFERROR`, `IFNA`, `ISERROR`, `ISNA`, `ISBLANK`)
-  receive **lazily-evaluated thunks** and handle both raised errors and
-  sentinel returns from embedded shared helpers. This mirrors the evaluator's
-  AST-level special cases; other functions (e.g. `ISNUMBER`, `ISTEXT`) are not
-  thunked and propagate argument errors like any generic worksheet function.
+- Error-consuming functions (`IFERROR`, `IFNA`, and the IS-family predicates
+  `ISERROR`, `ISNA`, `ISBLANK`, `ISNUMBER`, `ISTEXT`) receive **lazily-evaluated
+  thunks** and handle both raised errors and sentinel returns from embedded
+  shared helpers. This mirrors the evaluator: `ISERROR`/`ISNA`/`ISBLANK` are
+  AST-special-cased, while `ISNUMBER`/`ISTEXT` skip the generic argument error
+  precheck so they return booleans for error values (Excel IS semantics).
 - `compute_all` raises by default. Multi-cell range targets materialize as
   nested lists with per-cell sentinel codes (grid display semantics).
 - Lookup scans keep Excel **skip semantics** through the sentinel probe channel

--- a/excel_grapher/evaluator/evaluator.py
+++ b/excel_grapher/evaluator/evaluator.py
@@ -104,6 +104,11 @@ _SKIP_ERROR_PRECHECK = {
     # Logical reductions: short-circuit and fail-fast over lazy ranges.
     "AND",
     "OR",
+    # IS-family type predicates: Excel passes error values through; the
+    # callables return FALSE (they are not numbers/text). ISERROR/ISNA/ISBLANK
+    # are AST-special-cased above and never reach this generic path.
+    "ISNUMBER",
+    "ISTEXT",
 }
 
 if TYPE_CHECKING:

--- a/excel_grapher/exporter/codegen.py
+++ b/excel_grapher/exporter/codegen.py
@@ -104,7 +104,7 @@ _ARITHMETIC_OPS = frozenset({"+", "-", "*", "/", "^"})
 # Functions whose single argument is emitted as a lazily-evaluated thunk so the
 # exported runtime can catch raised Excel errors. Mirrors the evaluator's
 # AST-level special cases; other IS functions propagate argument errors there.
-_THUNK_ARG_FUNCTIONS = frozenset({"ISERROR", "ISNA", "ISBLANK"})
+_THUNK_ARG_FUNCTIONS = frozenset({"ISERROR", "ISNA", "ISBLANK", "ISNUMBER", "ISTEXT"})
 
 # Return unpacking hoists substantive ``xl_*`` runtime calls into statement-level
 # temporaries. Coercion helpers and error literals stay inline because they are

--- a/excel_grapher/exporter/export_runtime/__init__.py
+++ b/excel_grapher/exporter/export_runtime/__init__.py
@@ -11,7 +11,15 @@ functions (`IFERROR`, `IS*`) receive lazily-evaluated thunks.
 """
 
 from .aggregates import xl_sumproduct
-from .error_funcs import xl_iferror, xl_ifna, xl_isblank, xl_iserror, xl_isna
+from .error_funcs import (
+    xl_iferror,
+    xl_ifna,
+    xl_isblank,
+    xl_iserror,
+    xl_isna,
+    xl_isnumber,
+    xl_istext,
+)
 from .errors import XlErrorException, xl_raise
 from .lookup import xl_hlookup, xl_index, xl_lookup, xl_match, xl_vlookup, xl_xlookup
 from .offset import xl_offset, xl_range, xl_range_rows
@@ -47,6 +55,8 @@ __all__ = [
     "xl_isblank",
     "xl_iserror",
     "xl_isna",
+    "xl_isnumber",
+    "xl_istext",
     "xl_lookup",
     "xl_map_arithmetic",
     "xl_map_compare",

--- a/excel_grapher/exporter/export_runtime/error_funcs.py
+++ b/excel_grapher/exporter/export_runtime/error_funcs.py
@@ -23,6 +23,8 @@ __all__ = [
     "xl_isblank",
     "xl_iserror",
     "xl_isna",
+    "xl_isnumber",
+    "xl_istext",
 ]
 
 
@@ -89,3 +91,24 @@ def xl_isblank(value_fn: Callable[[], CellValue]) -> bool:
             return False
         value = value.value_at(1, 1)
     return value is None
+
+
+def xl_isnumber(value_fn: Callable[[], CellValue]) -> bool:
+    """Excel ISNUMBER: False for errors; True only for non-bool numbers."""
+    try:
+        value = _resolve_scalar(value_fn)
+    except XlErrorException:
+        return False
+    if isinstance(value, XlError):
+        return False
+    return not isinstance(value, bool) and isinstance(value, (int, float))
+
+
+def xl_istext(value_fn: Callable[[], CellValue]) -> bool:
+    """Excel ISTEXT: False for errors; True only for non-error strings."""
+    try:
+        value = _resolve_scalar(value_fn)
+    except XlErrorException:
+        return False
+    # XlError subclasses str; Excel ISTEXT returns FALSE for error values.
+    return isinstance(value, str) and not isinstance(value, XlError)

--- a/excel_grapher/exporter/export_runtime/info.py
+++ b/excel_grapher/exporter/export_runtime/info.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 from .values import CellValue, flatten
 
-__all__ = ["xl_count", "xl_isnumber"]
-
-
-def xl_isnumber(value: CellValue) -> bool:
-    return not isinstance(value, bool) and isinstance(value, (int, float))
+__all__ = ["xl_count"]
 
 
 def xl_count(*args: CellValue) -> int:

--- a/excel_grapher/runtime/info.py
+++ b/excel_grapher/runtime/info.py
@@ -12,7 +12,8 @@ def xl_isnumber(value: CellValue) -> bool:
 
 
 def xl_istext(value: CellValue) -> bool:
-    return isinstance(value, str)
+    # XlError subclasses str; Excel ISTEXT returns FALSE for error values.
+    return isinstance(value, str) and not isinstance(value, XlError)
 
 
 def xl_isblank(value: CellValue) -> bool:

--- a/tests/integration/exporter/test_raise_based_errors.py
+++ b/tests/integration/exporter/test_raise_based_errors.py
@@ -343,31 +343,32 @@ class TestErrorConsumers:
         assert result.generated_results["S!A1"] is True
         assert result.generated_results["S!A2"] is False
 
-    def test_isnumber_propagates_argument_errors_like_evaluator(self) -> None:
-        """Generic IS functions follow the evaluator's argument error precheck."""
+    def test_isnumber_error_args_return_false(self) -> None:
+        """ISNUMBER returns FALSE for error arguments (Excel IS semantics)."""
         graph = _make_graph(
             _make_node("S!A1", "=ISNUMBER(1/0)", None),
             _make_node("S!A2", "=ISNUMBER(2)", None),
         )
         result = assert_codegen_matches_evaluator(graph, ["S!A1", "S!A2"])
-        assert result.generated_results["S!A1"] == XlError.DIV
+        assert result.generated_results["S!A1"] is False
         assert result.generated_results["S!A2"] is True
 
-    def test_generic_functions_propagate_error_returning_argument(self) -> None:
-        """`NA()` returns an error sentinel; a generic consumer must propagate it.
+    def test_is_family_error_args_return_false(self) -> None:
+        """ISNUMBER/ISTEXT do not propagate error arguments; both return FALSE.
 
-        Unlike `1/0` (which raises), an error-returning function yields an
-        `XlError` sentinel. A non-thunked generic function such as `ISNUMBER`
-        or `ISTEXT` must not swallow it: the evaluator's argument error
-        precheck returns the error, so the export path must too.
+        Covers both raised errors (`1/0`) and error-returning helpers (`NA()`).
         """
         graph = _make_graph(
             _make_node("S!A1", "=ISNUMBER(NA())", None),
             _make_node("S!A2", "=ISTEXT(NA())", None),
+            _make_node("S!A3", "=ISTEXT(1/0)", None),
+            _make_node("S!A4", "=IF(ISNUMBER(1/0), 1, 0)", None),
         )
-        result = assert_codegen_matches_evaluator(graph, ["S!A1", "S!A2"])
-        assert result.generated_results["S!A1"] == XlError.NA
-        assert result.generated_results["S!A2"] == XlError.NA
+        result = assert_codegen_matches_evaluator(graph, ["S!A1", "S!A2", "S!A3", "S!A4"])
+        assert result.generated_results["S!A1"] is False
+        assert result.generated_results["S!A2"] is False
+        assert result.generated_results["S!A3"] is False
+        assert result.generated_results["S!A4"] == 0
 
     def test_if_with_erroring_condition_propagates(self) -> None:
         graph = _make_graph(_make_node("S!A1", "=IF(1/0, 1, 2)", None))

--- a/tests/unit/evaluator/test_functions.py
+++ b/tests/unit/evaluator/test_functions.py
@@ -311,6 +311,31 @@ def test_isnumber() -> None:
         assert result["S!A3"] is False  # TRUE is a boolean, not a number
 
 
+def test_isnumber_error_args_return_false() -> None:
+    """ISNUMBER treats error values as ordinary arguments (Excel IS semantics)."""
+    graph = _make_graph(
+        _make_node("S!A1", "=ISNUMBER(1/0)", None),
+        _make_node("S!A2", "=ISNUMBER(NA())", None),
+        _make_node("S!A3", "=ISNUMBER(#VALUE!)", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        result = ev.evaluate(["S!A1", "S!A2", "S!A3"])
+        assert result["S!A1"] is False
+        assert result["S!A2"] is False
+        assert result["S!A3"] is False
+
+
+def test_isnumber_guard_collapses_div_zero() -> None:
+    """IF(ISNUMBER(x/y), x/y, 0) returns the fallback when the division errors."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 0),
+        _make_node("S!A2", None, 0),
+        _make_node("S!B1", "=IF(ISNUMBER(S!A1/S!A2),S!A1/S!A2,0)", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        assert ev.evaluate(["S!B1"])["S!B1"] == 0
+
+
 def test_istext() -> None:
     """Test ISTEXT function."""
     graph = _make_graph(
@@ -321,6 +346,20 @@ def test_istext() -> None:
         result = ev.evaluate(["S!A1", "S!A2"])
         assert result["S!A1"] is True
         assert result["S!A2"] is False
+
+
+def test_istext_error_args_return_false() -> None:
+    """ISTEXT returns FALSE for errors; XlError must not count as text."""
+    graph = _make_graph(
+        _make_node("S!A1", "=ISTEXT(1/0)", None),
+        _make_node("S!A2", "=ISTEXT(NA())", None),
+        _make_node("S!A3", "=ISTEXT(#N/A)", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        result = ev.evaluate(["S!A1", "S!A2", "S!A3"])
+        assert result["S!A1"] is False
+        assert result["S!A2"] is False
+        assert result["S!A3"] is False
 
 
 def test_isblank() -> None:

--- a/tests/unit/exporter/test_export_runtime.py
+++ b/tests/unit/exporter/test_export_runtime.py
@@ -4,6 +4,8 @@ import pytest
 
 from excel_grapher.core import CellValue, XlError
 from excel_grapher.exporter.export_runtime import Range, XlErrorException
+from excel_grapher.exporter.export_runtime.error_funcs import xl_isnumber, xl_istext
+from excel_grapher.exporter.export_runtime.errors import xl_raise
 
 
 def test_xl_error_exception_carries_excel_error_code() -> None:
@@ -77,3 +79,14 @@ def test_range_row_and_column_views_preserve_laziness() -> None:
     assert rng.column(1).shape == (3, 1)
     assert rng.column(1).cell(3, 1) == "S!A3"
     assert calls == ["S!C2", "S!A3"]
+
+
+def test_xl_isnumber_istext_thunks_return_false_for_errors() -> None:
+    """Thunked ISNUMBER/ISTEXT catch raised errors and reject XlError sentinels."""
+    assert xl_isnumber(lambda: xl_raise(XlError.DIV)) is False
+    assert xl_isnumber(lambda: XlError.NA) is False
+    assert xl_isnumber(lambda: 2) is True
+    assert xl_istext(lambda: xl_raise(XlError.NA)) is False
+    assert xl_istext(lambda: XlError.DIV) is False
+    assert xl_istext(lambda: "hello") is True
+    assert xl_istext(lambda: 123) is False

--- a/tests/unit/runtime/test_smoke_blocker_functions.py
+++ b/tests/unit/runtime/test_smoke_blocker_functions.py
@@ -12,7 +12,7 @@ np = pytest.importorskip("numpy")
 from excel_grapher.core.coercions import datetime_to_excel_serial, to_number
 from excel_grapher.core.types import XlError
 from excel_grapher.runtime.datetime import xl_today
-from excel_grapher.runtime.info import xl_iserror, xl_isna
+from excel_grapher.runtime.info import xl_iserror, xl_isna, xl_isnumber, xl_istext
 from excel_grapher.runtime.math import xl_averageif, xl_countif
 from excel_grapher.runtime.text import xl_lower, xl_value
 
@@ -22,6 +22,15 @@ def test_xl_iserror_and_isna() -> None:
     assert xl_iserror(1) is False
     assert xl_isna(XlError.NA) is True
     assert xl_isna(XlError.DIV) is False
+
+
+def test_xl_isnumber_and_istext_reject_errors() -> None:
+    """ISNUMBER/ISTEXT return False for XlError (errors are not numbers or text)."""
+    assert xl_isnumber(XlError.DIV) is False
+    assert xl_isnumber(3) is True
+    assert xl_istext(XlError.NA) is False
+    assert xl_istext("hello") is True
+    assert xl_istext(123) is False
 
 
 def test_xl_lower_and_value() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #418. Excel IS-family predicates take error values as ordinary arguments and return booleans; they must not propagate. `ISNUMBER(#DIV/0!)` and `ISTEXT(#N/A)` are `FALSE`, which is what makes the ubiquitous `IF(ISNUMBER(x/y), x/y, 0)` guard work.

Previously the evaluator's generic argument error precheck returned the first error before calling `ISNUMBER`/`ISTEXT`, so the guard collapsed to `#DIV/0!` instead of `0`. Independently, `ISTEXT` treated `XlError` as text because it subclasses `str`.

## Changes

- Skip error precheck for `ISNUMBER` / `ISTEXT` in `FormulaEvaluator` (same Excel IS semantics as the AST-special-cased `ISERROR`/`ISNA`/`ISBLANK`).
- Make `xl_istext` exclude `XlError`.
- Thunk `ISNUMBER` / `ISTEXT` in export codegen and add raise-channel wrappers in `export_runtime/error_funcs.py` so evaluator ↔ export parity holds.
- Update parity docs and tests that previously encoded the buggy propagation behavior.

## Test plan

- [x] Unit tests for evaluator `ISNUMBER`/`ISTEXT` error args and the `IF(ISNUMBER(div), …, 0)` guard
- [x] Runtime + export-runtime unit coverage for `XlError` rejection
- [x] Integration parity tests updated to expect `FALSE` / fallback `0`
- [x] Full `uv run pytest` (2252 passed)
- [x] `ruff check` / `ruff format --check` / `ty check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c17b5ca-821b-4db7-8c3e-d6500f62aeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c17b5ca-821b-4db7-8c3e-d6500f62aeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

