### PR TITLE
fix(evaluator): ignore blanks/text/bools in range aggregates (#419)

### DIFF
--- a/excel_grapher/core/expr_eval.py
+++ b/excel_grapher/core/expr_eval.py
@@ -13,7 +13,7 @@ from fastpyxl.utils.cell import (
 from excel_grapher.core.address_keys import parse_address
 from excel_grapher.core.grid import Range
 
-from .coercions import flatten, numeric_values, to_bool, to_string
+from .coercions import flatten, to_bool, to_string
 from .excel_function_names import normalize_excel_function_name
 from .formula_ast import (
     AstNode,
@@ -27,7 +27,7 @@ from .formula_ast import (
     StringNode,
     UnaryOpNode,
 )
-from .math_funcs import abs_number, exp_number
+from .math_funcs import abs_number, exp_number, max_cells, min_cells, sum_cells
 from .operators import (
     xl_add,
     xl_concat,
@@ -314,28 +314,15 @@ def _range_node_to_excel_range(node: RangeNode) -> ExcelRange | None:
 
 
 def _fn_sum(args: list[CellValue]) -> CellValue:
-    nums, err = numeric_values(flatten(*args))
-    if err is not None:
-        return err
-    return float(sum(nums))
+    return sum_cells(*args)
 
 
 def _fn_min(args: list[CellValue]) -> CellValue:
-    nums, err = numeric_values(flatten(*args))
-    if err is not None:
-        return err
-    if not nums:
-        return XlError.VALUE
-    return float(min(nums))
+    return min_cells(*args)
 
 
 def _fn_max(args: list[CellValue]) -> CellValue:
-    nums, err = numeric_values(flatten(*args))
-    if err is not None:
-        return err
-    if not nums:
-        return XlError.VALUE
-    return float(max(nums))
+    return max_cells(*args)
 
 
 def _fn_abs(args: list[CellValue]) -> CellValue:

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -39,14 +39,39 @@ __all__ = [
 ]
 
 
+def _iter_aggregate_numbers(*args: CellValue) -> Iterator[float | XlError]:
+    """Yield numbers for SUM/AVERAGE/MIN/MAX/STDEV with Excel arg semantics.
+
+    Range/array arguments keep only numeric cells: blanks, text, and booleans
+    are skipped; `XlError` values propagate. Literal scalar arguments still
+    coerce via `to_number` (so `SUM(1, "2", TRUE)` is 4).
+    """
+    for arg in args:
+        grid = Grid.wrap(arg)
+        if grid is not None:
+            for cell in grid.iter_raw():
+                if isinstance(cell, XlError):
+                    yield cell
+                    return
+                if cell is None or isinstance(cell, (bool, str)):
+                    continue
+                if isinstance(cell, numbers.Real):
+                    yield float(cell)
+            continue
+        number = to_number(arg)
+        if isinstance(number, XlError):
+            yield number
+            return
+        yield float(number)
+
+
 def sum_cells(*args: CellValue) -> float | XlError:
     """Return the sum of numeric cells."""
     total = 0.0
-    for v in flatten(*args):
-        n = to_number(v)
-        if isinstance(n, XlError):
-            return n
-        total += float(n)
+    for value in _iter_aggregate_numbers(*args):
+        if isinstance(value, XlError):
+            return value
+        total += value
     return total
 
 
@@ -54,11 +79,10 @@ def average_cells(*args: CellValue) -> float | XlError:
     """Return the average of numeric cells."""
     total = 0.0
     count = 0
-    for v in flatten(*args):
-        n = to_number(v)
-        if isinstance(n, XlError):
-            return n
-        total += float(n)
+    for value in _iter_aggregate_numbers(*args):
+        if isinstance(value, XlError):
+            return value
+        total += value
         count += 1
     if count == 0:
         return XlError.DIV
@@ -69,11 +93,9 @@ def min_cells(*args: CellValue) -> float | XlError:
     """Return the minimum of numeric cells."""
     found = False
     current = 0.0
-    for v in flatten(*args):
-        n = to_number(v)
-        if isinstance(n, XlError):
-            return n
-        value = float(n)
+    for value in _iter_aggregate_numbers(*args):
+        if isinstance(value, XlError):
+            return value
         if not found or value < current:
             current = value
             found = True
@@ -86,11 +108,9 @@ def max_cells(*args: CellValue) -> float | XlError:
     """Return the maximum of numeric cells."""
     found = False
     current = 0.0
-    for v in flatten(*args):
-        n = to_number(v)
-        if isinstance(n, XlError):
-            return n
-        value = float(n)
+    for value in _iter_aggregate_numbers(*args):
+        if isinstance(value, XlError):
+            return value
         if not found or value > current:
             current = value
             found = True
@@ -146,11 +166,10 @@ def npv_cells(rate: CellValue, *values: CellValue) -> float | XlError:
 def stdev_cells(*args: CellValue) -> float | XlError:
     """Return sample standard deviation of numeric cells."""
     nums: list[float] = []
-    for v in flatten(*args):
-        n = to_number(v)
-        if isinstance(n, XlError):
-            return n
-        nums.append(float(n))
+    for value in _iter_aggregate_numbers(*args):
+        if isinstance(value, XlError):
+            return value
+        nums.append(value)
     if len(nums) < 2:
         return XlError.DIV
     mean = sum(nums) / len(nums)

--- a/tests/integration/exporter/test_golden_parity.py
+++ b/tests/integration/exporter/test_golden_parity.py
@@ -46,7 +46,7 @@ def test_golden_parity_mixed_features_small_graph() -> None:
         _make_node("S!B2", "=IF(S!A3,1,2)", None),  # 2 via Excel boolean coercion
         _make_node("S!B3", "=IFERROR(1/0,99)", None),  # 99 (DIV/0! caught)
         _make_node("S!B4", "=SUM(S!B2,S!B3)", None),  # 101
-        _make_node("S!C1", "=SUM(S!B1:S!B4)", None),  # includes boolean -> 1 + 2 + 99 + 101 = 203
+        _make_node("S!C1", "=SUM(S!B1:S!B4)", None),  # boolean in range ignored -> 2 + 99 + 101 = 202
     )
 
     targets = ["S!B1", "S!B2", "S!B3", "S!B4", "S!C1"]
@@ -56,7 +56,7 @@ def test_golden_parity_mixed_features_small_graph() -> None:
     assert result.generated_results["S!B2"] == 2
     assert result.generated_results["S!B3"] == 99
     assert result.generated_results["S!B4"] == 101.0
-    assert result.generated_results["S!C1"] == 203.0
+    assert result.generated_results["S!C1"] == 202.0
 
     # No OFFSET in this scenario, so dynamic OFFSET runtime should not be included.
     assert "_CELL_TABLE = {" not in result.generated_code

--- a/tests/integration/exporter/test_golden_parity.py
+++ b/tests/integration/exporter/test_golden_parity.py
@@ -46,7 +46,9 @@ def test_golden_parity_mixed_features_small_graph() -> None:
         _make_node("S!B2", "=IF(S!A3,1,2)", None),  # 2 via Excel boolean coercion
         _make_node("S!B3", "=IFERROR(1/0,99)", None),  # 99 (DIV/0! caught)
         _make_node("S!B4", "=SUM(S!B2,S!B3)", None),  # 101
-        _make_node("S!C1", "=SUM(S!B1:S!B4)", None),  # boolean in range ignored -> 2 + 99 + 101 = 202
+        _make_node(
+            "S!C1", "=SUM(S!B1:S!B4)", None
+        ),  # boolean in range ignored -> 2 + 99 + 101 = 202
     )
 
     targets = ["S!B1", "S!B2", "S!B3", "S!B4", "S!C1"]

--- a/tests/unit/core/test_range_aggregate_coercion.py
+++ b/tests/unit/core/test_range_aggregate_coercion.py
@@ -23,7 +23,7 @@ from excel_grapher.core.math_funcs import (
 
 
 def _mcve_range() -> Range:
-    """Synthetic range matching issue #419: numbers, \"\", blank, text, bool."""
+    """Synthetic range matching issue #419: numbers, empty text, blank, text, bool."""
     values: dict[str, CellValue] = {
         "S!A1": -0.2,
         "S!A2": -0.3,

--- a/tests/unit/core/test_range_aggregate_coercion.py
+++ b/tests/unit/core/test_range_aggregate_coercion.py
@@ -1,0 +1,117 @@
+"""Excel range-argument filtering for SUM/AVERAGE/MIN/MAX/STDEV (#419).
+
+Range/array args keep only numbers (skip blanks, text, booleans); errors
+propagate. Literal scalar args still coerce (`SUM(1, "2", TRUE)` is 4).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+import pytest
+
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.grid import Range
+from excel_grapher.core.math_funcs import (
+    average_cells,
+    max_cells,
+    min_cells,
+    stdev_cells,
+    sum_cells,
+)
+
+
+def _mcve_range() -> Range:
+    """Synthetic range matching issue #419: numbers, \"\", blank, text, bool."""
+    values: dict[str, CellValue] = {
+        "S!A1": -0.2,
+        "S!A2": -0.3,
+        "S!A3": "",  # empty text from a guard formula
+        "S!A4": None,  # truly blank
+        "S!A5": "n.a.",
+        "S!A6": True,
+    }
+    return Range("S", 1, 1, 6, 1, lambda a: values[a])
+
+
+def test_sum_range_ignores_blanks_text_and_booleans() -> None:
+    assert sum_cells(cast(CellValue, _mcve_range())) == -0.5
+
+
+def test_average_range_ignores_blanks_text_and_booleans() -> None:
+    assert average_cells(cast(CellValue, _mcve_range())) == -0.25
+
+
+def test_min_range_ignores_blanks_text_and_booleans() -> None:
+    assert min_cells(cast(CellValue, _mcve_range())) == -0.3
+
+
+def test_max_range_ignores_blanks_text_and_booleans() -> None:
+    assert max_cells(cast(CellValue, _mcve_range())) == -0.2
+
+
+def test_stdev_range_ignores_blanks_text_and_booleans() -> None:
+    result = stdev_cells(cast(CellValue, _mcve_range()))
+    assert isinstance(result, float)
+    assert result == pytest.approx(math.sqrt(0.005))
+
+
+def test_average_range_with_only_blanks_and_empty_text_does_not_halve() -> None:
+    """Silent failure shape: empties must not count as zeros in the divisor."""
+    values: dict[str, CellValue] = {
+        "S!A1": -0.2,
+        "S!A2": -0.3,
+        "S!A3": "",
+        "S!A4": None,
+    }
+    rng = Range("S", 1, 1, 4, 1, lambda a: values[a])
+    assert average_cells(cast(CellValue, rng)) == -0.25
+
+
+def test_nested_list_range_ignores_non_numerics() -> None:
+    assert sum_cells([[-0.2], [-0.3], [""], [None], ["n.a."], [True]]) == -0.5
+    assert average_cells([[-0.2], [-0.3], [""], [None]]) == -0.25
+
+
+def test_literal_scalars_still_coerce() -> None:
+    assert sum_cells(1, "2", True) == 4.0
+    assert average_cells(1, "3", False) == 4.0 / 3.0
+    assert min_cells(1, "2", True) == 1.0
+    assert max_cells(1, "2", True) == 2.0
+
+
+def test_mixed_literal_and_range_args() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 10.0, "S!A2": "skip"}[a])
+    assert sum_cells(1, cast(CellValue, rng), True) == 12.0
+
+
+def test_average_of_no_numbers_is_div_error() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": "", "S!A2": None}[a])
+    assert average_cells(cast(CellValue, rng)) == XlError.DIV
+    assert average_cells() == XlError.DIV
+
+
+def test_stdev_of_fewer_than_two_numbers_is_div_error() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": 1.0, "S!A2": ""}[a])
+    assert stdev_cells(cast(CellValue, rng)) == XlError.DIV
+
+
+def test_sum_min_max_of_no_numbers_is_zero() -> None:
+    rng = Range("S", 1, 1, 2, 1, lambda a: {"S!A1": "x", "S!A2": True}[a])
+    assert sum_cells(cast(CellValue, rng)) == 0.0
+    assert min_cells(cast(CellValue, rng)) == 0.0
+    assert max_cells(cast(CellValue, rng)) == 0.0
+
+
+def test_range_error_propagates() -> None:
+    calls: list[str] = []
+
+    def resolve(address: str) -> CellValue:
+        calls.append(address)
+        return {"S!A1": 1.0, "S!A2": XlError.DIV, "S!A3": 99.0}[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert sum_cells(cast(CellValue, rng)) == XlError.DIV
+    assert average_cells(cast(CellValue, rng)) == XlError.DIV
+    assert "S!A3" not in calls

--- a/tests/unit/evaluator/test_functions.py
+++ b/tests/unit/evaluator/test_functions.py
@@ -166,6 +166,32 @@ def test_min_max() -> None:
         assert result["S!A2"] == 3.0
 
 
+def test_range_aggregates_ignore_blanks_text_and_booleans() -> None:
+    """Range args ignore blanks/text/bools; only numbers participate (#419)."""
+    graph = _make_graph(
+        _make_node("S!A1", None, -0.2),
+        _make_node("S!A2", None, -0.3),
+        _make_node("S!A3", None, ""),
+        _make_node("S!A4", None, None),
+        _make_node("S!A5", None, "n.a."),
+        _make_node("S!A6", None, True),
+        _make_node("S!B1", "=AVERAGE(S!A1:A6)", None),
+        _make_node("S!B2", "=SUM(S!A1:A6)", None),
+        _make_node("S!B3", "=MIN(S!A1:A6)", None),
+        _make_node("S!B4", "=MAX(S!A1:A6)", None),
+        _make_node("S!B5", "=STDEV(S!A1:A6)", None),
+        _make_node("S!B6", "=AVERAGE(S!A1:A4)", None),
+    )
+    with FormulaEvaluator(graph) as ev:
+        result = ev.evaluate([f"S!B{i}" for i in range(1, 7)])
+        assert result["S!B1"] == -0.25
+        assert result["S!B2"] == -0.5
+        assert result["S!B3"] == -0.3
+        assert result["S!B4"] == -0.2
+        assert result["S!B5"] == pytest.approx(0.0707106781)
+        assert result["S!B6"] == -0.25
+
+
 def test_abs() -> None:
     """Test ABS function."""
     graph = _make_graph(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #419: `SUM` / `AVERAGE` / `MIN` / `MAX` / `STDEV` now apply Excel’s range-argument filter instead of coercing every cell through generic number conversion.

## Behavior

For **range/array** arguments:
- keep numbers only
- skip blanks (`None`), text (including `""`), and booleans
- propagate `XlError`

For **literal scalar** arguments, coercion is unchanged (`SUM(1, "2", TRUE)` is still `4`).

Empty numeric sets:
- `AVERAGE` / `STDEV` → `#DIV/0!`
- `SUM` / `MIN` / `MAX` → `0`

This removes both failure shapes from the issue: text in a range producing `#VALUE!`, and blanks/`""` silently counting as zeros (e.g. `AVERAGE` over 2 numbers + 2 empties returning half the correct mean).

## Implementation

Shared runtime in `excel_grapher/core/math_funcs.py` (`_iter_aggregate_numbers`), used by evaluator and export wrappers. Restricted `expr_eval` SUM/MIN/MAX now delegate to the same helpers for consistency.

## Tests

- Unit coverage of the #419 MCVE (lazy `Range` + nested lists), literal coercion, mixed args, empty sets, and error propagation
- Evaluator-level MCVE matching the issue table

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d2dcd2f-fe56-436f-a681-7a57b795553d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d2dcd2f-fe56-436f-a681-7a57b795553d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

