### PR TITLE
fix(coercions): reject empty text in numeric coercion (#420)

### DIFF
--- a/excel_grapher/core/coercions.py
+++ b/excel_grapher/core/coercions.py
@@ -66,10 +66,14 @@ def _try_parse_iso_date_serial(text: str) -> float | None:
 
 
 def try_coerce_string_to_float(text: str) -> float | None:
-    """Parse one Excel numeric string, or return None when coercion fails."""
+    """Parse one Excel numeric string, or return None when coercion fails.
+
+    Empty and whitespace-only text do not coerce (Excel arithmetic raises
+    `#VALUE!` for empty text, unlike blank cells which coerce to 0 via `None`).
+    """
     stripped = text.strip()
     if stripped == "":
-        return 0.0
+        return None
     try:
         return float(stripped)
     except ValueError:

--- a/excel_grapher/core/coercions.py
+++ b/excel_grapher/core/coercions.py
@@ -66,11 +66,7 @@ def _try_parse_iso_date_serial(text: str) -> float | None:
 
 
 def try_coerce_string_to_float(text: str) -> float | None:
-    """Parse one Excel numeric string, or return None when coercion fails.
-
-    Empty and whitespace-only text do not coerce (Excel arithmetic raises
-    `#VALUE!` for empty text, unlike blank cells which coerce to 0 via `None`).
-    """
+    """Parse one Excel numeric string; empty/whitespace text fails (`None`)."""
     stripped = text.strip()
     if stripped == "":
         return None

--- a/excel_grapher/core/math_funcs.py
+++ b/excel_grapher/core/math_funcs.py
@@ -39,14 +39,33 @@ __all__ = [
 ]
 
 
+def _numeric_for_aggregate(value: object) -> float | XlError | None:
+    """Coerce one aggregate cell; skip text (`None`), propagate `XlError`.
+
+    Excel full-scan aggregates (`SUM`, `AVERAGE`, `MIN`, `MAX`, `STDEV`) ignore
+    text — including empty guard results — rather than raising `#VALUE!`.
+    `XlError` is a `StrEnum`, so error sentinels must be checked before `str`.
+    """
+    if isinstance(value, XlError):
+        return value
+    if isinstance(value, str):
+        return None
+    number = to_number(cast(CellValue, value))
+    if isinstance(number, XlError):
+        return number
+    return float(number)
+
+
 def sum_cells(*args: CellValue) -> float | XlError:
     """Return the sum of numeric cells."""
     total = 0.0
     for v in flatten(*args):
-        n = to_number(v)
+        n = _numeric_for_aggregate(v)
+        if n is None:
+            continue
         if isinstance(n, XlError):
             return n
-        total += float(n)
+        total += n
     return total
 
 
@@ -55,10 +74,12 @@ def average_cells(*args: CellValue) -> float | XlError:
     total = 0.0
     count = 0
     for v in flatten(*args):
-        n = to_number(v)
+        n = _numeric_for_aggregate(v)
+        if n is None:
+            continue
         if isinstance(n, XlError):
             return n
-        total += float(n)
+        total += n
         count += 1
     if count == 0:
         return XlError.DIV
@@ -70,12 +91,13 @@ def min_cells(*args: CellValue) -> float | XlError:
     found = False
     current = 0.0
     for v in flatten(*args):
-        n = to_number(v)
+        n = _numeric_for_aggregate(v)
+        if n is None:
+            continue
         if isinstance(n, XlError):
             return n
-        value = float(n)
-        if not found or value < current:
-            current = value
+        if not found or n < current:
+            current = n
             found = True
     if not found:
         return 0.0
@@ -87,12 +109,13 @@ def max_cells(*args: CellValue) -> float | XlError:
     found = False
     current = 0.0
     for v in flatten(*args):
-        n = to_number(v)
+        n = _numeric_for_aggregate(v)
+        if n is None:
+            continue
         if isinstance(n, XlError):
             return n
-        value = float(n)
-        if not found or value > current:
-            current = value
+        if not found or n > current:
+            current = n
             found = True
     if not found:
         return 0.0
@@ -133,11 +156,13 @@ def npv_cells(rate: CellValue, *values: CellValue) -> float | XlError:
     result = 0.0
     count = 0
     for v in flatten(*values):
-        n = to_number(v)
+        n = _numeric_for_aggregate(v)
+        if n is None:
+            continue
         if isinstance(n, XlError):
             return n
         count += 1
-        result += float(n) / ((1 + r) ** count)
+        result += n / ((1 + r) ** count)
     if count == 0:
         return XlError.VALUE
     return result
@@ -147,10 +172,12 @@ def stdev_cells(*args: CellValue) -> float | XlError:
     """Return sample standard deviation of numeric cells."""
     nums: list[float] = []
     for v in flatten(*args):
-        n = to_number(v)
+        n = _numeric_for_aggregate(v)
+        if n is None:
+            continue
         if isinstance(n, XlError):
             return n
-        nums.append(float(n))
+        nums.append(n)
     if len(nums) < 2:
         return XlError.DIV
     mean = sum(nums) / len(nums)

--- a/excel_grapher/core/operators_fastpath.py
+++ b/excel_grapher/core/operators_fastpath.py
@@ -447,13 +447,23 @@ def try_fastpath_concat_array(
 
 
 def try_fastpath_sumproduct(arrays: list[np.ndarray]) -> float | None:
-    """Sum element-wise products when every array batch-coerces to float64."""
+    """Sum element-wise products when every array batch-coerces to float64.
+
+    Arrays containing plain text fall back to the reference path so SUMPRODUCT
+    can treat text as 0 (Excel). `batch_coerce_to_float64` would otherwise
+    parse numeric strings, which diverges from range-text semantics.
+    """
     if not arrays:
         return 0.0
     if arrays[0].size < MIN_OPERATOR_FASTPATH_CELLS:
         return None
     coerced: list[np.ndarray] = []
     for arr in arrays:
+        flat = arr.ravel()
+        for value in flat:
+            # `XlError` is a `StrEnum`; plain text must not use numeric coerce.
+            if isinstance(value, str) and not isinstance(value, XlError):
+                return None
         batch = batch_coerce_to_float64(arr)
         if batch is None:
             return None

--- a/excel_grapher/core/operators_reference.py
+++ b/excel_grapher/core/operators_reference.py
@@ -189,7 +189,11 @@ def reference_concat_array(
 
 
 def reference_sumproduct_arrays(arrays: list[Any]) -> float | XlError:
-    """Element-wise product reduction (C-order, fail-fast on ``to_number`` errors)."""
+    """Element-wise product reduction (C-order, fail-fast on ``XlError``).
+
+    Non-numeric text is treated as 0 (Excel SUMPRODUCT). `XlError` is a
+    `StrEnum`, so error sentinels are checked before the text branch.
+    """
     import numpy as np
 
     if not arrays:
@@ -199,9 +203,15 @@ def reference_sumproduct_arrays(arrays: list[Any]) -> float | XlError:
     for indices in np.ndindex(shape):
         product = 1.0
         for arr in arrays:
-            number = to_number(arr[indices])
-            if isinstance(number, XlError):
-                return number
+            cell = arr[indices]
+            if isinstance(cell, XlError):
+                return cell
+            if isinstance(cell, str):
+                number = 0.0
+            else:
+                number = to_number(cell)
+                if isinstance(number, XlError):
+                    return number
             product *= number
         result += product
     return result

--- a/excel_grapher/core/operators_reference.py
+++ b/excel_grapher/core/operators_reference.py
@@ -78,6 +78,12 @@ def compare_scalars(op: str, left: FormulaValue, right: FormulaValue) -> bool | 
     if isinstance(left, str) and isinstance(right, str):
         return _cmp_str(excel_casefold(left), excel_casefold(right))
 
+    # Exact empty text compares as 0 (Excel); whitespace-only does not coerce.
+    if isinstance(left, str) and left == "":
+        left = 0.0
+    if isinstance(right, str) and right == "":
+        right = 0.0
+
     ln = to_number(left)
     rn = to_number(right)
     if isinstance(ln, XlError) or isinstance(rn, XlError):

--- a/excel_grapher/core/sumproduct.py
+++ b/excel_grapher/core/sumproduct.py
@@ -37,9 +37,17 @@ def sumproduct_cells(*args: CellValue) -> float | XlError:
     for index0 in range(grids[0].size):
         product = 1.0
         for grid in grids:
-            number = to_number(cast(CellValue, grid.at_flat(index0)))
-            if isinstance(number, XlError):
-                return number
+            cell = cast(CellValue, grid.at_flat(index0))
+            # Excel SUMPRODUCT treats non-numeric text as 0 (not `#VALUE!`).
+            # `XlError` is a `StrEnum` — check errors before the `str` branch.
+            if isinstance(cell, XlError):
+                return cell
+            if isinstance(cell, str):
+                number = 0.0
+            else:
+                number = to_number(cell)
+                if isinstance(number, XlError):
+                    return number
             product *= number
         result += product
     return result

--- a/tests/integration/evaluator/test_empty_text_arithmetic_parity.py
+++ b/tests/integration/evaluator/test_empty_text_arithmetic_parity.py
@@ -1,7 +1,7 @@
 """Empty text vs blank arithmetic: evaluator ↔ export parity (#420).
 
-Guard formulas often return `\"\"`. Excel raises `#VALUE!` for arithmetic on
-empty text, while blank cells still coerce to 0 (`#DIV/0!` for division).
+Guard formulas often return empty text. Excel raises `#VALUE!` for arithmetic
+on empty text, while blank cells still coerce to 0 (`#DIV/0!` for division).
 """
 
 from __future__ import annotations

--- a/tests/integration/evaluator/test_empty_text_arithmetic_parity.py
+++ b/tests/integration/evaluator/test_empty_text_arithmetic_parity.py
@@ -38,8 +38,7 @@ def test_empty_text_arithmetic_parity_matches_excel_error_classes() -> None:
     graph = _make_graph(
         _make_node("S!A1", None, 1),
         _make_node("S!A2", '=IF(TRUE,"",0)', None),
-        # A3 intentionally absent from the graph as a true blank leaf via formula
-        # that yields None would also coerce; use an explicit blank leaf value.
+        # Blank leaf (`None`) still coerces to 0 in arithmetic.
         _make_node("S!A3", None, None),
         _make_node("S!B1", "=S!A1/S!A2", None),
         _make_node("S!B2", "=S!A1/S!A3", None),
@@ -50,3 +49,18 @@ def test_empty_text_arithmetic_parity_matches_excel_error_classes() -> None:
     assert result.evaluator_results["S!B1"] == XlError.VALUE
     assert result.evaluator_results["S!B2"] == XlError.DIV
     assert result.evaluator_results["S!B3"] == XlError.VALUE
+
+
+def test_sum_skips_empty_text_while_arithmetic_rejects_it() -> None:
+    """SUM ignores guard empty text; `+` still raises `#VALUE!` (parity)."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", '=IF(TRUE,"",0)', None),
+        _make_node("S!A3", None, 2),
+        _make_node("S!B1", "=SUM(S!A1:S!A3)", None),
+        _make_node("S!B2", "=S!A1+S!A2", None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!B1", "S!B2"])
+    assert result.evaluator_results["S!B1"] == 3.0
+    assert result.evaluator_results["S!B2"] == XlError.VALUE

--- a/tests/integration/evaluator/test_empty_text_arithmetic_parity.py
+++ b/tests/integration/evaluator/test_empty_text_arithmetic_parity.py
@@ -1,0 +1,52 @@
+"""Empty text vs blank arithmetic: evaluator ↔ export parity (#420).
+
+Guard formulas often return `\"\"`. Excel raises `#VALUE!` for arithmetic on
+empty text, while blank cells still coerce to 0 (`#DIV/0!` for division).
+"""
+
+from __future__ import annotations
+
+from excel_grapher import DependencyGraph, Node, XlError
+from excel_grapher.core.address_keys import parse_address
+from tests.integration.utils.parity_harness import assert_codegen_matches_evaluator
+
+
+def _make_node(address: str, formula: str | None, value: object) -> Node:
+    sheet, coord = parse_address(address)
+    col = "".join(c for c in coord if c.isalpha())
+    row = int("".join(c for c in coord if c.isdigit()))
+    return Node(
+        sheet=sheet,
+        column=col,
+        row=row,
+        formula=formula,
+        normalized_formula=formula,
+        value=value,
+        is_leaf=formula is None,
+    )
+
+
+def _make_graph(*nodes: Node) -> DependencyGraph:
+    graph = DependencyGraph()
+    for node in nodes:
+        graph.add_node(node)
+    return graph
+
+
+def test_empty_text_arithmetic_parity_matches_excel_error_classes() -> None:
+    """B1/B3: empty text -> #VALUE!; B2: blank cell divisor -> #DIV/0!."""
+    graph = _make_graph(
+        _make_node("S!A1", None, 1),
+        _make_node("S!A2", '=IF(TRUE,"",0)', None),
+        # A3 intentionally absent from the graph as a true blank leaf via formula
+        # that yields None would also coerce; use an explicit blank leaf value.
+        _make_node("S!A3", None, None),
+        _make_node("S!B1", "=S!A1/S!A2", None),
+        _make_node("S!B2", "=S!A1/S!A3", None),
+        _make_node("S!B3", "=S!A1+S!A2", None),
+    )
+
+    result = assert_codegen_matches_evaluator(graph, ["S!B1", "S!B2", "S!B3"])
+    assert result.evaluator_results["S!B1"] == XlError.VALUE
+    assert result.evaluator_results["S!B2"] == XlError.DIV
+    assert result.evaluator_results["S!B3"] == XlError.VALUE

--- a/tests/unit/core/test_aggregate_skip_text.py
+++ b/tests/unit/core/test_aggregate_skip_text.py
@@ -1,0 +1,66 @@
+"""Aggregates ignore non-numeric text like Excel (#420 follow-up).
+
+Arithmetic still raises `#VALUE!` on empty text via `to_number`; SUM/AVERAGE/
+MIN/MAX/STDEV skip text cells (including guard empty text) and keep
+propagating embedded errors.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from excel_grapher.core import CellValue, XlError
+from excel_grapher.core.grid import Range
+from excel_grapher.core.math_funcs import (
+    average_cells,
+    max_cells,
+    min_cells,
+    stdev_cells,
+    sum_cells,
+)
+from excel_grapher.core.operators import xl_add
+from excel_grapher.core.sumproduct import sumproduct_cells
+
+
+@pytest.mark.parametrize(
+    ("func", "args", "expected"),
+    [
+        (sum_cells, (1, "", 2), 3.0),
+        (sum_cells, (1, " ", "abc", 2), 3.0),
+        (sum_cells, ("", "  "), 0.0),
+        (average_cells, (2, "", 6), 4.0),
+        (average_cells, ("x", 10), 10.0),
+        (min_cells, (3, "", 1, "nope"), 1.0),
+        (max_cells, (3, "", 1, "nope"), 3.0),
+        (stdev_cells, (1, "", 3), pytest.approx(2.0**0.5)),
+    ],
+)
+def test_aggregates_skip_non_numeric_text(func, args, expected) -> None:
+    assert func(*args) == expected
+
+
+def test_sum_still_propagates_embedded_errors() -> None:
+    assert sum_cells(1, XlError.DIV, 2) == XlError.DIV
+
+
+def test_sum_skips_empty_text_in_lazy_range() -> None:
+    values = {"S!A1": 1, "S!A2": "", "S!A3": 2}
+
+    def resolve(address: str) -> CellValue:
+        return values[address]
+
+    rng = Range("S", 1, 1, 3, 1, resolve)
+    assert sum_cells(cast(CellValue, rng)) == 3.0
+
+
+def test_arithmetic_still_rejects_empty_text() -> None:
+    """Companion invariant: operators stay strict after aggregate skip fix."""
+    assert xl_add(1, "") == XlError.VALUE
+
+
+def test_sumproduct_treats_text_as_zero() -> None:
+    """SUMPRODUCT coerces non-numeric text to 0 (Excel), not `#VALUE!`."""
+    assert sumproduct_cells([1, ""], [1, 1]) == 1.0
+    assert sumproduct_cells([1, "x"], [2, 3]) == 2.0

--- a/tests/unit/core/test_empty_text_arithmetic.py
+++ b/tests/unit/core/test_empty_text_arithmetic.py
@@ -1,0 +1,77 @@
+"""Empty text vs blank cell coercion in scalar arithmetic (#420).
+
+Excel coerces blank cells to 0 in arithmetic, but empty-string / whitespace-only
+text never coerces and raises `#VALUE!`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from excel_grapher.core.coercions import to_number, try_coerce_string_to_float
+from excel_grapher.core.operators import (
+    xl_add,
+    xl_div,
+    xl_mul,
+    xl_neg,
+    xl_percent,
+    xl_pow,
+    xl_sub,
+)
+from excel_grapher.core.types import XlError
+
+
+@pytest.mark.parametrize("text", ["", " ", "  ", "\t", "\n"])
+def test_try_coerce_string_to_float_rejects_empty_and_whitespace(text: str) -> None:
+    assert try_coerce_string_to_float(text) is None
+
+
+@pytest.mark.parametrize("text", ["", " ", "  ", "\t"])
+def test_to_number_rejects_empty_and_whitespace_text(text: str) -> None:
+    assert to_number(text) == XlError.VALUE
+
+
+def test_to_number_still_coerces_blank_none_to_zero() -> None:
+    assert to_number(None) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("op", "left", "right"),
+    [
+        (xl_add, 1, ""),
+        (xl_add, "", 1),
+        (xl_sub, 1, " "),
+        (xl_mul, 1, "\t"),
+        (xl_div, 1, ""),
+        (xl_pow, 1, ""),
+        (xl_add, 1, "  "),
+    ],
+)
+def test_scalar_arithmetic_rejects_empty_text(op, left, right) -> None:
+    assert op(left, right) == XlError.VALUE
+
+
+@pytest.mark.parametrize(
+    ("op", "left", "right", "expected"),
+    [
+        (xl_add, 1, None, 1.0),
+        (xl_div, 1, None, XlError.DIV),
+        (xl_mul, None, 5, 0.0),
+        (xl_sub, 3, None, 3.0),
+    ],
+)
+def test_scalar_arithmetic_blank_none_still_coerces_to_zero(
+    op, left, right, expected
+) -> None:
+    assert op(left, right) == expected
+
+
+def test_unary_ops_reject_empty_text() -> None:
+    assert xl_neg("") == XlError.VALUE
+    assert xl_neg("  ") == XlError.VALUE
+    assert xl_percent("") == XlError.VALUE
+
+
+def test_unary_ops_blank_none_still_coerces_to_zero() -> None:
+    assert xl_neg(None) == 0.0
+    assert xl_percent(None) == 0.0

--- a/tests/unit/core/test_empty_text_arithmetic.py
+++ b/tests/unit/core/test_empty_text_arithmetic.py
@@ -60,9 +60,7 @@ def test_scalar_arithmetic_rejects_empty_text(op, left, right) -> None:
         (xl_sub, 3, None, 3.0),
     ],
 )
-def test_scalar_arithmetic_blank_none_still_coerces_to_zero(
-    op, left, right, expected
-) -> None:
+def test_scalar_arithmetic_blank_none_still_coerces_to_zero(op, left, right, expected) -> None:
     assert op(left, right) == expected
 
 

--- a/tests/unit/evaluator/test_helpers.py
+++ b/tests/unit/evaluator/test_helpers.py
@@ -23,7 +23,8 @@ def test_to_number_basic_types() -> None:
     assert to_number(False) == 0.0
     assert to_number(3) == 3.0
     assert to_number(3.5) == 3.5
-    assert to_number("  ") == 0.0
+    assert to_number("") == XlError.VALUE
+    assert to_number("  ") == XlError.VALUE
     assert to_number("2") == 2.0
     assert to_number("2.5") == 2.5
     assert to_number("abc") == XlError.VALUE
@@ -65,7 +66,7 @@ def test_helpers_accept_numpy_scalars() -> None:
         # --- Numeric-string coercion (matches FormulaEvaluator behavior) ---
         ("0", 0, True),
         ("  2.0 ", 2, True),
-        ("", 0, True),  # empty string coerces to 0.0 via to_number
+        ("", 0, True),  # exact empty text compares as 0 (Excel); not via to_number
         (None, 0, True),  # None coerces to 0.0 via to_number
         # --- Non-numeric strings fall back to case-insensitive string comparison ---
         ("TRUE", True, True),  # to_number("TRUE") fails -> compare to_string values


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #420: scalar arithmetic no longer coerces empty-string / whitespace-only text to `0`.

Excel distinguishes blank cells (`None` → coerce to 0) from empty text (`""` → `#VALUE!` in arithmetic). Guard formulas that return `""` are common; previously `1/""` became `#DIV/0!` and `1+""` silently became `1`.

## Changes

- `try_coerce_string_to_float`: stripped-empty strings return `None` (failed coerce) instead of `0.0`, so `to_number` yields `#VALUE!`
- `compare_scalars`: exact `""` still compares as `0` (Excel equality / ordering with numbers); whitespace-only does not coerce
- Unit + evaluator↔export parity tests covering the issue MCVE (`#VALUE!` vs blank `#DIV/0!`)

## Test plan

- [x] `uv run pytest tests/unit/core/test_empty_text_arithmetic.py tests/integration/evaluator/test_empty_text_arithmetic_parity.py tests/unit/evaluator/test_helpers.py`
- [ ] Broader operator / coercion / CI suite
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-082e181a-20c7-4b1b-8e6a-9439faa1e02b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-082e181a-20c7-4b1b-8e6a-9439faa1e02b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

