### PR TITLE
fix(series-bindings): full-arity positional docstring examples (#415)

### DIFF
--- a/excel_grapher/series_bindings/docstring_renderers.py
+++ b/excel_grapher/series_bindings/docstring_renderers.py
@@ -126,9 +126,11 @@ def _render_scalar_example(contract: SeriesBindingDocstringContract) -> list[str
 
 
 def _render_positional_example(contract: SeriesBindingDocstringContract) -> list[str]:
-    measure = _measure_field(contract)
-    values = [record.get(measure) for record in contract.example_records]
-    return [f"{contract.function_name}(ctx, {values!r})"]
+    """Render a positional measure example only when full key arity is known."""
+    values = contract.positional_example_values
+    if not values:
+        return []
+    return [f"{contract.function_name}(ctx, {list(values)!r})"]
 
 
 def _render_example_call(contract: SeriesBindingDocstringContract) -> list[str]:
@@ -138,7 +140,9 @@ def _render_example_call(contract: SeriesBindingDocstringContract) -> list[str]:
         return _render_scalar_example(contract)
     blocks = [_render_records_example(contract)]
     if contract.layout == "series" and _is_single_key(contract):
-        blocks.append(_render_positional_example(contract))
+        positional = _render_positional_example(contract)
+        if positional:
+            blocks.append(positional)
     lines: list[str] = []
     for index, block in enumerate(blocks):
         if index:

--- a/excel_grapher/series_bindings/docstrings.py
+++ b/excel_grapher/series_bindings/docstrings.py
@@ -42,6 +42,7 @@ class SeriesBindingDocstringContract:
     fields: Mapping[str, FieldContract]
     example_records: tuple[Mapping[str, object], ...]
     notes: str
+    positional_example_values: tuple[object, ...] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -219,6 +220,29 @@ def _example_records_from_resolution(
     return tuple(examples)
 
 
+def _positional_example_values_from_resolution(
+    series: dict[str, Any],
+    resolution: SeriesResolution,
+) -> tuple[object, ...] | None:
+    """Return full-arity measure values for positional setter examples.
+
+    Positional coercion requires `len(values) == len(key_order)`. Keyed record
+    examples may stay partial, so this samples every leaf in canonical key order
+    rather than reusing the capped `example_records` list.
+    """
+    if str(series.get("layout", "")) != "series":
+        return None
+    key_fields = [str(field) for field in (series.get("key") or [])]
+    if len(key_fields) != 1 or resolution["requires_address"]:
+        return None
+    key_field = key_fields[0]
+    measure = _measure_concept(series)
+    leaves = sorted(resolution["leaves"], key=lambda leaf: leaf["key"][key_field])
+    if not leaves:
+        return None
+    return tuple(leaf["record"][measure] for leaf in leaves)
+
+
 def derive_doc_contract(
     series: dict[str, Any],
     *,
@@ -255,6 +279,7 @@ def derive_doc_contract(
         fields=field_contracts,
         example_records=_example_records_from_resolution(resolution, required_fields),
         notes=str(series.get("notes") or series.get("sdmx_notes") or ""),
+        positional_example_values=_positional_example_values_from_resolution(series, resolution),
     )
 
 

--- a/tests/unit/series_bindings/test_docstrings.py
+++ b/tests/unit/series_bindings/test_docstrings.py
@@ -22,6 +22,8 @@ from excel_grapher.series_bindings.docstring_renderers import (
     NumpySeriesDocstringRenderer,
     PlainSeriesDocstringRenderer,
     RstSeriesDocstringRenderer,
+    _render_example_call,
+    _render_positional_example,
     resolve_series_docstring_renderer,
 )
 from excel_grapher.series_bindings.docstrings import (
@@ -39,6 +41,7 @@ from excel_grapher.series_bindings.docstrings import (
     run_series_docstring_callback,
     unregister_series_docstring_callback,
 )
+from excel_grapher.series_bindings.setter_codegen import _canonical_key_order
 from excel_grapher.series_bindings.types import SeriesResolution, WorkbookSeriesBindings
 from tests.paths import SERIES_BINDINGS_FIXTURES as FIXTURES
 
@@ -483,11 +486,14 @@ def _series_contract_and_doc(
     *,
     layout: str = "series",
     keys: tuple[str, ...] = ("COUNTRY",),
+    positional_example_values: tuple[object, ...] | None = (60.0, 80.0),
 ) -> tuple[SeriesBindingDocstringContract, SeriesFunctionDoc]:
     example_records: list[dict[str, object]] = [
         {**{key: country for key in keys}, "OBS_VALUE": value}
         for country, value in (("Borvelia", 60.0), ("Litellia", 80.0))
     ]
+    if len(keys) != 1 or layout != "series":
+        positional_example_values = None
     contract = SeriesBindingDocstringContract(
         series_id="country_initial_debt",
         function_name="set_country_initial_debt",
@@ -515,6 +521,7 @@ def _series_contract_and_doc(
         },
         example_records=tuple(example_records),
         notes="",
+        positional_example_values=positional_example_values,
     )
     doc = SeriesFunctionDoc(
         summary="Set country initial debt.",
@@ -548,6 +555,69 @@ def test_series_setter_docstring_describes_series_shapes() -> None:
     assert "empty_measure" in rendered
     assert "set_country_initial_debt(ctx, [" in rendered
     assert "set_country_initial_debt(ctx, [60.0, 80.0])" in rendered
+
+
+def test_render_positional_example_uses_full_key_order_values() -> None:
+    contract, _doc = _series_contract_and_doc(
+        positional_example_values=(60.0, 80.0, 100.0),
+    )
+    assert _render_positional_example(contract) == [
+        "set_country_initial_debt(ctx, [60.0, 80.0, 100.0])"
+    ]
+
+
+def test_render_positional_example_omitted_without_full_values() -> None:
+    """Partial example_records must not advertise an invalid positional call."""
+    contract, _doc = _series_contract_and_doc(positional_example_values=None)
+    assert _render_positional_example(contract) == []
+    example_call = "\n".join(_render_example_call(contract))
+    assert "set_country_initial_debt(ctx, [" in example_call
+    assert "set_country_initial_debt(ctx, [60.0, 80.0])" not in example_call
+
+
+def test_derive_doc_contract_positional_values_match_key_order(tmp_path: Path) -> None:
+    wb_path = tmp_path / "lic_inputs.xlsx"
+    _write_borvelia_workbook(wb_path)
+    graph = create_dependency_graph(
+        wb_path,
+        expand_data_range("Inputs!F5:J5"),
+        load_values=True,
+    )
+    bindings = load_series_bindings(FIXTURES / "borvelia_primary_balance.yaml")
+    series = bindings["series"][0]
+    resolved = resolve_series_binding(graph, wb_path, series)
+    key_fields = [str(field) for field in (series.get("key") or [])]
+    key_order = _canonical_key_order(resolved, key_fields)
+    assert key_order is not None
+    assert len(key_order) == 5
+
+    contract = derive_doc_contract(
+        series,
+        function_kind="setter",
+        function_name="set_borvelia_primary_balance",
+        resolution=resolved,
+        bindings=bindings,
+    )
+
+    assert len(contract.example_records) == 2
+    assert contract.positional_example_values == (-2.0, -1.0, 0.0, 1.0, 2.0)
+    assert len(contract.positional_example_values) == len(key_order)
+
+    rendered = GoogleSeriesDocstringRenderer().render(
+        contract,
+        SeriesFunctionDoc(
+            summary="Set borvelia_primary_balance.",
+            purpose="Updates workbook inputs from Records.",
+            record_matching="Records match cells by key fields.",
+            field_descriptions={
+                field: FieldDoc(description=f"Value for {field}.")
+                for field in contract.required_fields
+            },
+        ),
+        series=series,
+    )
+    assert "set_borvelia_primary_balance(ctx, [-2.0, -1.0, 0.0, 1.0, 2.0])" in rendered
+    assert "set_borvelia_primary_balance(ctx, [-2.0, -1.0])" not in rendered
 
 
 def test_series_multi_key_setter_omits_positional_shape() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #415. Generated Google-style (and other) setter docstrings were building positional `Sequence[float]` examples from `example_records`, which `_example_records_from_resolution` caps at `max_records=2`. Runtime `coerce_setter_input` requires `len(values) == len(key_order)`, so incomplete examples like `set_x(ctx, [a, b])` for a 5-key series were invalid and broke downstream QMD validation when copied by docs LLMs.

## Approach

Chose option 2 from the issue: keep keyed record examples partial, but build positional examples from the full canonical key order.

- Add `positional_example_values` to `SeriesBindingDocstringContract`
- Derive it from every resolution leaf in canonical key order (single-key series only)
- `_render_positional_example` uses that field and omits the positional call when arity is unknown/`None`

## Test plan

- [x] Unit tests for full-arity positional render, omit-when-unknown, and borvelia derive/render (5 values)
- [x] `uv run pytest tests/unit/series_bindings/test_docstrings.py` (37 passed)
- [x] `uv run pytest tests/unit/series_bindings/` (414 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8af08f6-2072-4c99-a2eb-60d0ec67d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8af08f6-2072-4c99-a2eb-60d0ec67d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

